### PR TITLE
feat: add server-side API key support for LLM providers

### DIFF
--- a/apps/vela-api/.env.example
+++ b/apps/vela-api/.env.example
@@ -1,0 +1,28 @@
+# Application Name
+APP_NAME=Vela Japanese Learning App
+
+# AWS Configuration (Required)
+AWS_ACCESS_KEY_ID=your_aws_access_key
+AWS_SECRET_ACCESS_KEY=your_aws_secret_key
+AWS_REGION=us-east-1
+
+# Cognito Configuration (Required for authentication)
+VITE_COGNITO_USER_POOL_ID=us-east-1_xxxxxxxxx
+COGNITO_CLIENT_ID=xxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# DynamoDB Configuration
+DDB_ENDPOINT=https://dynamodb.us-east-1.amazonaws.com
+DDB_REGION=us-east-1
+DDB_TABLE=vela
+
+# LLM API Keys (Optional - Server-side keys for all users)
+# If not provided, users must supply their own API keys
+GOOGLE_API_KEY=your_google_api_key_here
+OPENROUTER_API_KEY=your_openrouter_api_key_here
+
+# CORS Configuration
+CORS_ALLOWED_ORIGINS=*
+
+# TTS Configuration (Optional)
+TTS_AUDIO_BUCKET_NAME=your-tts-bucket
+ELEVENLABS_API_KEY=your_elevenlabs_key

--- a/apps/vela-api/README.md
+++ b/apps/vela-api/README.md
@@ -88,7 +88,12 @@ The following environment variables are required:
 
 ### LLM Chat
 
-Users must provide their own API keys when making requests to LLM providers (Google Gemini, OpenRouter, etc.). API keys are sent in the request body and are not stored on the server.
+**Server-side API keys (recommended):**
+
+- `GOOGLE_API_KEY`: Google Gemini API key for all users (optional)
+- `OPENROUTER_API_KEY`: OpenRouter API key for all users (optional)
+
+If server-side API keys are configured, they will be used for all requests. Users can optionally provide their own API keys in the request body to override server defaults.
 
 - `APP_NAME`: Application name for OpenRouter headers
 

--- a/apps/vela-api/src/index.ts
+++ b/apps/vela-api/src/index.ts
@@ -67,6 +67,8 @@ if (process.env.NODE_ENV === 'development') {
       process.env.COGNITO_CLIENT_ID || process.env.VITE_COGNITO_USER_POOL_CLIENT_ID,
     TTS_AUDIO_BUCKET_NAME: process.env.TTS_AUDIO_BUCKET_NAME,
     ELEVENLABS_API_KEY: process.env.ELEVENLABS_API_KEY,
+    GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
+    OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
     CORS_ALLOWED_ORIGINS:
       process.env.CORS_ALLOWED_ORIGINS || 'http://localhost:9000,http://127.0.0.1:9000',
   };
@@ -131,6 +133,8 @@ if (process.env.NODE_ENV === 'development') {
     COGNITO_CLIENT_ID: process.env.COGNITO_CLIENT_ID,
     TTS_AUDIO_BUCKET_NAME: process.env.TTS_AUDIO_BUCKET_NAME,
     ELEVENLABS_API_KEY: process.env.ELEVENLABS_API_KEY,
+    GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
+    OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
     CORS_ALLOWED_ORIGINS:
       process.env.CORS_ALLOWED_ORIGINS || 'http://localhost:9000,http://127.0.0.1:9000',
   };
@@ -163,6 +167,8 @@ if (process.env.NODE_ENV === 'development') {
     COGNITO_CLIENT_ID: process.env.COGNITO_CLIENT_ID,
     TTS_AUDIO_BUCKET_NAME: process.env.TTS_AUDIO_BUCKET_NAME,
     ELEVENLABS_API_KEY: process.env.ELEVENLABS_API_KEY,
+    GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
+    OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
     CORS_ALLOWED_ORIGINS: process.env.CORS_ALLOWED_ORIGINS,
   };
 

