### PR TITLE
[codex] Fix extension auth session reuse

### DIFF
--- a/apps/vela-ext/entrypoints/content.ts
+++ b/apps/vela-ext/entrypoints/content.ts
@@ -316,31 +316,34 @@ function buildOverlay(sentences: string[]): ShadowRoot {
 export default defineContentScript({
   matches: ['*://*/*'],
   main() {
-    browser.runtime.onMessage.addListener((message: unknown) => {
-      if (
-        typeof message !== 'object' ||
-        message === null ||
-        !('type' in message) ||
-        (message.type !== 'SCAN_PAGE' && message.type !== 'GET_VELA_WEBAPP_SESSION')
-      )
-        return;
+    browser.runtime.onMessage.addListener(
+      (message: unknown, _sender: unknown, sendResponse: (_response?: unknown) => void) => {
+        if (
+          typeof message !== 'object' ||
+          message === null ||
+          !('type' in message) ||
+          (message.type !== 'SCAN_PAGE' && message.type !== 'GET_VELA_WEBAPP_SESSION')
+        )
+          return;
 
-      if (message.type === 'GET_VELA_WEBAPP_SESSION') {
-        return readCognitoSessionFromStorage(window.localStorage);
-      }
+        if (message.type === 'GET_VELA_WEBAPP_SESSION') {
+          sendResponse(readCognitoSessionFromStorage(window.localStorage));
+          return;
+        }
 
-      // Remove any existing overlay before creating a new one
-      document.getElementById('vela-ext-overlay-host')?.remove();
+        // Remove any existing overlay before creating a new one
+        document.getElementById('vela-ext-overlay-host')?.remove();
 
-      const sentences = scanJapaneseSentences();
-      if (sentences.length === 0) {
-        // Content scripts can't use browser.notifications — ask the background
-        // script to show the "no sentences found" notification.
-        browser.runtime.sendMessage({ type: 'NO_JAPANESE_FOUND' }).catch(() => {});
-        return;
-      }
+        const sentences = scanJapaneseSentences();
+        if (sentences.length === 0) {
+          // Content scripts can't use browser.notifications — ask the background
+          // script to show the "no sentences found" notification.
+          browser.runtime.sendMessage({ type: 'NO_JAPANESE_FOUND' }).catch(() => {});
+          return;
+        }
 
-      buildOverlay(sentences);
-    });
+        buildOverlay(sentences);
+      },
+    );
   },
 });

--- a/apps/vela-ext/entrypoints/content.ts
+++ b/apps/vela-ext/entrypoints/content.ts
@@ -1,3 +1,5 @@
+import { readCognitoSessionFromStorage } from './utils/webappSession';
+
 // Export for unit testing
 export function scanJapaneseSentences(): string[] {
   const japaneseRe = /[\u3040-\u9FAF\uFF66-\uFF9F]/;
@@ -319,9 +321,13 @@ export default defineContentScript({
         typeof message !== 'object' ||
         message === null ||
         !('type' in message) ||
-        message.type !== 'SCAN_PAGE'
+        (message.type !== 'SCAN_PAGE' && message.type !== 'GET_VELA_WEBAPP_SESSION')
       )
         return;
+
+      if (message.type === 'GET_VELA_WEBAPP_SESSION') {
+        return readCognitoSessionFromStorage(window.localStorage);
+      }
 
       // Remove any existing overlay before creating a new one
       document.getElementById('vela-ext-overlay-host')?.remove();

--- a/apps/vela-ext/entrypoints/content.ts
+++ b/apps/vela-ext/entrypoints/content.ts
@@ -327,7 +327,11 @@ export default defineContentScript({
           return;
 
         if (message.type === 'GET_VELA_WEBAPP_SESSION') {
-          sendResponse(readCognitoSessionFromStorage(window.localStorage));
+          try {
+            sendResponse(readCognitoSessionFromStorage(window.localStorage));
+          } catch {
+            sendResponse(null);
+          }
           return;
         }
 

--- a/apps/vela-ext/entrypoints/popup/App.vue
+++ b/apps/vela-ext/entrypoints/popup/App.vue
@@ -3,13 +3,20 @@ import { ref, onMounted } from 'vue';
 import LoginPage from './LoginPage.vue';
 import DashboardPage from './DashboardPage.vue';
 import { isAuthenticated } from '../utils/storage';
+import { importWebappSession } from '../utils/webappSession';
 
 const authenticated = ref(false);
 const loading = ref(true);
 
 onMounted(async () => {
-  authenticated.value = await isAuthenticated();
-  loading.value = false;
+  try {
+    authenticated.value = await isAuthenticated();
+    if (!authenticated.value) {
+      authenticated.value = await importWebappSession();
+    }
+  } finally {
+    loading.value = false;
+  }
 });
 
 function handleLoginSuccess() {

--- a/apps/vela-ext/entrypoints/popup/App.vue
+++ b/apps/vela-ext/entrypoints/popup/App.vue
@@ -13,7 +13,15 @@ onMounted(async () => {
     authenticated.value = await isAuthenticated();
     if (!authenticated.value) {
       authenticated.value = await importWebappSession();
+      if (authenticated.value) {
+        // Notify the background script so it can flush any queued offline saves.
+        browser.runtime.sendMessage({ type: 'LOGIN_SUCCESS' }).catch(() => {
+          // Background may not be listening during tests or development reloads.
+        });
+      }
     }
+  } catch (error: unknown) {
+    console.error('[Vela] Failed to initialise session:', error);
   } finally {
     loading.value = false;
   }

--- a/apps/vela-ext/entrypoints/popup/LoginPage.vue
+++ b/apps/vela-ext/entrypoints/popup/LoginPage.vue
@@ -23,9 +23,12 @@
             id="email"
             v-model="email"
             type="email"
+            name="username"
+            autocomplete="username"
+            inputmode="email"
             placeholder="your@email.com"
             required
-            :disabled="loading"
+            :disabled="loading || webSessionLoading"
           />
         </div>
 
@@ -35,9 +38,11 @@
             id="password"
             v-model="password"
             type="password"
+            name="password"
+            autocomplete="current-password"
             placeholder="Enter your password"
             required
-            :disabled="loading"
+            :disabled="loading || webSessionLoading"
           />
         </div>
 
@@ -45,9 +50,28 @@
           {{ error }}
         </div>
 
-        <button type="submit" class="login-button" :disabled="loading">
+        <button type="submit" class="login-button" :disabled="loading || webSessionLoading">
           {{ loading ? 'Signing in...' : 'Sign In' }}
         </button>
+
+        <div class="web-session-actions">
+          <button
+            type="button"
+            class="web-session-button"
+            :disabled="loading || webSessionLoading"
+            @click="handleUseWebappSession"
+          >
+            {{ webSessionLoading ? 'Checking...' : 'Use Web App Session' }}
+          </button>
+          <button
+            type="button"
+            class="open-webapp-button"
+            :disabled="loading || webSessionLoading"
+            @click="openWebappLogin"
+          >
+            Open Web App Login
+          </button>
+        </div>
       </form>
     </div>
   </div>
@@ -57,6 +81,7 @@
 import { ref, onMounted, watch } from 'vue';
 import { signIn } from '../utils/api';
 import { saveAuthTokens } from '../utils/storage';
+import { importWebappSession, openWebappLogin } from '../utils/webappSession';
 
 const emit = defineEmits<{
   loginSuccess: [];
@@ -65,6 +90,7 @@ const emit = defineEmits<{
 const email = ref('');
 const password = ref('');
 const loading = ref(false);
+const webSessionLoading = ref(false);
 const error = ref('');
 const isDarkMode = ref(false);
 
@@ -81,6 +107,25 @@ watch(isDarkMode, async (newValue) => {
 
 function toggleTheme() {
   isDarkMode.value = !isDarkMode.value;
+}
+
+async function handleUseWebappSession() {
+  webSessionLoading.value = true;
+  error.value = '';
+
+  try {
+    const imported = await importWebappSession();
+    if (imported) {
+      emit('loginSuccess');
+      return;
+    }
+
+    error.value = 'Open Vela in a browser tab and sign in, then try again.';
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to import web app session';
+  } finally {
+    webSessionLoading.value = false;
+  }
 }
 
 async function handleLogin() {
@@ -272,6 +317,35 @@ async function handleLogin() {
 
 .login-button:disabled {
   background-color: var(--border-color);
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.web-session-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.web-session-button,
+.open-webapp-button {
+  padding: 10px 8px;
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.web-session-button:hover:not(:disabled),
+.open-webapp-button:hover:not(:disabled) {
+  background-color: var(--bg-hover);
+}
+
+.web-session-button:disabled,
+.open-webapp-button:disabled {
   cursor: not-allowed;
   opacity: 0.6;
 }

--- a/apps/vela-ext/entrypoints/utils/api.ts
+++ b/apps/vela-ext/entrypoints/utils/api.ts
@@ -13,6 +13,37 @@ export interface SaveDictionaryEntryParams {
   context?: string;
 }
 
+async function getErrorMessage(response: Response, fallback: string): Promise<string> {
+  const fallbackWithStatus =
+    typeof response.status === 'number' ? `${fallback} (HTTP ${response.status})` : fallback;
+
+  try {
+    const contentType = response.headers.get('content-type') ?? '';
+    if (contentType && !contentType.toLowerCase().includes('application/json')) {
+      return fallbackWithStatus;
+    }
+
+    const error = (await response.json()) as { error?: unknown; message?: unknown };
+    if (typeof error.error === 'string' && error.error.length > 0) {
+      return error.error;
+    }
+    if (typeof error.message === 'string' && error.message.length > 0) {
+      return error.message;
+    }
+    return fallback;
+  } catch {
+    return fallbackWithStatus;
+  }
+}
+
+async function getJsonBody<T>(response: Response, fallback: string): Promise<T> {
+  try {
+    return (await response.json()) as T;
+  } catch {
+    throw new Error(`${fallback}: invalid response from server`);
+  }
+}
+
 // Authentication API
 export async function signIn(email: string, password: string): Promise<AuthTokens> {
   const response = await fetch(`${API_BASE_URL}/auth/signin`, {
@@ -24,11 +55,10 @@ export async function signIn(email: string, password: string): Promise<AuthToken
   });
 
   if (!response.ok) {
-    const error = await response.json();
-    throw new Error(error.error || 'Sign in failed');
+    throw new Error(await getErrorMessage(response, 'Sign in failed'));
   }
 
-  const data = await response.json();
+  const data = await getJsonBody<{ tokens: AuthTokens }>(response, 'Sign in failed');
   return data.tokens;
 }
 
@@ -45,7 +75,7 @@ export async function checkSession(idToken: string): Promise<boolean> {
       return false;
     }
 
-    const data = await response.json();
+    const data = await getJsonBody<{ authenticated?: boolean }>(response, 'Session check failed');
     return data.authenticated === true;
   } catch {
     return false;
@@ -63,11 +93,10 @@ export async function refreshToken(refreshToken: string): Promise<AuthTokens> {
   });
 
   if (!response.ok) {
-    const error = await response.json();
-    throw new Error(error.error || 'Token refresh failed');
+    throw new Error(await getErrorMessage(response, 'Token refresh failed'));
   }
 
-  const data = await response.json();
+  const data = await getJsonBody<{ tokens: AuthTokens }>(response, 'Token refresh failed');
   return data.tokens;
 }
 
@@ -86,12 +115,11 @@ export async function saveDictionaryEntry(
   });
 
   if (!response.ok) {
-    const error = await response.json();
-    throw new Error(error.error || 'Failed to save dictionary entry');
+    throw new Error(await getErrorMessage(response, 'Failed to save dictionary entry'));
   }
 }
 
-export async function getMyDictionaries(idToken: string, limit = 50) {
+export async function getMyDictionaries(idToken: string, limit = 50): Promise<any[]> {
   const response = await fetch(`${API_BASE_URL}/my-dictionaries?limit=${limit}`, {
     method: 'GET',
     headers: {
@@ -100,10 +128,9 @@ export async function getMyDictionaries(idToken: string, limit = 50) {
   });
 
   if (!response.ok) {
-    const error = await response.json();
-    throw new Error(error.error || 'Failed to fetch dictionary entries');
+    throw new Error(await getErrorMessage(response, 'Failed to fetch dictionary entries'));
   }
 
-  const data = await response.json();
+  const data = await getJsonBody<{ data: any[] }>(response, 'Failed to fetch dictionary entries');
   return data.data;
 }

--- a/apps/vela-ext/entrypoints/utils/api.ts
+++ b/apps/vela-ext/entrypoints/utils/api.ts
@@ -30,7 +30,7 @@ async function getErrorMessage(response: Response, fallback: string): Promise<st
     if (typeof error.message === 'string' && error.message.length > 0) {
       return error.message;
     }
-    return fallback;
+    return fallbackWithStatus;
   } catch {
     return fallbackWithStatus;
   }

--- a/apps/vela-ext/entrypoints/utils/webappSession.ts
+++ b/apps/vela-ext/entrypoints/utils/webappSession.ts
@@ -1,0 +1,129 @@
+import { checkSession, type AuthTokens } from './api';
+import { saveAuthTokens } from './storage';
+
+export interface WebappSession {
+  tokens: AuthTokens;
+  email: string | null;
+}
+
+export const WEBAPP_URL_PATTERNS = [
+  'https://vela.cwchanap.dev/*',
+  'http://localhost:9000/*',
+  'http://127.0.0.1:9000/*',
+];
+
+function getWebappBaseUrl(): string {
+  return import.meta.env.MODE === 'development'
+    ? 'http://localhost:9000'
+    : 'https://vela.cwchanap.dev';
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const payload = token.split('.')[1];
+  if (!payload) return null;
+
+  try {
+    const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+    return JSON.parse(atob(padded)) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function extractEmailFromIdToken(idToken: string, fallbackUsername: string): string | null {
+  const payload = decodeJwtPayload(idToken);
+  const email = payload?.email;
+
+  if (typeof email === 'string' && email.length > 0) {
+    return email;
+  }
+
+  return fallbackUsername.includes('@') ? fallbackUsername : null;
+}
+
+function isCompleteTokenSet(value: Partial<AuthTokens>): value is AuthTokens {
+  return (
+    typeof value.accessToken === 'string' &&
+    value.accessToken.length > 0 &&
+    typeof value.refreshToken === 'string' &&
+    value.refreshToken.length > 0 &&
+    typeof value.idToken === 'string' &&
+    value.idToken.length > 0
+  );
+}
+
+export function readCognitoSessionFromStorage(
+  storage: Storage = window.localStorage,
+): WebappSession | null {
+  for (let index = 0; index < storage.length; index += 1) {
+    const key = storage.key(index);
+    if (!key?.startsWith('CognitoIdentityServiceProvider.') || !key.endsWith('.LastAuthUser')) {
+      continue;
+    }
+
+    const username = storage.getItem(key);
+    if (!username) continue;
+
+    const baseKey = key.slice(0, -'.LastAuthUser'.length);
+    const tokens: Partial<AuthTokens> = {
+      accessToken: storage.getItem(`${baseKey}.${username}.accessToken`) ?? undefined,
+      refreshToken: storage.getItem(`${baseKey}.${username}.refreshToken`) ?? undefined,
+      idToken: storage.getItem(`${baseKey}.${username}.idToken`) ?? undefined,
+    };
+
+    if (!isCompleteTokenSet(tokens)) continue;
+
+    return {
+      tokens,
+      email: extractEmailFromIdToken(tokens.idToken, username),
+    };
+  }
+
+  return null;
+}
+
+function isWebappSession(value: unknown): value is WebappSession {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Partial<WebappSession>;
+
+  return (
+    typeof candidate.tokens === 'object' &&
+    candidate.tokens !== null &&
+    isCompleteTokenSet(candidate.tokens) &&
+    (typeof candidate.email === 'string' || candidate.email === null)
+  );
+}
+
+export async function importWebappSession(): Promise<boolean> {
+  const tabs = await browser.tabs.query({ url: WEBAPP_URL_PATTERNS });
+  const orderedTabs = [...tabs].sort(
+    (a, b) => Number(Boolean(b.active)) - Number(Boolean(a.active)),
+  );
+
+  for (const tab of orderedTabs) {
+    if (typeof tab.id !== 'number') continue;
+
+    try {
+      const session = await browser.tabs.sendMessage(tab.id, { type: 'GET_VELA_WEBAPP_SESSION' });
+      if (!isWebappSession(session)) continue;
+
+      const isValid = await checkSession(session.tokens.idToken);
+      if (!isValid) continue;
+
+      await saveAuthTokens(session.tokens, session.email ?? undefined);
+      await browser.runtime.sendMessage({ type: 'LOGIN_SUCCESS' }).catch(() => {
+        // Background may not be listening during tests or development reloads.
+      });
+      return true;
+    } catch {
+      // A Vela tab might exist before the content script is ready. Try the next tab.
+    }
+  }
+
+  return false;
+}
+
+export async function openWebappLogin(): Promise<void> {
+  await browser.tabs.create({ url: `${getWebappBaseUrl()}/auth/login` });
+}

--- a/apps/vela-ext/entrypoints/utils/webappSession.ts
+++ b/apps/vela-ext/entrypoints/utils/webappSession.ts
@@ -1,4 +1,4 @@
-import { checkSession, type AuthTokens } from './api';
+import { checkSession, refreshToken, type AuthTokens } from './api';
 import { saveAuthTokens } from './storage';
 
 export interface WebappSession {
@@ -115,7 +115,17 @@ export async function importWebappSession(): Promise<boolean> {
     if (!isWebappSession(session)) continue;
 
     const isValid = await checkSession(session.tokens.idToken);
-    if (!isValid) continue;
+    if (!isValid) {
+      // ID token may be expired — try refreshing with the refresh token
+      // before skipping, since the user may still be signed in on the web app
+      try {
+        const newTokens = await refreshToken(session.tokens.refreshToken);
+        await saveAuthTokens(newTokens, session.email ?? undefined);
+        return true;
+      } catch {
+        continue;
+      }
+    }
 
     await saveAuthTokens(session.tokens, session.email ?? undefined);
     return true;

--- a/apps/vela-ext/entrypoints/utils/webappSession.ts
+++ b/apps/vela-ext/entrypoints/utils/webappSession.ts
@@ -104,21 +104,21 @@ export async function importWebappSession(): Promise<boolean> {
   for (const tab of orderedTabs) {
     if (typeof tab.id !== 'number') continue;
 
+    let session: unknown;
     try {
-      const session = await browser.tabs.sendMessage(tab.id, { type: 'GET_VELA_WEBAPP_SESSION' });
-      if (!isWebappSession(session)) continue;
-
-      const isValid = await checkSession(session.tokens.idToken);
-      if (!isValid) continue;
-
-      await saveAuthTokens(session.tokens, session.email ?? undefined);
-      await browser.runtime.sendMessage({ type: 'LOGIN_SUCCESS' }).catch(() => {
-        // Background may not be listening during tests or development reloads.
-      });
-      return true;
+      session = await browser.tabs.sendMessage(tab.id, { type: 'GET_VELA_WEBAPP_SESSION' });
     } catch {
       // A Vela tab might exist before the content script is ready. Try the next tab.
+      continue;
     }
+
+    if (!isWebappSession(session)) continue;
+
+    const isValid = await checkSession(session.tokens.idToken);
+    if (!isValid) continue;
+
+    await saveAuthTokens(session.tokens, session.email ?? undefined);
+    return true;
   }
 
   return false;

--- a/apps/vela-ext/tests/content.test.ts
+++ b/apps/vela-ext/tests/content.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import contentScriptConfig, { scanJapaneseSentences } from '../entrypoints/content';
 
@@ -32,8 +32,14 @@ function getRegisteredMessageListener() {
     throw new Error('Expected content script to register a message listener');
   }
 
-  return call[0] as (_message: unknown) => void;
+  return call[0] as (
+    _message: unknown,
+    _sender: unknown,
+    _sendResponse: (_response?: unknown) => void,
+  ) => void;
 }
+
+const noopSendResponse = vi.fn();
 
 beforeEach(() => {
   document.body.innerHTML = '';
@@ -185,9 +191,9 @@ describe('content script message listener', () => {
     contentScript.main();
     const listener = getRegisteredMessageListener();
 
-    expect(() => listener(undefined)).not.toThrow();
-    expect(() => listener(null)).not.toThrow();
-    expect(() => listener('SCAN_PAGE')).not.toThrow();
+    expect(() => listener(undefined, undefined, noopSendResponse)).not.toThrow();
+    expect(() => listener(null, undefined, noopSendResponse)).not.toThrow();
+    expect(() => listener('SCAN_PAGE', undefined, noopSendResponse)).not.toThrow();
     expect(document.getElementById('vela-ext-overlay-host')).toBeNull();
   });
 
@@ -199,7 +205,7 @@ describe('content script message listener', () => {
 
     contentScript.main();
     const listener = getRegisteredMessageListener();
-    listener({ type: 'SCAN_PAGE' });
+    listener({ type: 'SCAN_PAGE' }, undefined, noopSendResponse);
 
     // Should NOT show the overlay
     expect(document.getElementById('vela-ext-overlay-host')).toBeNull();
@@ -209,7 +215,7 @@ describe('content script message listener', () => {
     });
   });
 
-  it('returns the web-app Cognito session from localStorage when requested by the popup', () => {
+  it('sends the web-app Cognito session from localStorage via sendResponse when requested by the popup', () => {
     const idToken = jwtWithPayload({ email: 'user@example.com' });
     localStorage.setItem(
       'CognitoIdentityServiceProvider.client-id.LastAuthUser',
@@ -230,8 +236,10 @@ describe('content script message listener', () => {
 
     contentScript.main();
     const listener = getRegisteredMessageListener();
+    const sendResponse = vi.fn();
+    listener({ type: 'GET_VELA_WEBAPP_SESSION' }, {}, sendResponse);
 
-    expect(listener({ type: 'GET_VELA_WEBAPP_SESSION' })).toEqual({
+    expect(sendResponse).toHaveBeenCalledWith({
       tokens: {
         accessToken: 'access-token',
         refreshToken: 'refresh-token',
@@ -252,7 +260,7 @@ describe('content script message listener', () => {
 
     contentScript.main();
     const listener = getRegisteredMessageListener();
-    listener({ type: 'SCAN_PAGE' });
+    listener({ type: 'SCAN_PAGE' }, undefined, noopSendResponse);
 
     const host = document.getElementById('vela-ext-overlay-host');
     const shadowRoot = host?.shadowRoot;
@@ -281,7 +289,7 @@ describe('content script message listener', () => {
 
     contentScript.main();
     const listener = getRegisteredMessageListener();
-    listener({ type: 'SCAN_PAGE' });
+    listener({ type: 'SCAN_PAGE' }, undefined, noopSendResponse);
 
     const host = document.getElementById('vela-ext-overlay-host');
     const shadowRoot = host?.shadowRoot;
@@ -303,7 +311,7 @@ describe('content script message listener', () => {
 
     contentScript.main();
     const listener = getRegisteredMessageListener();
-    listener({ type: 'SCAN_PAGE' });
+    listener({ type: 'SCAN_PAGE' }, undefined, noopSendResponse);
 
     const host = document.getElementById('vela-ext-overlay-host');
     const shadowRoot = host?.shadowRoot;
@@ -330,7 +338,7 @@ describe('content script message listener', () => {
 
     contentScript.main();
     const listener = getRegisteredMessageListener();
-    listener({ type: 'SCAN_PAGE' });
+    listener({ type: 'SCAN_PAGE' }, undefined, noopSendResponse);
 
     const host = document.getElementById('vela-ext-overlay-host');
     const shadowRoot = host?.shadowRoot;

--- a/apps/vela-ext/tests/content.test.ts
+++ b/apps/vela-ext/tests/content.test.ts
@@ -3,6 +3,27 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import contentScriptConfig, { scanJapaneseSentences } from '../entrypoints/content';
 
 const contentScript = contentScriptConfig as unknown as { main(): void };
+const localStorageState: Record<string, string> = {};
+
+Object.defineProperty(window, 'localStorage', {
+  value: {
+    get length() {
+      return Object.keys(localStorageState).length;
+    },
+    key: (index: number) => Object.keys(localStorageState)[index] ?? null,
+    getItem: (key: string) => localStorageState[key] ?? null,
+    setItem: (key: string, value: string) => {
+      localStorageState[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete localStorageState[key];
+    },
+    clear: () => {
+      Object.keys(localStorageState).forEach((key) => delete localStorageState[key]);
+    },
+  },
+  configurable: true,
+});
 
 function getRegisteredMessageListener() {
   const addListener = (globalThis as any).browser.runtime.onMessage.addListener;
@@ -16,9 +37,17 @@ function getRegisteredMessageListener() {
 
 beforeEach(() => {
   document.body.innerHTML = '';
+  localStorage.clear();
   (globalThis as any).browser.runtime.onMessage.addListener.mockClear();
   (globalThis as any).browser.runtime.sendMessage.mockReset();
 });
+
+function jwtWithPayload(payload: Record<string, unknown>) {
+  return `header.${btoa(JSON.stringify(payload))
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replace(/=+$/, '')}.signature`;
+}
 
 describe('scanJapaneseSentences', () => {
   it('collects Japanese text nodes matching the regex', () => {
@@ -177,6 +206,38 @@ describe('content script message listener', () => {
     // Should send a message to the background script so it can show the notification
     expect((globalThis as any).browser.runtime.sendMessage).toHaveBeenCalledWith({
       type: 'NO_JAPANESE_FOUND',
+    });
+  });
+
+  it('returns the web-app Cognito session from localStorage when requested by the popup', () => {
+    const idToken = jwtWithPayload({ email: 'user@example.com' });
+    localStorage.setItem(
+      'CognitoIdentityServiceProvider.client-id.LastAuthUser',
+      'user@example.com',
+    );
+    localStorage.setItem(
+      'CognitoIdentityServiceProvider.client-id.user@example.com.accessToken',
+      'access-token',
+    );
+    localStorage.setItem(
+      'CognitoIdentityServiceProvider.client-id.user@example.com.refreshToken',
+      'refresh-token',
+    );
+    localStorage.setItem(
+      'CognitoIdentityServiceProvider.client-id.user@example.com.idToken',
+      idToken,
+    );
+
+    contentScript.main();
+    const listener = getRegisteredMessageListener();
+
+    expect(listener({ type: 'GET_VELA_WEBAPP_SESSION' })).toEqual({
+      tokens: {
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        idToken,
+      },
+      email: 'user@example.com',
     });
   });
 

--- a/apps/vela-ext/tests/content.test.ts
+++ b/apps/vela-ext/tests/content.test.ts
@@ -249,6 +249,24 @@ describe('content script message listener', () => {
     });
   });
 
+  it('responds with null when localStorage access throws a SecurityError', () => {
+    // Override localStorage.getItem to throw
+    const originalGetItem = window.localStorage.getItem;
+    vi.spyOn(window.localStorage, 'getItem').mockImplementation(() => {
+      throw new DOMException('The operation is insecure.', 'SecurityError');
+    });
+
+    contentScript.main();
+    const listener = getRegisteredMessageListener();
+    const sendResponse = vi.fn();
+    listener({ type: 'GET_VELA_WEBAPP_SESSION' }, {}, sendResponse);
+
+    expect(sendResponse).toHaveBeenCalledWith(null);
+
+    vi.restoreAllMocks();
+    window.localStorage.getItem = originalGetItem;
+  });
+
   it('shows success only after SAVE_SENTENCES resolves', async () => {
     document.body.innerHTML = '<p>日本語を勉強しています。</p>';
     let resolveMessage: ((_value?: unknown) => void) | undefined;

--- a/apps/vela-ext/tests/popup/App.test.ts
+++ b/apps/vela-ext/tests/popup/App.test.ts
@@ -65,4 +65,44 @@ describe('popup App', () => {
     expect(wrapper.find('[data-testid="dashboard-page"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="login-page"]').exists()).toBe(false);
   });
+
+  it('sends LOGIN_SUCCESS to background after successful auto-import', async () => {
+    mockIsAuthenticated.mockResolvedValue(false);
+    mockImportWebappSession.mockResolvedValue(true);
+
+    mount(App);
+    await flushPromises();
+
+    expect((globalThis as any).browser.runtime.sendMessage).toHaveBeenCalledWith({
+      type: 'LOGIN_SUCCESS',
+    });
+  });
+
+  it('does not send LOGIN_SUCCESS when no session is imported', async () => {
+    mockIsAuthenticated.mockResolvedValue(false);
+    mockImportWebappSession.mockResolvedValue(false);
+
+    mount(App);
+    await flushPromises();
+
+    expect((globalThis as any).browser.runtime.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('logs error and recovers when initialisation throws', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockIsAuthenticated.mockRejectedValue(new Error('Storage corrupted'));
+
+    const wrapper = mount(App);
+    await flushPromises();
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[Vela] Failed to initialise session:',
+      expect.any(Error),
+    );
+    // Loading should complete even after error
+    expect(wrapper.find('[data-testid="login-page"]').exists()).toBe(true);
+    expect(wrapper.find('.loading').exists()).toBe(false);
+
+    consoleSpy.mockRestore();
+  });
 });

--- a/apps/vela-ext/tests/popup/App.test.ts
+++ b/apps/vela-ext/tests/popup/App.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+
+const { mockIsAuthenticated, mockImportWebappSession } = vi.hoisted(() => ({
+  mockIsAuthenticated: vi.fn(),
+  mockImportWebappSession: vi.fn(),
+}));
+
+vi.mock('../../entrypoints/utils/storage', () => ({
+  isAuthenticated: mockIsAuthenticated,
+}));
+
+vi.mock('../../entrypoints/utils/webappSession', () => ({
+  importWebappSession: mockImportWebappSession,
+}));
+
+vi.mock('../../entrypoints/popup/LoginPage.vue', () => ({
+  default: {
+    name: 'LoginPage',
+    emits: ['loginSuccess'],
+    template: '<div data-testid="login-page" />',
+  },
+}));
+
+vi.mock('../../entrypoints/popup/DashboardPage.vue', () => ({
+  default: {
+    name: 'DashboardPage',
+    emits: ['logout'],
+    template: '<div data-testid="dashboard-page" />',
+  },
+}));
+
+import App from '../../entrypoints/popup/App.vue';
+
+describe('popup App', () => {
+  beforeEach(() => {
+    mockIsAuthenticated.mockReset();
+    mockImportWebappSession.mockReset();
+
+    (globalThis as any).browser = {
+      runtime: {
+        sendMessage: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+  });
+
+  it('uses an existing extension session when present', async () => {
+    mockIsAuthenticated.mockResolvedValue(true);
+
+    const wrapper = mount(App);
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="dashboard-page"]').exists()).toBe(true);
+    expect(mockImportWebappSession).not.toHaveBeenCalled();
+  });
+
+  it('imports an open web-app session before showing the login page', async () => {
+    mockIsAuthenticated.mockResolvedValue(false);
+    mockImportWebappSession.mockResolvedValue(true);
+
+    const wrapper = mount(App);
+    await flushPromises();
+
+    expect(mockImportWebappSession).toHaveBeenCalledOnce();
+    expect(wrapper.find('[data-testid="dashboard-page"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="login-page"]').exists()).toBe(false);
+  });
+});

--- a/apps/vela-ext/tests/popup/LoginPage.test.ts
+++ b/apps/vela-ext/tests/popup/LoginPage.test.ts
@@ -53,8 +53,8 @@ describe('LoginPage', () => {
 
   beforeEach(() => {
     Object.keys(storageState).forEach((k) => delete storageState[k]);
-    mockSignIn.mockClear();
-    mockSaveAuthTokens.mockClear();
+    mockSignIn.mockReset();
+    mockSaveAuthTokens.mockReset();
     mockImportWebappSession.mockReset();
     mockOpenWebappLogin.mockReset();
     setupBrowserMocks();

--- a/apps/vela-ext/tests/popup/LoginPage.test.ts
+++ b/apps/vela-ext/tests/popup/LoginPage.test.ts
@@ -3,10 +3,14 @@ import { mount, flushPromises, VueWrapper } from '@vue/test-utils';
 import type { ComponentPublicInstance } from 'vue';
 import LoginPage from '../../entrypoints/popup/LoginPage.vue';
 
-const { mockSignIn, mockSaveAuthTokens } = vi.hoisted(() => ({
-  mockSignIn: vi.fn(),
-  mockSaveAuthTokens: vi.fn(),
-}));
+const { mockSignIn, mockSaveAuthTokens, mockImportWebappSession, mockOpenWebappLogin } = vi.hoisted(
+  () => ({
+    mockSignIn: vi.fn(),
+    mockSaveAuthTokens: vi.fn(),
+    mockImportWebappSession: vi.fn(),
+    mockOpenWebappLogin: vi.fn(),
+  }),
+);
 
 vi.mock('../../entrypoints/utils/api', () => ({
   signIn: mockSignIn,
@@ -14,6 +18,11 @@ vi.mock('../../entrypoints/utils/api', () => ({
 
 vi.mock('../../entrypoints/utils/storage', () => ({
   saveAuthTokens: mockSaveAuthTokens,
+}));
+
+vi.mock('../../entrypoints/utils/webappSession', () => ({
+  importWebappSession: mockImportWebappSession,
+  openWebappLogin: mockOpenWebappLogin,
 }));
 
 const storageState: Record<string, unknown> = {};
@@ -46,6 +55,8 @@ describe('LoginPage', () => {
     Object.keys(storageState).forEach((k) => delete storageState[k]);
     mockSignIn.mockClear();
     mockSaveAuthTokens.mockClear();
+    mockImportWebappSession.mockReset();
+    mockOpenWebappLogin.mockReset();
     setupBrowserMocks();
   });
 
@@ -73,6 +84,19 @@ describe('LoginPage', () => {
     it('renders the page title', () => {
       wrapper = mount(LoginPage);
       expect(wrapper.text()).toContain('Vela Login');
+    });
+
+    it('marks credentials fields for browser and password-manager autofill', () => {
+      wrapper = mount(LoginPage);
+
+      expect(wrapper.find('#email').attributes()).toMatchObject({
+        name: 'username',
+        autocomplete: 'username',
+      });
+      expect(wrapper.find('#password').attributes()).toMatchObject({
+        name: 'password',
+        autocomplete: 'current-password',
+      });
     });
 
     it('does not show error message initially', () => {
@@ -284,6 +308,50 @@ describe('LoginPage', () => {
       expect(wrapper.find('.error-message').exists()).toBe(true);
       expect(wrapper.find('.error-message').text()).toContain('email and password');
       expect(mockSignIn).not.toHaveBeenCalled();
+    });
+
+    it('does not prevent native paste events on credential inputs', async () => {
+      wrapper = mount(LoginPage);
+      await flushPromises();
+
+      const preventEmailPaste = vi.fn();
+      const preventPasswordPaste = vi.fn();
+
+      await wrapper.find('#email').trigger('paste', {
+        clipboardData: { getData: () => 'pasted@example.com' },
+        preventDefault: preventEmailPaste,
+      });
+      await wrapper.find('#password').trigger('paste', {
+        clipboardData: { getData: () => 'pasted-password' },
+        preventDefault: preventPasswordPaste,
+      });
+
+      expect(preventEmailPaste).not.toHaveBeenCalled();
+      expect(preventPasswordPaste).not.toHaveBeenCalled();
+    });
+
+    it('imports the web-app session when the user clicks use web app session', async () => {
+      mockImportWebappSession.mockResolvedValue(true);
+      wrapper = mount(LoginPage);
+      await flushPromises();
+
+      await wrapper.find('.web-session-button').trigger('click');
+      await flushPromises();
+
+      expect(mockImportWebappSession).toHaveBeenCalledOnce();
+      expect(wrapper.emitted('loginSuccess')).toBeTruthy();
+    });
+
+    it('shows a readable message when no web-app session can be imported', async () => {
+      mockImportWebappSession.mockResolvedValue(false);
+      wrapper = mount(LoginPage);
+      await flushPromises();
+
+      await wrapper.find('.web-session-button').trigger('click');
+      await flushPromises();
+
+      expect(wrapper.find('.error-message').text()).toContain('Open Vela in a browser tab');
+      expect(wrapper.emitted('loginSuccess')).toBeUndefined();
     });
   });
 });

--- a/apps/vela-ext/tests/utils/api.test.ts
+++ b/apps/vela-ext/tests/utils/api.test.ts
@@ -67,10 +67,10 @@ describe('signIn', () => {
     await expect(signIn('bad@example.com', 'wrong')).rejects.toThrow('Invalid credentials');
   });
 
-  it('throws generic error when response has no error field', async () => {
+  it('throws generic error with status when response has no error field', async () => {
     mockFetch.mockResolvedValue(mockJsonResponse({}, 500));
 
-    await expect(signIn('user@example.com', 'pass')).rejects.toThrow('Sign in failed');
+    await expect(signIn('user@example.com', 'pass')).rejects.toThrow('Sign in failed (HTTP 500)');
   });
 
   it('throws a readable error when the sign in endpoint returns non-JSON HTML', async () => {
@@ -162,10 +162,10 @@ describe('refreshToken', () => {
     await expect(refreshToken('bad-refresh')).rejects.toThrow('Token expired');
   });
 
-  it('throws generic error when response has no error field', async () => {
+  it('throws generic error with status when response has no error field', async () => {
     mockFetch.mockResolvedValue(mockJsonResponse({}, 500));
 
-    await expect(refreshToken('token')).rejects.toThrow('Token refresh failed');
+    await expect(refreshToken('token')).rejects.toThrow('Token refresh failed (HTTP 500)');
   });
 });
 
@@ -207,11 +207,11 @@ describe('saveDictionaryEntry', () => {
     );
   });
 
-  it('throws generic error when response has no error field', async () => {
+  it('throws generic error with status when response has no error field', async () => {
     mockFetch.mockResolvedValue(mockJsonResponse({}, 500));
 
     await expect(saveDictionaryEntry('token', { sentence: 'テスト' })).rejects.toThrow(
-      'Failed to save dictionary entry',
+      'Failed to save dictionary entry (HTTP 500)',
     );
   });
 
@@ -260,9 +260,11 @@ describe('getMyDictionaries', () => {
     await expect(getMyDictionaries('bad-token')).rejects.toThrow('Unauthorized');
   });
 
-  it('throws generic error when response has no error field', async () => {
+  it('throws generic error with status when response has no error field', async () => {
     mockFetch.mockResolvedValue(mockJsonResponse({}, 500));
 
-    await expect(getMyDictionaries('token')).rejects.toThrow('Failed to fetch dictionary entries');
+    await expect(getMyDictionaries('token')).rejects.toThrow(
+      'Failed to fetch dictionary entries (HTTP 500)',
+    );
   });
 });

--- a/apps/vela-ext/tests/utils/api.test.ts
+++ b/apps/vela-ext/tests/utils/api.test.ts
@@ -1,5 +1,11 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { signIn, checkSession, refreshToken, saveDictionaryEntry, getMyDictionaries } from '../../entrypoints/utils/api';
+import {
+  signIn,
+  checkSession,
+  refreshToken,
+  saveDictionaryEntry,
+  getMyDictionaries,
+} from '../../entrypoints/utils/api';
 
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
@@ -8,7 +14,24 @@ function mockJsonResponse(data: unknown, status = 200) {
   return {
     ok: status >= 200 && status < 300,
     status,
+    headers: {
+      get: vi.fn((name: string) =>
+        name.toLowerCase() === 'content-type' ? 'application/json' : null,
+      ),
+    },
     json: vi.fn().mockResolvedValue(data),
+  };
+}
+
+function mockHtmlErrorResponse(status = 502) {
+  return {
+    ok: false,
+    status,
+    headers: {
+      get: vi.fn((name: string) => (name.toLowerCase() === 'content-type' ? 'text/html' : null)),
+    },
+    text: vi.fn().mockResolvedValue('<!doctype html><title>Bad Gateway</title>'),
+    json: vi.fn().mockRejectedValue(new SyntaxError('Unexpected token < in JSON')),
   };
 }
 
@@ -48,6 +71,27 @@ describe('signIn', () => {
     mockFetch.mockResolvedValue(mockJsonResponse({}, 500));
 
     await expect(signIn('user@example.com', 'pass')).rejects.toThrow('Sign in failed');
+  });
+
+  it('throws a readable error when the sign in endpoint returns non-JSON HTML', async () => {
+    mockFetch.mockResolvedValue(mockHtmlErrorResponse(502));
+
+    await expect(signIn('user@example.com', 'pass')).rejects.toThrow('Sign in failed (HTTP 502)');
+  });
+
+  it('throws a readable error when a successful sign in response is not JSON', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: {
+        get: vi.fn((name: string) => (name.toLowerCase() === 'content-type' ? 'text/html' : null)),
+      },
+      json: vi.fn().mockRejectedValue(new SyntaxError('Unexpected token < in JSON')),
+    });
+
+    await expect(signIn('user@example.com', 'pass')).rejects.toThrow(
+      'Sign in failed: invalid response from server',
+    );
   });
 
   it('sends Content-Type: application/json header', async () => {

--- a/apps/vela-ext/tests/utils/webappSession.test.ts
+++ b/apps/vela-ext/tests/utils/webappSession.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthTokens } from '../../entrypoints/utils/api';
+
+const { mockCheckSession, mockSaveAuthTokens } = vi.hoisted(() => ({
+  mockCheckSession: vi.fn(),
+  mockSaveAuthTokens: vi.fn(),
+}));
+
+vi.mock('../../entrypoints/utils/api', () => ({
+  checkSession: mockCheckSession,
+}));
+
+vi.mock('../../entrypoints/utils/storage', () => ({
+  saveAuthTokens: mockSaveAuthTokens,
+}));
+
+import {
+  importWebappSession,
+  readCognitoSessionFromStorage,
+} from '../../entrypoints/utils/webappSession';
+
+function jwtWithPayload(payload: Record<string, unknown>) {
+  return `header.${btoa(JSON.stringify(payload))
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replace(/=+$/, '')}.signature`;
+}
+
+function makeStorage(values: Record<string, string>) {
+  const keys = Object.keys(values);
+  return {
+    length: keys.length,
+    key: (index: number) => keys[index] ?? null,
+    getItem: (key: string) => values[key] ?? null,
+  } as Storage;
+}
+
+describe('readCognitoSessionFromStorage', () => {
+  it('extracts Amplify Cognito tokens and email from web-app localStorage', () => {
+    const idToken = jwtWithPayload({ email: 'user@example.com' });
+    const storage = makeStorage({
+      'CognitoIdentityServiceProvider.client-id.LastAuthUser': 'user@example.com',
+      'CognitoIdentityServiceProvider.client-id.user@example.com.accessToken': 'access-token',
+      'CognitoIdentityServiceProvider.client-id.user@example.com.refreshToken': 'refresh-token',
+      'CognitoIdentityServiceProvider.client-id.user@example.com.idToken': idToken,
+    });
+
+    expect(readCognitoSessionFromStorage(storage)).toEqual({
+      tokens: {
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        idToken,
+      },
+      email: 'user@example.com',
+    });
+  });
+
+  it('returns null when the web-app storage does not contain a complete Cognito session', () => {
+    const storage = makeStorage({
+      'CognitoIdentityServiceProvider.client-id.LastAuthUser': 'user@example.com',
+      'CognitoIdentityServiceProvider.client-id.user@example.com.accessToken': 'access-token',
+    });
+
+    expect(readCognitoSessionFromStorage(storage)).toBeNull();
+  });
+});
+
+describe('importWebappSession', () => {
+  const tokens: AuthTokens = {
+    accessToken: 'access-token',
+    refreshToken: 'refresh-token',
+    idToken: 'id-token',
+  };
+
+  beforeEach(() => {
+    mockCheckSession.mockReset();
+    mockSaveAuthTokens.mockReset();
+
+    (globalThis as any).browser = {
+      runtime: {
+        sendMessage: vi.fn().mockResolvedValue(undefined),
+      },
+      tabs: {
+        query: vi.fn().mockResolvedValue([{ id: 10, active: true }]),
+        sendMessage: vi.fn().mockResolvedValue({ tokens, email: 'user@example.com' }),
+      },
+    };
+  });
+
+  it('imports and saves a valid session from an open Vela web-app tab', async () => {
+    mockCheckSession.mockResolvedValue(true);
+
+    await expect(importWebappSession()).resolves.toBe(true);
+
+    expect(browser.tabs.query).toHaveBeenCalledWith({
+      url: ['https://vela.cwchanap.dev/*', 'http://localhost:9000/*', 'http://127.0.0.1:9000/*'],
+    });
+    expect(browser.tabs.sendMessage).toHaveBeenCalledWith(10, { type: 'GET_VELA_WEBAPP_SESSION' });
+    expect(mockCheckSession).toHaveBeenCalledWith('id-token');
+    expect(mockSaveAuthTokens).toHaveBeenCalledWith(tokens, 'user@example.com');
+    expect(browser.runtime.sendMessage).toHaveBeenCalledWith({ type: 'LOGIN_SUCCESS' });
+  });
+
+  it('does not import a session that the API rejects', async () => {
+    mockCheckSession.mockResolvedValue(false);
+
+    await expect(importWebappSession()).resolves.toBe(false);
+
+    expect(mockSaveAuthTokens).not.toHaveBeenCalled();
+  });
+});

--- a/apps/vela-ext/tests/utils/webappSession.test.ts
+++ b/apps/vela-ext/tests/utils/webappSession.test.ts
@@ -1,13 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AuthTokens } from '../../entrypoints/utils/api';
 
-const { mockCheckSession, mockSaveAuthTokens } = vi.hoisted(() => ({
+const { mockCheckSession, mockRefreshToken, mockSaveAuthTokens } = vi.hoisted(() => ({
   mockCheckSession: vi.fn(),
+  mockRefreshToken: vi.fn(),
   mockSaveAuthTokens: vi.fn(),
 }));
 
 vi.mock('../../entrypoints/utils/api', () => ({
   checkSession: mockCheckSession,
+  refreshToken: mockRefreshToken,
 }));
 
 vi.mock('../../entrypoints/utils/storage', () => ({
@@ -74,6 +76,7 @@ describe('importWebappSession', () => {
 
   beforeEach(() => {
     mockCheckSession.mockReset();
+    mockRefreshToken.mockReset();
     mockSaveAuthTokens.mockReset();
 
     (globalThis as any).browser = {
@@ -102,9 +105,36 @@ describe('importWebappSession', () => {
 
   it('does not import a session that the API rejects', async () => {
     mockCheckSession.mockResolvedValue(false);
+    mockRefreshToken.mockRejectedValue(new Error('Refresh failed'));
 
     await expect(importWebappSession()).resolves.toBe(false);
 
+    expect(mockSaveAuthTokens).not.toHaveBeenCalled();
+  });
+
+  it('imports a session by refreshing an expired ID token', async () => {
+    const newTokens: AuthTokens = {
+      accessToken: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+      idToken: 'new-id-token',
+    };
+
+    mockCheckSession.mockResolvedValue(false);
+    mockRefreshToken.mockResolvedValue(newTokens);
+
+    await expect(importWebappSession()).resolves.toBe(true);
+
+    expect(mockRefreshToken).toHaveBeenCalledWith('refresh-token');
+    expect(mockSaveAuthTokens).toHaveBeenCalledWith(newTokens, 'user@example.com');
+  });
+
+  it('skips when both checkSession and refreshToken fail', async () => {
+    mockCheckSession.mockResolvedValue(false);
+    mockRefreshToken.mockRejectedValue(new Error('Refresh token expired'));
+
+    await expect(importWebappSession()).resolves.toBe(false);
+
+    expect(mockRefreshToken).toHaveBeenCalledWith('refresh-token');
     expect(mockSaveAuthTokens).not.toHaveBeenCalled();
   });
 

--- a/apps/vela-ext/tests/utils/webappSession.test.ts
+++ b/apps/vela-ext/tests/utils/webappSession.test.ts
@@ -98,7 +98,6 @@ describe('importWebappSession', () => {
     expect(browser.tabs.sendMessage).toHaveBeenCalledWith(10, { type: 'GET_VELA_WEBAPP_SESSION' });
     expect(mockCheckSession).toHaveBeenCalledWith('id-token');
     expect(mockSaveAuthTokens).toHaveBeenCalledWith(tokens, 'user@example.com');
-    expect(browser.runtime.sendMessage).toHaveBeenCalledWith({ type: 'LOGIN_SUCCESS' });
   });
 
   it('does not import a session that the API rejects', async () => {
@@ -107,5 +106,33 @@ describe('importWebappSession', () => {
     await expect(importWebappSession()).resolves.toBe(false);
 
     expect(mockSaveAuthTokens).not.toHaveBeenCalled();
+  });
+
+  it('skips a tab when sendMessage rejects (content script not ready)', async () => {
+    (browser.tabs.sendMessage as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('Could not establish connection'),
+    );
+    mockCheckSession.mockResolvedValue(true);
+
+    await expect(importWebappSession()).resolves.toBe(false);
+
+    expect(mockSaveAuthTokens).not.toHaveBeenCalled();
+  });
+
+  it('skips a tab without an id', async () => {
+    (browser.tabs.query as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: undefined, active: true },
+    ]);
+
+    await expect(importWebappSession()).resolves.toBe(false);
+
+    expect(browser.tabs.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('propagates saveAuthTokens errors instead of swallowing them', async () => {
+    mockCheckSession.mockResolvedValue(true);
+    mockSaveAuthTokens.mockRejectedValue(new Error('Storage full'));
+
+    await expect(importWebappSession()).rejects.toThrow('Storage full');
   });
 });

--- a/apps/vela-ext/wxt.config.ts
+++ b/apps/vela-ext/wxt.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     host_permissions: [
       'https://vela.cwchanap.dev/*',
       'http://localhost:9000/*', // Allow localhost in development (Quasar dev server)
+      'http://127.0.0.1:9000/*', // Allow 127.0.0.1 in development (Quasar dev server)
       'http://localhost:9005/*', // Allow localhost API in development
     ],
   },

--- a/apps/vela/src/composables/queries/useAuthQueries.test.ts
+++ b/apps/vela/src/composables/queries/useAuthQueries.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
 import { flushPromises } from '@vue/test-utils';
 import { withQueryClient } from 'src/test-utils/withQueryClient';
+import { authKeys as sharedAuthKeys } from '@vela/common';
 
 const mockAuthService = {
   getCurrentSession: vi.fn(),
@@ -30,6 +31,10 @@ describe('useAuthQueries', () => {
   });
 
   describe('authKeys', () => {
+    it('re-exports the shared auth query keys', async () => {
+      expect(authKeys).toBe(sharedAuthKeys);
+    });
+
     it('generates correct session key', async () => {
       expect(authKeys.session()).toEqual(['auth', 'session']);
     });

--- a/apps/vela/src/composables/queries/useAuthQueries.ts
+++ b/apps/vela/src/composables/queries/useAuthQueries.ts
@@ -6,16 +6,9 @@ import {
   type ProfileData,
 } from 'src/services/authService';
 import type { Profile, UserPreferences } from 'src/types/shared';
+import { authKeys } from '@vela/common';
 
-/**
- * Query key factory for auth-related queries
- */
-export const authKeys = {
-  all: ['auth'] as const,
-  session: () => [...authKeys.all, 'session'] as const,
-  user: () => [...authKeys.all, 'user'] as const,
-  profile: (userId: string) => [...authKeys.all, 'profile', userId] as const,
-};
+export { authKeys };
 
 /**
  * Hook to get the current user session

--- a/apps/vela/src/composables/queries/useGameQueries.test.ts
+++ b/apps/vela/src/composables/queries/useGameQueries.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { flushPromises } from '@vue/test-utils';
 import { withQueryClient } from 'src/test-utils/withQueryClient';
+import { gameKeys as sharedGameKeys } from '@vela/common';
 
 const mockGameService = {
   getVocabularyQuestions: vi.fn(),
@@ -15,6 +16,11 @@ describe('useGameQueries', () => {
   });
 
   describe('gameKeys', () => {
+    it('re-exports the shared game query keys', async () => {
+      const { gameKeys } = await import('./useGameQueries');
+      expect(gameKeys).toBe(sharedGameKeys);
+    });
+
     it('generates correct vocabulary key', async () => {
       const { gameKeys } = await import('./useGameQueries');
       expect(gameKeys.vocabulary(10)).toEqual(['games', 'vocabulary', 10]);

--- a/apps/vela/src/composables/queries/useGameQueries.ts
+++ b/apps/vela/src/composables/queries/useGameQueries.ts
@@ -1,14 +1,8 @@
 import { useQuery } from '@tanstack/vue-query';
 import { gameService } from 'src/services/gameService';
+import { gameKeys } from '@vela/common';
 
-/**
- * Query key factory for game-related queries
- */
-export const gameKeys = {
-  all: ['games'] as const,
-  vocabulary: (count: number) => [...gameKeys.all, 'vocabulary', count] as const,
-  sentences: (count: number) => [...gameKeys.all, 'sentences', count] as const,
-};
+export { gameKeys };
 
 /**
  * Hook to fetch vocabulary questions for games

--- a/apps/vela/src/composables/queries/useProgressQueries.test.ts
+++ b/apps/vela/src/composables/queries/useProgressQueries.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { flushPromises } from '@vue/test-utils';
 import { isRef } from 'vue';
 import { withQueryClient } from 'src/test-utils/withQueryClient';
+import { progressKeys as sharedProgressKeys } from '@vela/common';
 
 const mockProgressService = {
   getProgressAnalytics: vi.fn(),
@@ -16,6 +17,11 @@ describe('useProgressQueries', () => {
   });
 
   describe('progressKeys', () => {
+    it('re-exports the shared progress query keys', async () => {
+      const { progressKeys } = await import('./useProgressQueries');
+      expect(progressKeys).toBe(sharedProgressKeys);
+    });
+
     it('generates correct all key', async () => {
       const { progressKeys } = await import('./useProgressQueries');
       expect(progressKeys.all).toEqual(['progress']);

--- a/apps/vela/src/composables/queries/useProgressQueries.ts
+++ b/apps/vela/src/composables/queries/useProgressQueries.ts
@@ -1,13 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/vue-query';
 import { progressService } from 'src/services/progressService';
+import { progressKeys } from '@vela/common';
 
-/**
- * Query key factory for progress-related queries
- */
-export const progressKeys = {
-  all: ['progress'] as const,
-  analytics: (userId: string | null) => [...progressKeys.all, 'analytics', userId] as const,
-};
+export { progressKeys };
 
 /**
  * Hook to fetch progress analytics for the current user

--- a/apps/vela/src/services/gameService.test.ts
+++ b/apps/vela/src/services/gameService.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { gameService, InsufficientVocabularyError } from './gameService';
 import type { Vocabulary, Sentence } from 'src/types/database';
 import type { LegacyVocabularyPayload } from 'src/utils/vocabulary';
@@ -29,6 +31,18 @@ describe('gameService', () => {
       expect(error).toBeInstanceOf(Error);
       expect(error.name).toBe('InsufficientVocabularyError');
       expect(error.message).toBe('Insufficient vocabulary for generating questions');
+    });
+  });
+
+  describe('module boundaries', () => {
+    it('keeps service and utility types independent from Pinia stores', () => {
+      const appRoot = resolve(__dirname, '..');
+      const files = ['services/gameService.ts', 'utils/vocabulary.ts'];
+
+      for (const file of files) {
+        const source = readFileSync(resolve(appRoot, file), 'utf8');
+        expect(source).not.toContain('src/stores/games');
+      }
     });
   });
 

--- a/apps/vela/src/services/gameService.ts
+++ b/apps/vela/src/services/gameService.ts
@@ -1,4 +1,4 @@
-import type { Question, SentenceQuestion, VocabularyOption } from 'src/stores/games';
+import type { Question, SentenceQuestion, VocabularyOption } from 'src/types/games';
 import type { Vocabulary, Sentence } from 'src/types/database';
 import { getApiUrl } from 'src/utils/api';
 import { shuffleArray } from 'src/utils/array';

--- a/apps/vela/src/stores/games.ts
+++ b/apps/vela/src/stores/games.ts
@@ -1,27 +1,8 @@
 import { defineStore } from 'pinia';
-import type { Vocabulary, Sentence, JLPTLevel } from 'src/types/database';
+import type { JLPTLevel } from 'src/types/database';
+import type { Question, SentenceQuestion } from 'src/types/games';
 
-export interface SentenceQuestion {
-  sentence: Sentence;
-  scrambled: string[];
-  correctAnswer: string;
-}
-
-export interface VocabularyOption {
-  /** Unique identifier for the vocabulary item */
-  id: string;
-  /** Japanese word text (may contain kanji) */
-  text: string;
-  /** Hiragana reading for furigana display */
-  reading?: string;
-}
-
-export interface Question {
-  word: Vocabulary;
-  options: VocabularyOption[];
-  /** id of the correct answer vocabulary */
-  correctAnswer: string;
-}
+export type { Question, SentenceQuestion, VocabularyOption } from 'src/types/games';
 
 export interface GameState {
   score: number;

--- a/apps/vela/src/types/games.ts
+++ b/apps/vela/src/types/games.ts
@@ -1,0 +1,23 @@
+import type { Sentence, Vocabulary } from './database';
+
+export interface SentenceQuestion {
+  sentence: Sentence;
+  scrambled: string[];
+  correctAnswer: string;
+}
+
+export interface VocabularyOption {
+  /** Unique identifier for the vocabulary item */
+  id: string;
+  /** Japanese word text (may contain kanji) */
+  text: string;
+  /** Hiragana reading for furigana display */
+  reading?: string;
+}
+
+export interface Question {
+  word: Vocabulary;
+  options: VocabularyOption[];
+  /** id of the correct answer vocabulary */
+  correctAnswer: string;
+}

--- a/apps/vela/src/utils/vocabulary.ts
+++ b/apps/vela/src/utils/vocabulary.ts
@@ -1,4 +1,4 @@
-import type { VocabularyOption } from 'src/stores/games';
+import type { VocabularyOption } from 'src/types/games';
 import type { Vocabulary } from 'src/types/database';
 import { shuffleArray } from './array';
 

--- a/apps/vela/vitest.config.ts
+++ b/apps/vela/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
       template: { transformAssetUrls },
     }),
     quasar({
-      sassVariables: 'src/quasar-variables.sass',
+      sassVariables: 'src/css/quasar.variables.scss',
     }) as unknown as any,
   ],
   test: {


### PR DESCRIPTION
## Summary

- Add a Vela web-app session bridge for the browser extension popup, so it can import and validate an existing Amplify/Cognito session from open Vela web-app tabs.
- Harden extension API response parsing so non-JSON or invalid JSON responses produce readable login/API errors instead of raw `Unexpected token` failures.
- Update the popup login form for password-manager-friendly fields and native paste behavior, including a manual web-app session import path.
- Add regression coverage for session import, API response handling, and popup login behavior.

## Root Cause

The extension only checked its own `browser.storage.local`, so it could not reuse the web app's Cognito session. The login API helpers also assumed every response body was JSON, which exposed raw JSON parser errors when a misrouted or failing endpoint returned HTML/text.

## Validation

- `bun run test:unit` from `apps/vela-ext` (151 tests)
- `bun run compile` from `apps/vela-ext`
- `bun run lint` from `apps/vela-ext`
- `bun run build` from `apps/vela-ext`

Note: `bun run build` still prints the existing WXT `InlineConfig#runner` deprecation warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now import authentication directly from the Vela web app instead of manually signing in
  * Added automatic session detection and web app login flow
  * Improved API error handling with consistent, more descriptive error messages
  
* **Tests**
  * Extended test coverage for new session management and authentication workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cwchanap/Vela/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->