--- a/apps/vela-api/src/routes/llm-chat.ts
+++ b/apps/vela-api/src/routes/llm-chat.ts
@@ -36,13 +36,20 @@ llmChat.post('/', async (c) => {
 
   try {
     if (provider === 'google') {
-      const apiKey: string | undefined = input.apiKey;
+      // Prefer user-provided API key, fall back to server-side key
+      const apiKey: string | undefined = input.apiKey || c.env.GOOGLE_API_KEY;
       if (!apiKey) {
-        return c.json({ error: 'Missing API key for Google provider' }, 400);
+        return c.json(
+          {
+            error:
+              'Missing API key for Google provider. Configure GOOGLE_API_KEY on server or provide your own API key.',
+          },
+          400,
+        );
       }
 
       const model = input.model || 'gemini-2.5-flash-lite';
-      const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
+      const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
 
       type Part = { text: string };
       type Content = { role?: 'user' | 'model'; parts: Part[] };
@@ -86,7 +93,10 @@ llmChat.post('/', async (c) => {
 
       const res = await fetch(endpoint, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'x-goog-api-key': apiKey,
+        },
         body: JSON.stringify(body),
       });
 
@@ -101,9 +111,16 @@ llmChat.post('/', async (c) => {
     }
 
     if (provider === 'openrouter') {
-      const apiKey: string | undefined = input.apiKey;
+      // Prefer user-provided API key, fall back to server-side key
+      const apiKey: string | undefined = input.apiKey || c.env.OPENROUTER_API_KEY;
       if (!apiKey) {
-        return c.json({ error: 'Missing API key for OpenRouter provider' }, 400);
+        return c.json(
+          {
+            error:
+              'Missing API key for OpenRouter provider. Configure OPENROUTER_API_KEY on server or provide your own API key.',
+          },
+          400,
+        );
       }
 
       const model = input.model || 'openai/gpt-oss-20b:free';

--- a/apps/vela-api/src/types.ts
+++ b/apps/vela-api/src/types.ts
@@ -17,6 +17,10 @@ export interface Env {
   TTS_AUDIO_BUCKET_NAME?: string;
   ELEVENLABS_API_KEY?: string;
 
+  // LLM API Keys (server-side)
+  GOOGLE_API_KEY?: string;
+  OPENROUTER_API_KEY?: string;
+
   // CORS configuration
   CORS_ALLOWED_ORIGINS?: string;
 }

--- a/apps/vela/src/services/llm/providers/googleProvider.ts
+++ b/apps/vela/src/services/llm/providers/googleProvider.ts
@@ -9,13 +9,15 @@ interface GoogleProviderOptions {
 /**
  * Google AI Studio (Generative Language API - Gemini) provider
  * Docs: https://ai.google.dev/gemini-api/docs
+ *
+ * API calls are routed through the server which handles API keys.
+ * Server-side API keys are preferred; user-provided keys are optional overrides.
  */
 export class GoogleProvider implements LLMProvider {
   readonly name: LLMProviderName = 'google';
   private model: string;
 
   constructor(options?: GoogleProviderOptions) {
-    // API calls are proxied via AWS Lambda API; no client-side API key
     this.model = options?.model || 'gemini-2.5-flash-lite';
   }
 

--- a/apps/vela/src/services/llm/providers/openrouterProvider.ts
+++ b/apps/vela/src/services/llm/providers/openrouterProvider.ts
@@ -10,6 +10,9 @@ interface OpenRouterProviderOptions {
 /**
  * OpenRouter provider (OpenAI-compatible Chat Completions)
  * Docs: https://openrouter.ai/docs
+ *
+ * API calls are routed through the server which handles API keys.
+ * Server-side API keys are preferred; user-provided keys are optional overrides.
  */
 export class OpenRouterProvider implements LLMProvider {
   readonly name: LLMProviderName = 'openrouter';
@@ -17,7 +20,6 @@ export class OpenRouterProvider implements LLMProvider {
   private appName: string | null;
 
   constructor(options?: OpenRouterProviderOptions) {
-    // API calls are proxied via AWS Lambda API; no client-side API key
     this.model = options?.model || 'openai/gpt-oss-20b:free';
     this.appName = options?.appName ?? null;
   }


### PR DESCRIPTION
- Added GOOGLE_API_KEY and OPENROUTER_API_KEY environment variables for server-side configuration
- Modified LLM chat route to prefer user-provided API keys but fall back to server-side keys
- Changed Google API authentication from query parameter to x-goog-api-key header
- Updated error messages to indicate both server and user key options
- Added comprehensive tests for server key fallback and user key override scenarios
- Added .env.example with

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled optional server-side API key configuration for LLM providers, reducing the need to supply keys with each request.
  * Per-request API keys can override server-side defaults when needed.

* **Documentation**
  * Updated environment configuration templates and documentation to explain API key setup options.
  * Improved error guidance for missing API key configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->