### PR TITLE
feat(ext): replace credential login with web-app session import

### DIFF
--- a/.codex/skills/test-vela-extension/SKILL.md
+++ b/.codex/skills/test-vela-extension/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: test-vela-extension
+description: Run and verify the Vela browser extension local test workflow. Use when working in the Vela monorepo on apps/vela-ext, WXT, browser extension context menus, extension login/session import behavior, the one-command dev:extension-test loop, Chrome DevTools/browser MCP inspection, or the extension-test.html fixture.
+---
+
+# Test Vela Extension
+
+Use this skill to exercise the Vela extension with the app, API, WXT runner, and browser MCP in one loop.
+
+## Workflow
+
+1. Work from the Vela monorepo root, not `apps/vela-ext`:
+
+   ```bash
+   bun run dev:extension-test
+   ```
+
+   Keep the command session open while testing. Wait for all of these signals:
+   - Quasar reports `App URL................ http://localhost:9000/`
+   - API reports `Vela API development server running on port 9005`
+   - WXT reports `Started dev server @ http://localhost:3000`
+   - WXT reports `Built extension`
+   - WXT reports `Opened browser`
+
+2. Use browser MCP / Chrome DevTools after startup. `mcp__chrome_devtools__.list_pages` should show:
+   - `http://localhost:9000/auth/login`
+   - `http://localhost:9000/extension-test.html`
+
+   If MCP cannot connect, inspect `apps/vela-ext/wxt.config.ts`. In extension test mode, `webExt.chromiumArgs` must include `--remote-debugging-port=9222`, and WXT must be restarted after changing it.
+
+3. Select the fixture page and take a snapshot. It should contain:
+   - title `Vela Extension Test Fixture`
+   - instruction `Select a sentence, right-click, then choose Add vocab to Vela.`
+   - Japanese sample sentences including `今日は新しい単語を三つ覚えました。`
+
+4. Verify extension runtime targets through Chrome DevTools:
+
+   ```bash
+   curl -s http://127.0.0.1:9222/json/list
+   ```
+
+   Expect two page targets plus a `service_worker` target whose URL is `chrome-extension://.../background.js`.
+
+5. Do not claim the native right-click menu itself was inspected through MCP. Chrome native context menus and toolbar popups are not reliably exposed to page-level DevTools automation. Instead, verify the same extension path by sending a scan message from the loaded service worker:
+
+   ```bash
+   bun /path/to/test-vela-extension/scripts/trigger_scan.mjs
+   ```
+
+   Then take a browser MCP snapshot of `http://localhost:9000/extension-test.html`. Expect the overlay:
+   - `Found 3 Japanese sentences`
+   - three checked Japanese sentence checkboxes
+   - button `Save selected (3)`
+
+6. For unauthenticated behavior, click `Save selected (3)` from MCP. Expect the overlay to report `3 could not be saved (not signed in)` and no page console errors. This confirms the no-session path is handled without extension login/logout UI.
+
+7. When finished, stop every process started for the test. Check and clear these ports:
+
+   ```bash
+   lsof -ti :3000 -ti :9000 -ti :9005 -ti :9222
+   ```
+
+   Kill only the listed dev/test processes you started, then rerun the `lsof` command and expect no output.
+
+## Expected Project Hooks
+
+If the workflow is missing or broken, inspect these files before inventing a new path:
+
+- root `package.json`: `dev:extension-test` should run Turbo for `apps/vela`, `apps/vela-api`, and `apps/vela-ext`
+- `apps/vela/package.json`: `dev:extension-test` should delegate to `bun run dev`
+- `apps/vela-api/package.json`: `dev:extension-test` should delegate to `bun run dev`
+- `apps/vela-ext/package.json`: `dev:extension-test` should run `VELA_EXT_TEST_MODE=1 wxt`
+- `apps/vela-ext/wxt.config.ts`: `webExt` should open login plus fixture pages with a persistent `.wxt/chrome-data` profile and DevTools port `9222`
+- `apps/vela/public/extension-test.html`: fixture page for context-menu and scan testing
+
+## Verification
+
+For workflow/config changes, run at least:
+
+```bash
+bun run test:unit -- tests/devWorkflow.test.ts
+bun run compile
+git diff --check
+```
+
+For extension behavior changes, prefer the full runtime loop above and report exactly which MCP snapshots, console checks, and unauthenticated/authenticated paths were verified.

--- a/.codex/skills/test-vela-extension/agents/openai.yaml
+++ b/.codex/skills/test-vela-extension/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Test Vela Extension"
+  short_description: "Run the Vela extension debug loop"
+  default_prompt: "Use $test-vela-extension to start and verify the Vela browser extension workflow with browser MCP."

--- a/.codex/skills/test-vela-extension/scripts/trigger_scan.mjs
+++ b/.codex/skills/test-vela-extension/scripts/trigger_scan.mjs
@@ -26,8 +26,13 @@ try {
           resolve({ ok: false, error: 'Fixture tab not found: ${fixtureUrl}' });
           return;
         }
-        chrome.tabs.sendMessage(tabs[0].id, { type: 'SCAN_PAGE' });
-        resolve({ ok: true, tabId: tabs[0].id, url: tabs[0].url });
+        chrome.tabs.sendMessage(tabs[0].id, { type: 'SCAN_PAGE' }, (response) => {
+          if (chrome.runtime.lastError) {
+            resolve({ ok: false, error: chrome.runtime.lastError.message });
+            return;
+          }
+          resolve({ ok: true, tabId: tabs[0].id, url: tabs[0].url });
+        });
       });
     })
   `;

--- a/.codex/skills/test-vela-extension/scripts/trigger_scan.mjs
+++ b/.codex/skills/test-vela-extension/scripts/trigger_scan.mjs
@@ -1,0 +1,93 @@
+const devtoolsUrl = process.env.CHROME_DEVTOOLS_URL ?? 'http://127.0.0.1:9222';
+const fixtureUrl = process.argv[2] ?? 'http://localhost:9000/extension-test.html';
+
+const targets = await fetchJson(`${devtoolsUrl}/json/list`);
+const worker = targets.find(
+  (target) => target.type === 'service_worker' && target.url.includes('/background.js'),
+);
+
+if (!worker?.webSocketDebuggerUrl) {
+  throw new Error('Vela extension service worker target was not found');
+}
+
+const client = await connectDevtools(worker.webSocketDebuggerUrl);
+
+try {
+  await client.send('Runtime.enable');
+  const expression = `
+    new Promise((resolve) => {
+      chrome.tabs.query({ url: ${JSON.stringify(fixtureUrl)} }, (tabs) => {
+        const queryError = chrome.runtime.lastError?.message;
+        if (queryError) {
+          resolve({ ok: false, error: queryError });
+          return;
+        }
+        if (!tabs[0]?.id) {
+          resolve({ ok: false, error: 'Fixture tab not found: ${fixtureUrl}' });
+          return;
+        }
+        chrome.tabs.sendMessage(tabs[0].id, { type: 'SCAN_PAGE' });
+        resolve({ ok: true, tabId: tabs[0].id, url: tabs[0].url });
+      });
+    })
+  `;
+
+  const response = await client.send('Runtime.evaluate', {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  const value = response.result?.result?.value;
+
+  if (!value?.ok) {
+    throw new Error(value?.error ?? 'Failed to trigger Vela extension scan');
+  }
+
+  console.log(JSON.stringify(value, null, 2));
+} finally {
+  client.close();
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+async function connectDevtools(webSocketDebuggerUrl) {
+  const ws = new WebSocket(webSocketDebuggerUrl);
+  let nextId = 1;
+  const pending = new Map();
+
+  ws.addEventListener('message', (event) => {
+    const message = JSON.parse(event.data);
+    if (!message.id || !pending.has(message.id)) return;
+    const { resolve, reject } = pending.get(message.id);
+    pending.delete(message.id);
+    if (message.error) {
+      reject(new Error(message.error.message ?? JSON.stringify(message.error)));
+      return;
+    }
+    resolve(message);
+  });
+
+  await new Promise((resolve, reject) => {
+    ws.addEventListener('open', resolve, { once: true });
+    ws.addEventListener('error', reject, { once: true });
+  });
+
+  return {
+    send(method, params = {}) {
+      return new Promise((resolve, reject) => {
+        const id = nextId++;
+        pending.set(id, { resolve, reject });
+        ws.send(JSON.stringify({ id, method, params }));
+      });
+    },
+    close() {
+      ws.close();
+    },
+  };
+}

--- a/apps/vela-api/package.json
+++ b/apps/vela-api/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "scripts": {
     "dev": "NODE_ENV=development bun --watch src/index.ts",
+    "dev:extension-test": "bun run dev",
     "build": "NODE_ENV=production bun build src/index.ts --outdir dist --target bun --minify --sourcemap",
     "test": "bun run test:unit",
     "test:unit": "bun test",

--- a/apps/vela-ext/README.md
+++ b/apps/vela-ext/README.md
@@ -4,7 +4,7 @@ Browser extension for saving Japanese sentences to your Vela dictionary.
 
 ## Features
 
-- **Authentication**: Login with your Vela account credentials
+- **Authentication**: Imports an active Vela web-app session
 - **Context Menu Integration**: Right-click on selected text to save sentences
 - **Instant Saving**: Sentences are saved with source URL and context
 - **Dashboard**: View all your saved sentences in the extension popup
@@ -25,14 +25,22 @@ Browser extension for saving Japanese sentences to your Vela dictionary.
 
    Edit `.env` to set your API URL (defaults to production: `https://vela.cwchanap.dev/api`)
 
-3. Start development:
+3. Start manual extension development:
 
    ```bash
    bun dev              # Chrome
    bun dev:firefox      # Firefox
    ```
 
-4. Build for production:
+4. Start the low-friction local test loop from the monorepo root:
+
+   ```bash
+   bun run dev:extension-test
+   ```
+
+   This starts the Vela app, Vela API, and WXT extension runner together. WXT opens Chrome with the extension installed, a persistent `.wxt/chrome-data` profile, the Vela login page, and `/extension-test.html` for right-click testing.
+
+5. Build for production:
    ```bash
    bun build            # Chrome
    bun build:firefox    # Firefox
@@ -40,10 +48,10 @@ Browser extension for saving Japanese sentences to your Vela dictionary.
 
 ## Usage
 
-1. **Login**: Click the extension icon and log in with your Vela account
+1. **Login**: Open the Vela web app and sign in there, then click the extension icon and refresh/import the web-app session
 2. **Save Sentences**:
    - Select any text on a webpage
-   - Right-click and choose "Save to Vela Dictionary"
+   - Right-click and choose "Add vocab to Vela"
    - You'll see a notification confirming the save
 3. **View Saved Sentences**: Click the extension icon to view your saved sentences
 

--- a/apps/vela-ext/entrypoints/background.ts
+++ b/apps/vela-ext/entrypoints/background.ts
@@ -378,16 +378,18 @@ export async function flushQueue(): Promise<void> {
 
 async function recreateContextMenus(): Promise<void> {
   await browser.contextMenus.removeAll();
-  browser.contextMenus.create({
-    id: ADD_VOCAB_CONTEXT_MENU_ID,
-    title: 'Add vocab to Vela',
-    contexts: ['selection'],
-  });
-  browser.contextMenus.create({
-    id: SCAN_PAGE_CONTEXT_MENU_ID,
-    title: 'Scan page for Japanese',
-    contexts: ['page'],
-  });
+  await Promise.all([
+    browser.contextMenus.create({
+      id: ADD_VOCAB_CONTEXT_MENU_ID,
+      title: 'Add vocab to Vela',
+      contexts: ['selection'],
+    }),
+    browser.contextMenus.create({
+      id: SCAN_PAGE_CONTEXT_MENU_ID,
+      title: 'Scan page for Japanese',
+      contexts: ['page'],
+    }),
+  ]);
 }
 
 export function registerContextMenus(): Promise<void> {

--- a/apps/vela-ext/entrypoints/background.ts
+++ b/apps/vela-ext/entrypoints/background.ts
@@ -2,6 +2,9 @@ import { getValidIdToken, refreshIdToken, getUserEmail } from './utils/storage';
 import { openDB, STORE_NAME } from './utils/idb';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'https://vela.cwchanap.dev/api';
+const ADD_VOCAB_CONTEXT_MENU_ID = 'add-vocab-to-vela';
+const SCAN_PAGE_CONTEXT_MENU_ID = 'scan-page-vela';
+let contextMenuRegistrationPromise: Promise<void> | null = null;
 
 // ── IndexedDB queue ──────────────────────────────────────────────────────────
 
@@ -373,30 +376,47 @@ export async function flushQueue(): Promise<void> {
 
 // ── Extension entry point ────────────────────────────────────────────────────
 
+async function recreateContextMenus(): Promise<void> {
+  await browser.contextMenus.removeAll();
+  browser.contextMenus.create({
+    id: ADD_VOCAB_CONTEXT_MENU_ID,
+    title: 'Add vocab to Vela',
+    contexts: ['selection'],
+  });
+  browser.contextMenus.create({
+    id: SCAN_PAGE_CONTEXT_MENU_ID,
+    title: 'Scan page for Japanese',
+    contexts: ['page'],
+  });
+}
+
+export function registerContextMenus(): Promise<void> {
+  contextMenuRegistrationPromise ??= recreateContextMenus().finally(() => {
+    contextMenuRegistrationPromise = null;
+  });
+  return contextMenuRegistrationPromise;
+}
+
 export default defineBackground(() => {
   console.log('Vela extension background script loaded', { id: browser.runtime.id });
 
   browser.runtime.onInstalled.addListener(() => {
-    browser.contextMenus.create({
-      id: 'save-to-vela',
-      title: 'Save to My Dictionaries',
-      contexts: ['selection'],
-    });
-    browser.contextMenus.create({
-      id: 'scan-page-vela',
-      title: 'Scan page for Japanese',
-      contexts: ['page'],
-    });
-    console.log('Context menus created');
+    registerContextMenus()
+      .then(() => console.log('Context menus created'))
+      .catch((error) => console.error('[Vela] Failed to create context menus:', error));
   });
 
+  registerContextMenus()
+    .then(() => console.log('Context menus ready'))
+    .catch((error) => console.error('[Vela] Failed to initialise context menus:', error));
+
   browser.contextMenus.onClicked.addListener(async (info, tab) => {
-    if (info.menuItemId === 'scan-page-vela' && tab?.id) {
+    if (info.menuItemId === SCAN_PAGE_CONTEXT_MENU_ID && tab?.id) {
       await requestPageScan(tab.id);
       return;
     }
 
-    if (info.menuItemId === 'save-to-vela' && info.selectionText) {
+    if (info.menuItemId === ADD_VOCAB_CONTEXT_MENU_ID && info.selectionText) {
       const selectedText = info.selectionText.trim();
       if (!selectedText) return;
 
@@ -421,7 +441,7 @@ export default defineBackground(() => {
           message,
         });
       } catch (error) {
-        console.error('[Vela] Error in save-to-vela handler:', error);
+        console.error('[Vela] Error in add-vocab-to-vela handler:', error);
         browser.notifications.create({
           type: 'basic',
           iconUrl: browser.runtime.getURL('/icon/128.png'),

--- a/apps/vela-ext/entrypoints/popup/App.vue
+++ b/apps/vela-ext/entrypoints/popup/App.vue
@@ -35,7 +35,7 @@ function handleLoginSuccess() {
   });
 }
 
-function handleLogout() {
+function handleSessionExpired() {
   authenticated.value = false;
 }
 </script>
@@ -43,7 +43,7 @@ function handleLogout() {
 <template>
   <div v-if="loading" class="loading">Loading...</div>
   <LoginPage v-else-if="!authenticated" @login-success="handleLoginSuccess" />
-  <DashboardPage v-else @logout="handleLogout" />
+  <DashboardPage v-else @session-expired="handleSessionExpired" />
 </template>
 
 <style scoped>

--- a/apps/vela-ext/entrypoints/popup/App.vue
+++ b/apps/vela-ext/entrypoints/popup/App.vue
@@ -2,7 +2,7 @@
 import { ref, onMounted } from 'vue';
 import LoginPage from './LoginPage.vue';
 import DashboardPage from './DashboardPage.vue';
-import { isAuthenticated } from '../utils/storage';
+import { isAuthenticated, clearAuthData } from '../utils/storage';
 import { importWebappSession } from '../utils/webappSession';
 
 const authenticated = ref(false);
@@ -35,8 +35,13 @@ function handleLoginSuccess() {
   });
 }
 
-function handleSessionExpired() {
+async function handleSessionExpired() {
   authenticated.value = false;
+  try {
+    await clearAuthData();
+  } catch (error: unknown) {
+    console.error('[Vela] Failed to clear auth data on session expiry:', error);
+  }
 }
 </script>
 

--- a/apps/vela-ext/entrypoints/popup/App.vue
+++ b/apps/vela-ext/entrypoints/popup/App.vue
@@ -2,7 +2,7 @@
 import { ref, onMounted } from 'vue';
 import LoginPage from './LoginPage.vue';
 import DashboardPage from './DashboardPage.vue';
-import { isAuthenticated, clearAuthData } from '../utils/storage';
+import { isAuthenticated, clearAuthData, isExplicitSignout } from '../utils/storage';
 import { importWebappSession } from '../utils/webappSession';
 
 const authenticated = ref(false);
@@ -12,12 +12,15 @@ onMounted(async () => {
   try {
     authenticated.value = await isAuthenticated();
     if (!authenticated.value) {
-      authenticated.value = await importWebappSession();
-      if (authenticated.value) {
-        // Notify the background script so it can flush any queued offline saves.
-        browser.runtime.sendMessage({ type: 'LOGIN_SUCCESS' }).catch(() => {
-          // Background may not be listening during tests or development reloads.
-        });
+      const signedOut = await isExplicitSignout();
+      if (!signedOut) {
+        authenticated.value = await importWebappSession();
+        if (authenticated.value) {
+          // Notify the background script so it can flush any queued offline saves.
+          browser.runtime.sendMessage({ type: 'LOGIN_SUCCESS' }).catch(() => {
+            // Background may not be listening during tests or development reloads.
+          });
+        }
       }
     }
   } catch (error: unknown) {

--- a/apps/vela-ext/entrypoints/popup/DashboardPage.vue
+++ b/apps/vela-ext/entrypoints/popup/DashboardPage.vue
@@ -12,7 +12,6 @@
             >
               {{ isDarkMode ? '☀️' : '🌙' }}
             </button>
-            <button @click="handleLogout" class="icon-button" title="Logout">🚪</button>
           </div>
         </div>
         <p>Logged in as: {{ userEmail }}</p>
@@ -29,7 +28,7 @@
           <ol v-show="instructionsExpanded">
             <li>Select any text on a webpage</li>
             <li>Right-click to open the context menu</li>
-            <li>Click "Save to My Dictionaries"</li>
+            <li>Click "Add vocab to Vela"</li>
           </ol>
         </div>
 
@@ -92,11 +91,11 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, watch, computed } from 'vue';
 import { getMyDictionaries } from '../utils/api';
-import { getValidIdToken, refreshIdToken, getUserEmail, clearAuthData } from '../utils/storage';
+import { getValidIdToken, refreshIdToken, getUserEmail } from '../utils/storage';
 import { getPendingQueueCount } from '../utils/pendingQueue';
 
 const emit = defineEmits<{
-  logout: [];
+  sessionExpired: [];
 }>();
 
 const userEmail = ref('');
@@ -180,10 +179,9 @@ async function loadEntries() {
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'Failed to load dictionary entries';
 
-    // If session expired, log out the user
-    if (err instanceof Error && err.message.includes('Session expired')) {
+    if (err instanceof Error && isAuthenticationError(err)) {
       setTimeout(() => {
-        handleLogout();
+        emit('sessionExpired');
       }, 2000);
     }
   } finally {
@@ -196,13 +194,13 @@ function toggleTheme() {
   isDarkMode.value = !isDarkMode.value;
 }
 
-async function handleLogout() {
-  await clearAuthData();
-  // Don't clear the pending queue on logout — queued records are attributed
-  // to a specific userEmail and flushQueue() already discards mismatched
-  // records when a different user signs in. Wiping here silently loses saves
-  // if the same user re-authenticates (e.g. after a session-expiry auto-logout).
-  emit('logout');
+function isAuthenticationError(error: Error): boolean {
+  return [
+    'Session expired',
+    'Not authenticated',
+    'No refresh token available',
+    'No ID token available',
+  ].some((message) => error.message.includes(message));
 }
 
 function formatDate(timestamp: number): string {

--- a/apps/vela-ext/entrypoints/popup/DashboardPage.vue
+++ b/apps/vela-ext/entrypoints/popup/DashboardPage.vue
@@ -204,10 +204,10 @@ function toggleTheme() {
 async function handleSignOut() {
   try {
     await clearAuthData();
-    await setExplicitSignout();
   } catch (error: unknown) {
     console.error('[Vela] Failed to clear auth data on sign out:', error);
   }
+  await setExplicitSignout();
   emit('sessionExpired');
 }
 

--- a/apps/vela-ext/entrypoints/popup/DashboardPage.vue
+++ b/apps/vela-ext/entrypoints/popup/DashboardPage.vue
@@ -92,7 +92,13 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, watch, computed } from 'vue';
 import { getMyDictionaries } from '../utils/api';
-import { getValidIdToken, refreshIdToken, getUserEmail, clearAuthData } from '../utils/storage';
+import {
+  getValidIdToken,
+  refreshIdToken,
+  getUserEmail,
+  clearAuthData,
+  setExplicitSignout,
+} from '../utils/storage';
 import { getPendingQueueCount } from '../utils/pendingQueue';
 
 const emit = defineEmits<{
@@ -198,6 +204,7 @@ function toggleTheme() {
 async function handleSignOut() {
   try {
     await clearAuthData();
+    await setExplicitSignout();
   } catch (error: unknown) {
     console.error('[Vela] Failed to clear auth data on sign out:', error);
   }

--- a/apps/vela-ext/entrypoints/popup/DashboardPage.vue
+++ b/apps/vela-ext/entrypoints/popup/DashboardPage.vue
@@ -5,6 +5,7 @@
         <div class="header-top">
           <h2>Vela Dictionary</h2>
           <div class="header-actions">
+            <button @click="handleSignOut" class="icon-button" title="Sign Out">🚪</button>
             <button
               @click="toggleTheme"
               class="icon-button"
@@ -91,7 +92,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, watch, computed } from 'vue';
 import { getMyDictionaries } from '../utils/api';
-import { getValidIdToken, refreshIdToken, getUserEmail } from '../utils/storage';
+import { getValidIdToken, refreshIdToken, getUserEmail, clearAuthData } from '../utils/storage';
 import { getPendingQueueCount } from '../utils/pendingQueue';
 
 const emit = defineEmits<{
@@ -192,6 +193,15 @@ async function loadEntries() {
 
 function toggleTheme() {
   isDarkMode.value = !isDarkMode.value;
+}
+
+async function handleSignOut() {
+  try {
+    await clearAuthData();
+  } catch (error: unknown) {
+    console.error('[Vela] Failed to clear auth data on sign out:', error);
+  }
+  emit('sessionExpired');
 }
 
 function isAuthenticationError(error: Error): boolean {

--- a/apps/vela-ext/entrypoints/popup/LoginPage.vue
+++ b/apps/vela-ext/entrypoints/popup/LoginPage.vue
@@ -3,7 +3,7 @@
     <div class="login-card">
       <div class="login-header">
         <div class="header-top">
-          <h2>Vela Login</h2>
+          <h2>Sign in on Vela</h2>
           <button
             @click="toggleTheme"
             class="theme-toggle"
@@ -16,83 +16,51 @@
         <p>Save Japanese sentences to your dictionary</p>
       </div>
 
-      <form @submit.prevent="handleLogin" class="login-form">
-        <div class="form-group">
-          <label for="email">Email</label>
-          <input
-            id="email"
-            v-model="email"
-            type="email"
-            name="username"
-            autocomplete="username"
-            inputmode="email"
-            placeholder="your@email.com"
-            required
-            :disabled="loading || webSessionLoading"
-          />
-        </div>
-
-        <div class="form-group">
-          <label for="password">Password</label>
-          <input
-            id="password"
-            v-model="password"
-            type="password"
-            name="password"
-            autocomplete="current-password"
-            placeholder="Enter your password"
-            required
-            :disabled="loading || webSessionLoading"
-          />
-        </div>
+      <div class="session-panel">
+        <p class="session-copy">Sign in with the Vela web app, then return here.</p>
+        <a class="login-url" :href="loginUrl" @click.prevent="handleOpenWebappLogin">
+          {{ loginUrl }}
+        </a>
 
         <div v-if="error" class="error-message">
           {{ error }}
         </div>
 
-        <button type="submit" class="login-button" :disabled="loading || webSessionLoading">
-          {{ loading ? 'Signing in...' : 'Sign In' }}
-        </button>
-
         <div class="web-session-actions">
           <button
             type="button"
-            class="web-session-button"
-            :disabled="loading || webSessionLoading"
-            @click="handleUseWebappSession"
+            class="open-webapp-button"
+            :disabled="webSessionLoading"
+            @click="handleOpenWebappLogin"
           >
-            {{ webSessionLoading ? 'Checking...' : 'Use Web App Session' }}
+            Open Vela Login
           </button>
           <button
             type="button"
-            class="open-webapp-button"
-            :disabled="loading || webSessionLoading"
-            @click="openWebappLogin"
+            class="web-session-button"
+            :disabled="webSessionLoading"
+            @click="handleUseWebappSession"
           >
-            Open Web App Login
+            {{ webSessionLoading ? 'Checking...' : 'Refresh Session' }}
           </button>
         </div>
-      </form>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted, watch } from 'vue';
-import { signIn } from '../utils/api';
-import { saveAuthTokens } from '../utils/storage';
-import { importWebappSession, openWebappLogin } from '../utils/webappSession';
+import { getWebappLoginUrl, importWebappSession, openWebappLogin } from '../utils/webappSession';
 
 const emit = defineEmits<{
   loginSuccess: [];
 }>();
 
-const email = ref('');
-const password = ref('');
-const loading = ref(false);
 const webSessionLoading = ref(false);
 const error = ref('');
 const isDarkMode = ref(false);
+const loginUrl = getWebappLoginUrl();
 
 onMounted(async () => {
   // Load theme preference
@@ -109,6 +77,11 @@ function toggleTheme() {
   isDarkMode.value = !isDarkMode.value;
 }
 
+async function handleOpenWebappLogin() {
+  error.value = '';
+  await openWebappLogin();
+}
+
 async function handleUseWebappSession() {
   webSessionLoading.value = true;
   error.value = '';
@@ -120,31 +93,11 @@ async function handleUseWebappSession() {
       return;
     }
 
-    error.value = 'Open Vela in a browser tab and sign in, then try again.';
+    error.value = 'Sign in at the URL above, then return here and refresh the session.';
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'Failed to import web app session';
   } finally {
     webSessionLoading.value = false;
-  }
-}
-
-async function handleLogin() {
-  if (!email.value || !password.value) {
-    error.value = 'Please enter both email and password';
-    return;
-  }
-
-  loading.value = true;
-  error.value = '';
-
-  try {
-    const tokens = await signIn(email.value, password.value);
-    await saveAuthTokens(tokens, email.value);
-    emit('loginSuccess');
-  } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Login failed';
-  } finally {
-    loading.value = false;
   }
 }
 </script>
@@ -159,13 +112,11 @@ async function handleLogin() {
   --text-secondary: #333;
   --text-tertiary: #666;
   --border-color: #ddd;
-  --border-focus: #4a90e2;
   --accent-color: #4a90e2;
   --accent-hover: #357abd;
   --error-bg: #fee;
   --error-border: #fcc;
   --error-text: #c33;
-  --input-disabled-bg: #f5f5f5;
 }
 
 .login-container.dark {
@@ -176,13 +127,11 @@ async function handleLogin() {
   --text-secondary: #d0d0d0;
   --text-tertiary: #a0a0a0;
   --border-color: #404040;
-  --border-focus: #5ba3f5;
   --accent-color: #5ba3f5;
   --accent-hover: #4a90e2;
   --error-bg: #3d1a1a;
   --error-border: #5c2828;
   --error-text: #ff6b6b;
-  --input-disabled-bg: #2a2a2a;
 }
 
 .login-container {
@@ -246,48 +195,34 @@ async function handleLogin() {
   text-align: center;
 }
 
-.login-form {
+.session-panel {
   display: flex;
   flex-direction: column;
   gap: 16px;
 }
 
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.form-group label {
+.session-copy {
+  margin: 0;
   font-size: 14px;
-  font-weight: 500;
+  line-height: 1.45;
   color: var(--text-secondary);
 }
 
-.form-group input {
+.login-url {
+  display: block;
   padding: 10px 12px;
+  background-color: var(--bg-secondary);
   border: 1px solid var(--border-color);
   border-radius: 6px;
-  font-size: 14px;
-  background-color: var(--bg-primary);
-  color: var(--text-primary);
-  transition: border-color 0.2s;
+  color: var(--accent-color);
+  font-size: 13px;
+  line-height: 1.35;
+  text-decoration: none;
+  word-break: break-all;
 }
 
-.form-group input:focus {
-  outline: none;
-  border-color: var(--border-focus);
-}
-
-.form-group input:disabled {
-  background-color: var(--input-disabled-bg);
-  cursor: not-allowed;
-  opacity: 0.6;
-}
-
-.form-group input::placeholder {
-  color: var(--text-tertiary);
-  opacity: 0.6;
+.login-url:hover {
+  background-color: var(--bg-hover);
 }
 
 .error-message {
@@ -297,28 +232,6 @@ async function handleLogin() {
   border-radius: 6px;
   color: var(--error-text);
   font-size: 14px;
-}
-
-.login-button {
-  padding: 12px;
-  background-color: var(--accent-color);
-  color: white;
-  border: none;
-  border-radius: 6px;
-  font-size: 15px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.login-button:hover:not(:disabled) {
-  background-color: var(--accent-hover);
-}
-
-.login-button:disabled {
-  background-color: var(--border-color);
-  cursor: not-allowed;
-  opacity: 0.6;
 }
 
 .web-session-actions {

--- a/apps/vela-ext/entrypoints/popup/LoginPage.vue
+++ b/apps/vela-ext/entrypoints/popup/LoginPage.vue
@@ -52,6 +52,7 @@
 <script setup lang="ts">
 import { ref, onMounted, watch } from 'vue';
 import { getWebappLoginUrl, importWebappSession, openWebappLogin } from '../utils/webappSession';
+import { clearExplicitSignout } from '../utils/storage';
 
 const emit = defineEmits<{
   loginSuccess: [];
@@ -94,6 +95,7 @@ async function handleUseWebappSession() {
   try {
     const imported = await importWebappSession();
     if (imported) {
+      await clearExplicitSignout();
       emit('loginSuccess');
       return;
     }

--- a/apps/vela-ext/entrypoints/popup/LoginPage.vue
+++ b/apps/vela-ext/entrypoints/popup/LoginPage.vue
@@ -79,7 +79,12 @@ function toggleTheme() {
 
 async function handleOpenWebappLogin() {
   error.value = '';
-  await openWebappLogin();
+  try {
+    await openWebappLogin();
+  } catch (err) {
+    console.error('[Vela] Failed to open webapp login:', err);
+    error.value = err instanceof Error ? err.message : 'Failed to open login page';
+  }
 }
 
 async function handleUseWebappSession() {

--- a/apps/vela-ext/entrypoints/utils/api.ts
+++ b/apps/vela-ext/entrypoints/utils/api.ts
@@ -44,24 +44,6 @@ async function getJsonBody<T>(response: Response, fallback: string): Promise<T> 
   }
 }
 
-// Authentication API
-export async function signIn(email: string, password: string): Promise<AuthTokens> {
-  const response = await fetch(`${API_BASE_URL}/auth/signin`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ email, password }),
-  });
-
-  if (!response.ok) {
-    throw new Error(await getErrorMessage(response, 'Sign in failed'));
-  }
-
-  const data = await getJsonBody<{ tokens: AuthTokens }>(response, 'Sign in failed');
-  return data.tokens;
-}
-
 export async function checkSession(idToken: string): Promise<boolean> {
   try {
     const response = await fetch(`${API_BASE_URL}/auth/session`, {

--- a/apps/vela-ext/entrypoints/utils/storage.ts
+++ b/apps/vela-ext/entrypoints/utils/storage.ts
@@ -4,6 +4,7 @@ import { refreshToken as refreshTokenAPI } from './api';
 const STORAGE_KEYS = {
   AUTH_TOKENS: 'vela_auth_tokens',
   USER_EMAIL: 'vela_user_email',
+  EXPLICIT_SIGNOUT: 'vela_explicit_signout',
 };
 
 export async function saveAuthTokens(tokens: AuthTokens, email?: string): Promise<void> {
@@ -92,6 +93,31 @@ export async function refreshAccessToken(): Promise<string> {
     await clearAuthData();
     throw new Error('Session expired. Please log in again.');
   }
+}
+
+/**
+ * Record that the user explicitly signed out from the extension popup.
+ * Prevents auto-import from the web-app session on the next popup open.
+ */
+export async function setExplicitSignout(): Promise<void> {
+  await browser.storage.local.set({ [STORAGE_KEYS.EXPLICIT_SIGNOUT]: true });
+}
+
+/**
+ * Check whether the user explicitly signed out (suppresses auto-import).
+ */
+export async function isExplicitSignout(): Promise<boolean> {
+  const result = (await browser.storage.local.get(STORAGE_KEYS.EXPLICIT_SIGNOUT)) as {
+    [STORAGE_KEYS.EXPLICIT_SIGNOUT]?: boolean;
+  };
+  return result[STORAGE_KEYS.EXPLICIT_SIGNOUT] === true;
+}
+
+/**
+ * Clear the explicit-signout flag so auto-import can resume.
+ */
+export async function clearExplicitSignout(): Promise<void> {
+  await browser.storage.local.remove(STORAGE_KEYS.EXPLICIT_SIGNOUT);
 }
 
 /**

--- a/apps/vela-ext/entrypoints/utils/webappSession.ts
+++ b/apps/vela-ext/entrypoints/utils/webappSession.ts
@@ -18,6 +18,10 @@ function getWebappBaseUrl(): string {
     : 'https://vela.cwchanap.dev';
 }
 
+export function getWebappLoginUrl(): string {
+  return `${getWebappBaseUrl()}/auth/login`;
+}
+
 function decodeJwtPayload(token: string): Record<string, unknown> | null {
   const payload = token.split('.')[1];
   if (!payload) return null;
@@ -135,5 +139,5 @@ export async function importWebappSession(): Promise<boolean> {
 }
 
 export async function openWebappLogin(): Promise<void> {
-  await browser.tabs.create({ url: `${getWebappBaseUrl()}/auth/login` });
+  await browser.tabs.create({ url: getWebappLoginUrl() });
 }

--- a/apps/vela-ext/package.json
+++ b/apps/vela-ext/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "wxt",
+    "dev:extension-test": "VELA_EXT_TEST_MODE=1 wxt",
     "dev:firefox": "wxt -b firefox",
     "build": "wxt build",
     "build:firefox": "wxt build -b firefox",

--- a/apps/vela-ext/package.json
+++ b/apps/vela-ext/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "wxt",
-    "dev:extension-test": "VELA_EXT_TEST_MODE=1 wxt",
+    "dev:extension-test": "VITE_API_URL=http://localhost:9005/api VELA_EXT_TEST_MODE=1 wxt",
     "dev:firefox": "wxt -b firefox",
     "build": "wxt build",
     "build:firefox": "wxt build -b firefox",

--- a/apps/vela-ext/package.json
+++ b/apps/vela-ext/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "wxt",
-    "dev:extension-test": "VITE_API_URL=http://localhost:9005/api VELA_EXT_TEST_MODE=1 wxt",
+    "dev:extension-test": "bash -c 'for i in $(seq 1 60); do curl -s -o /dev/null http://localhost:9000 2>/dev/null && break; sleep 1; done; VITE_API_URL=http://localhost:9005/api VELA_EXT_TEST_MODE=1 wxt'",
     "dev:firefox": "wxt -b firefox",
     "build": "wxt build",
     "build:firefox": "wxt build -b firefox",

--- a/apps/vela-ext/tests/background.test.ts
+++ b/apps/vela-ext/tests/background.test.ts
@@ -1,74 +1,86 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockNotificationsCreate, mockTabsSendMessage, mockRuntimeGetURL, mockIdbStore, idbState } =
-  vi.hoisted(() => {
-    const mockNotificationsCreate = vi.fn();
-    const mockTabsSendMessage = vi.fn();
-    const mockRuntimeGetURL = vi.fn((p: string) => `chrome-extension://abc123${p}`);
+const {
+  mockContextMenusCreate,
+  mockContextMenusRemoveAll,
+  mockNotificationsCreate,
+  mockTabsSendMessage,
+  mockRuntimeGetURL,
+  mockIdbStore,
+  idbState,
+} = vi.hoisted(() => {
+  const mockContextMenusCreate = vi.fn();
+  const mockContextMenusRemoveAll = vi.fn().mockResolvedValue(undefined);
+  const mockNotificationsCreate = vi.fn();
+  const mockTabsSendMessage = vi.fn();
+  const mockRuntimeGetURL = vi.fn((p: string) => `chrome-extension://abc123${p}`);
 
-    (globalThis as any).browser = {
-      runtime: {
-        id: 'test-ext-id',
-        onInstalled: { addListener: vi.fn() },
-        onMessage: { addListener: vi.fn() },
-        onStartup: { addListener: vi.fn() },
-        getURL: mockRuntimeGetURL,
-        sendMessage: vi.fn(),
-      },
-      contextMenus: {
-        create: vi.fn(),
-        onClicked: { addListener: vi.fn() },
-      },
-      notifications: {
-        create: mockNotificationsCreate,
-      },
-      tabs: {
-        sendMessage: mockTabsSendMessage,
-      },
-      windows: {
-        WINDOW_ID_NONE: -1,
-        onFocusChanged: { addListener: vi.fn() },
-      },
-      storage: { local: { get: vi.fn(), set: vi.fn(), remove: vi.fn(), clear: vi.fn() } },
-    };
+  (globalThis as any).browser = {
+    runtime: {
+      id: 'test-ext-id',
+      onInstalled: { addListener: vi.fn() },
+      onMessage: { addListener: vi.fn() },
+      onStartup: { addListener: vi.fn() },
+      getURL: mockRuntimeGetURL,
+      sendMessage: vi.fn(),
+    },
+    contextMenus: {
+      create: mockContextMenusCreate,
+      removeAll: mockContextMenusRemoveAll,
+      onClicked: { addListener: vi.fn() },
+    },
+    notifications: {
+      create: mockNotificationsCreate,
+    },
+    tabs: {
+      sendMessage: mockTabsSendMessage,
+    },
+    windows: {
+      WINDOW_ID_NONE: -1,
+      onFocusChanged: { addListener: vi.fn() },
+    },
+    storage: { local: { get: vi.fn(), set: vi.fn(), remove: vi.fn(), clear: vi.fn() } },
+  };
 
-    /** Shared mutable state for the IDB mock — tests configure this per-case. */
-    const idbState = {
-      getAllResult: [] as any[],
-    };
+  /** Shared mutable state for the IDB mock — tests configure this per-case. */
+  const idbState = {
+    getAllResult: [] as any[],
+  };
 
-    /** Build a fake IDBRequest-like object that immediately fires onsuccess with a given value. */
-    function makeSuccessRequest(result: any = undefined) {
-      return {
-        result,
-        get onsuccess() {
-          return null;
-        },
-        set onsuccess(cb: any) {
-          cb();
-        },
-        get onerror() {
-          return null;
-        },
-        set onerror(_: any) {},
-      };
-    }
-
-    const mockIdbStore = {
-      add: vi.fn(() => makeSuccessRequest()),
-      getAll: vi.fn(() => makeSuccessRequest(idbState.getAllResult)),
-      delete: vi.fn(() => makeSuccessRequest()),
-      put: vi.fn(() => makeSuccessRequest()),
-    };
-
+  /** Build a fake IDBRequest-like object that immediately fires onsuccess with a given value. */
+  function makeSuccessRequest(result: any = undefined) {
     return {
-      mockNotificationsCreate,
-      mockTabsSendMessage,
-      mockRuntimeGetURL,
-      mockIdbStore,
-      idbState,
+      result,
+      get onsuccess() {
+        return null;
+      },
+      set onsuccess(cb: any) {
+        cb();
+      },
+      get onerror() {
+        return null;
+      },
+      set onerror(_: any) {},
     };
-  });
+  }
+
+  const mockIdbStore = {
+    add: vi.fn(() => makeSuccessRequest()),
+    getAll: vi.fn(() => makeSuccessRequest(idbState.getAllResult)),
+    delete: vi.fn(() => makeSuccessRequest()),
+    put: vi.fn(() => makeSuccessRequest()),
+  };
+
+  return {
+    mockContextMenusCreate,
+    mockContextMenusRemoveAll,
+    mockNotificationsCreate,
+    mockTabsSendMessage,
+    mockRuntimeGetURL,
+    mockIdbStore,
+    idbState,
+  };
+});
 
 vi.mock('../entrypoints/utils/idb', () => ({
   openDB: vi.fn().mockResolvedValue({
@@ -89,11 +101,35 @@ vi.mock('../entrypoints/utils/storage', () => ({
 import {
   buildPendingSentenceRecord,
   flushQueue,
+  registerContextMenus,
   requestPageScan,
   saveSentenceToAPI,
   shouldDiscardPendingRecord,
 } from '../entrypoints/background';
 import { getValidIdToken, refreshIdToken, getUserEmail } from '../entrypoints/utils/storage';
+
+describe('registerContextMenus', () => {
+  beforeEach(() => {
+    mockContextMenusCreate.mockClear();
+    mockContextMenusRemoveAll.mockClear();
+  });
+
+  it('recreates context menus when the background script starts', async () => {
+    await registerContextMenus();
+
+    expect(mockContextMenusRemoveAll).toHaveBeenCalledOnce();
+    expect(mockContextMenusCreate).toHaveBeenCalledWith({
+      id: 'add-vocab-to-vela',
+      title: 'Add vocab to Vela',
+      contexts: ['selection'],
+    });
+    expect(mockContextMenusCreate).toHaveBeenCalledWith({
+      id: 'scan-page-vela',
+      title: 'Scan page for Japanese',
+      contexts: ['page'],
+    });
+  });
+});
 
 describe('buildPendingSentenceRecord', () => {
   it('creates a record with retries: 0, a timestamp, and an idempotencyKey', () => {

--- a/apps/vela-ext/tests/background.test.ts
+++ b/apps/vela-ext/tests/background.test.ts
@@ -129,6 +129,13 @@ describe('registerContextMenus', () => {
       contexts: ['page'],
     });
   });
+
+  it('deduplicates concurrent calls — removeAll called only once', async () => {
+    await Promise.all([registerContextMenus(), registerContextMenus()]);
+
+    expect(mockContextMenusRemoveAll).toHaveBeenCalledOnce();
+    expect(mockContextMenusCreate).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('buildPendingSentenceRecord', () => {

--- a/apps/vela-ext/tests/background.test.ts
+++ b/apps/vela-ext/tests/background.test.ts
@@ -9,7 +9,7 @@ const {
   mockIdbStore,
   idbState,
 } = vi.hoisted(() => {
-  const mockContextMenusCreate = vi.fn();
+  const mockContextMenusCreate = vi.fn().mockResolvedValue(undefined);
   const mockContextMenusRemoveAll = vi.fn().mockResolvedValue(undefined);
   const mockNotificationsCreate = vi.fn();
   const mockTabsSendMessage = vi.fn();

--- a/apps/vela-ext/tests/devWorkflow.test.ts
+++ b/apps/vela-ext/tests/devWorkflow.test.ts
@@ -30,7 +30,9 @@ describe('extension local testing workflow', () => {
     );
     expect(appPackage.scripts?.['dev:extension-test']).toBe('bun run dev');
     expect(apiPackage.scripts?.['dev:extension-test']).toBe('bun run dev');
-    expect(extensionPackage.scripts?.['dev:extension-test']).toBe('VELA_EXT_TEST_MODE=1 wxt');
+    expect(extensionPackage.scripts?.['dev:extension-test']).toBe(
+      'VITE_API_URL=http://localhost:9005/api VELA_EXT_TEST_MODE=1 wxt',
+    );
   });
 
   it('configures WXT to auto-launch Chrome only for extension test mode', () => {

--- a/apps/vela-ext/tests/devWorkflow.test.ts
+++ b/apps/vela-ext/tests/devWorkflow.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const extensionRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = resolve(extensionRoot, '../..');
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, 'utf8')) as T;
+}
+
+function readText(path: string): string {
+  return readFileSync(path, 'utf8');
+}
+
+type PackageJson = {
+  scripts?: Record<string, string>;
+};
+
+describe('extension local testing workflow', () => {
+  it('provides one root command that starts the app, API, and extension test runner', () => {
+    const rootPackage = readJson<PackageJson>(resolve(repoRoot, 'package.json'));
+    const appPackage = readJson<PackageJson>(resolve(repoRoot, 'apps/vela/package.json'));
+    const apiPackage = readJson<PackageJson>(resolve(repoRoot, 'apps/vela-api/package.json'));
+    const extensionPackage = readJson<PackageJson>(resolve(extensionRoot, 'package.json'));
+
+    expect(rootPackage.scripts?.['dev:extension-test']).toBe(
+      'turbo run dev:extension-test --parallel --filter=./apps/vela --filter=./apps/vela-api --filter=./apps/vela-ext',
+    );
+    expect(appPackage.scripts?.['dev:extension-test']).toBe('bun run dev');
+    expect(apiPackage.scripts?.['dev:extension-test']).toBe('bun run dev');
+    expect(extensionPackage.scripts?.['dev:extension-test']).toBe('VELA_EXT_TEST_MODE=1 wxt');
+  });
+
+  it('configures WXT to auto-launch Chrome only for extension test mode', () => {
+    const config = readText(resolve(extensionRoot, 'wxt.config.ts'));
+
+    expect(config).toContain('const isExtensionTestMode = process.env.VELA_EXT_TEST_MODE ===');
+    expect(config).toContain('webExt:');
+    expect(config).toContain('disabled: !isExtensionTestMode');
+    expect(config).toContain("startUrls: ['http://localhost:9000/auth/login'");
+    expect(config).toContain("'--user-data-dir=.wxt/chrome-data'");
+    expect(config).toContain("'--remote-debugging-port=9222'");
+    expect(config).not.toContain('runner:');
+  });
+
+  it('serves a Japanese fixture page from the Vela app for context-menu testing', () => {
+    const fixture = readText(resolve(repoRoot, 'apps/vela/public/extension-test.html'));
+
+    expect(fixture).toContain('<title>Vela Extension Test Fixture</title>');
+    expect(fixture).toContain('今日は新しい単語を三つ覚えました。');
+    expect(fixture).toContain('Select a sentence, right-click, then choose Add vocab to Vela.');
+  });
+});

--- a/apps/vela-ext/tests/devWorkflow.test.ts
+++ b/apps/vela-ext/tests/devWorkflow.test.ts
@@ -30,9 +30,12 @@ describe('extension local testing workflow', () => {
     );
     expect(appPackage.scripts?.['dev:extension-test']).toBe('bun run dev');
     expect(apiPackage.scripts?.['dev:extension-test']).toBe('bun run dev');
-    expect(extensionPackage.scripts?.['dev:extension-test']).toBe(
-      'VITE_API_URL=http://localhost:9005/api VELA_EXT_TEST_MODE=1 wxt',
-    );
+    const extensionTestScript = extensionPackage.scripts?.['dev:extension-test'];
+    expect(extensionTestScript).toContain('http://localhost:9000');
+    expect(extensionTestScript).toContain('VELA_EXT_TEST_MODE=1');
+    expect(extensionTestScript).toContain('VITE_API_URL=http://localhost:9005/api');
+    expect(extensionTestScript).toContain('wxt');
+    expect(extensionTestScript).toContain('curl');
   });
 
   it('configures WXT to auto-launch Chrome only for extension test mode', () => {

--- a/apps/vela-ext/tests/popup/App.test.ts
+++ b/apps/vela-ext/tests/popup/App.test.ts
@@ -1,15 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushPromises, mount } from '@vue/test-utils';
 
-const { mockIsAuthenticated, mockImportWebappSession, mockClearAuthData } = vi.hoisted(() => ({
-  mockIsAuthenticated: vi.fn(),
-  mockImportWebappSession: vi.fn(),
-  mockClearAuthData: vi.fn(),
-}));
+const { mockIsAuthenticated, mockImportWebappSession, mockClearAuthData, mockIsExplicitSignout } =
+  vi.hoisted(() => ({
+    mockIsAuthenticated: vi.fn(),
+    mockImportWebappSession: vi.fn(),
+    mockClearAuthData: vi.fn(),
+    mockIsExplicitSignout: vi.fn(),
+  }));
 
 vi.mock('../../entrypoints/utils/storage', () => ({
   isAuthenticated: mockIsAuthenticated,
   clearAuthData: mockClearAuthData,
+  isExplicitSignout: mockIsExplicitSignout,
 }));
 
 vi.mock('../../entrypoints/utils/webappSession', () => ({
@@ -39,6 +42,7 @@ describe('popup App', () => {
     mockIsAuthenticated.mockReset();
     mockImportWebappSession.mockReset();
     mockClearAuthData.mockReset().mockResolvedValue(undefined);
+    mockIsExplicitSignout.mockReset().mockResolvedValue(false);
 
     (globalThis as any).browser = {
       runtime: {
@@ -141,5 +145,29 @@ describe('popup App', () => {
     );
 
     consoleSpy.mockRestore();
+  });
+
+  it('skips web-app auto-import when the user explicitly signed out', async () => {
+    mockIsAuthenticated.mockResolvedValue(false);
+    mockIsExplicitSignout.mockResolvedValue(true);
+
+    const wrapper = mount(App);
+    await flushPromises();
+
+    expect(mockImportWebappSession).not.toHaveBeenCalled();
+    expect(wrapper.find('[data-testid="login-page"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="dashboard-page"]').exists()).toBe(false);
+  });
+
+  it('attempts web-app auto-import when explicit signout flag is not set', async () => {
+    mockIsAuthenticated.mockResolvedValue(false);
+    mockIsExplicitSignout.mockResolvedValue(false);
+    mockImportWebappSession.mockResolvedValue(false);
+
+    const wrapper = mount(App);
+    await flushPromises();
+
+    expect(mockImportWebappSession).toHaveBeenCalledOnce();
+    expect(wrapper.find('[data-testid="login-page"]').exists()).toBe(true);
   });
 });

--- a/apps/vela-ext/tests/popup/App.test.ts
+++ b/apps/vela-ext/tests/popup/App.test.ts
@@ -1,13 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushPromises, mount } from '@vue/test-utils';
 
-const { mockIsAuthenticated, mockImportWebappSession } = vi.hoisted(() => ({
+const { mockIsAuthenticated, mockImportWebappSession, mockClearAuthData } = vi.hoisted(() => ({
   mockIsAuthenticated: vi.fn(),
   mockImportWebappSession: vi.fn(),
+  mockClearAuthData: vi.fn(),
 }));
 
 vi.mock('../../entrypoints/utils/storage', () => ({
   isAuthenticated: mockIsAuthenticated,
+  clearAuthData: mockClearAuthData,
 }));
 
 vi.mock('../../entrypoints/utils/webappSession', () => ({
@@ -36,6 +38,7 @@ describe('popup App', () => {
   beforeEach(() => {
     mockIsAuthenticated.mockReset();
     mockImportWebappSession.mockReset();
+    mockClearAuthData.mockReset().mockResolvedValue(undefined);
 
     (globalThis as any).browser = {
       runtime: {
@@ -113,9 +116,30 @@ describe('popup App', () => {
     await flushPromises();
 
     wrapper.findComponent({ name: 'DashboardPage' }).vm.$emit('sessionExpired');
-    await wrapper.vm.$nextTick();
+    await flushPromises();
 
     expect(wrapper.find('[data-testid="login-page"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="dashboard-page"]').exists()).toBe(false);
+    expect(mockClearAuthData).toHaveBeenCalledOnce();
+  });
+
+  it('logs error when clearAuthData fails during session expiry', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockIsAuthenticated.mockResolvedValue(true);
+    mockClearAuthData.mockRejectedValue(new Error('Storage corrupted'));
+
+    const wrapper = mount(App);
+    await flushPromises();
+
+    wrapper.findComponent({ name: 'DashboardPage' }).vm.$emit('sessionExpired');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="login-page"]').exists()).toBe(true);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[Vela] Failed to clear auth data on session expiry:',
+      expect.any(Error),
+    );
+
+    consoleSpy.mockRestore();
   });
 });

--- a/apps/vela-ext/tests/popup/App.test.ts
+++ b/apps/vela-ext/tests/popup/App.test.ts
@@ -25,7 +25,7 @@ vi.mock('../../entrypoints/popup/LoginPage.vue', () => ({
 vi.mock('../../entrypoints/popup/DashboardPage.vue', () => ({
   default: {
     name: 'DashboardPage',
-    emits: ['logout'],
+    emits: ['sessionExpired'],
     template: '<div data-testid="dashboard-page" />',
   },
 }));
@@ -104,5 +104,18 @@ describe('popup App', () => {
     expect(wrapper.find('.loading').exists()).toBe(false);
 
     consoleSpy.mockRestore();
+  });
+
+  it('returns to the redirect page when the dashboard reports an expired session', async () => {
+    mockIsAuthenticated.mockResolvedValue(true);
+
+    const wrapper = mount(App);
+    await flushPromises();
+
+    wrapper.findComponent({ name: 'DashboardPage' }).vm.$emit('sessionExpired');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-testid="login-page"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="dashboard-page"]').exists()).toBe(false);
   });
 });

--- a/apps/vela-ext/tests/popup/DashboardPage.test.ts
+++ b/apps/vela-ext/tests/popup/DashboardPage.test.ts
@@ -284,8 +284,8 @@ describe('DashboardPage', () => {
 
       expect(mockClearAuthData).toHaveBeenCalledOnce();
       expect(wrapper.emitted('sessionExpired')).toBeTruthy();
-      // setExplicitSignout should still be called even if clearAuthData fails
-      expect(mockSetExplicitSignout).not.toHaveBeenCalled();
+      // setExplicitSignout is always called regardless of clearAuthData outcome
+      expect(mockSetExplicitSignout).toHaveBeenCalledOnce();
       expect(consoleSpy).toHaveBeenCalledWith(
         '[Vela] Failed to clear auth data on sign out:',
         expect.any(Error),

--- a/apps/vela-ext/tests/popup/DashboardPage.test.ts
+++ b/apps/vela-ext/tests/popup/DashboardPage.test.ts
@@ -12,13 +12,19 @@ const { mockGetPendingQueueCount } = vi.hoisted(() => ({
   mockGetPendingQueueCount: vi.fn(),
 }));
 
-const { mockGetValidIdToken, mockRefreshIdToken, mockGetUserEmail, mockClearAllPending } =
-  vi.hoisted(() => ({
-    mockGetValidIdToken: vi.fn(),
-    mockRefreshIdToken: vi.fn(),
-    mockGetUserEmail: vi.fn(),
-    mockClearAllPending: vi.fn().mockResolvedValue(undefined),
-  }));
+const {
+  mockGetValidIdToken,
+  mockRefreshIdToken,
+  mockGetUserEmail,
+  mockClearAllPending,
+  mockClearAuthData,
+} = vi.hoisted(() => ({
+  mockGetValidIdToken: vi.fn(),
+  mockRefreshIdToken: vi.fn(),
+  mockGetUserEmail: vi.fn(),
+  mockClearAllPending: vi.fn().mockResolvedValue(undefined),
+  mockClearAuthData: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock('../../entrypoints/utils/api', () => ({
   getMyDictionaries: mockGetMyDictionaries,
@@ -32,6 +38,7 @@ vi.mock('../../entrypoints/utils/storage', () => ({
   getValidIdToken: mockGetValidIdToken,
   refreshIdToken: mockRefreshIdToken,
   getUserEmail: mockGetUserEmail,
+  clearAuthData: mockClearAuthData,
 }));
 
 vi.mock('../../entrypoints/utils/idb', () => ({
@@ -92,6 +99,7 @@ describe('DashboardPage', () => {
     mockGetUserEmail.mockClear();
     mockClearAllPending.mockClear();
     mockGetPendingQueueCount.mockClear();
+    mockClearAuthData.mockClear().mockResolvedValue(undefined);
 
     // Set up browser API mocks
     // Using 'as any' to assign mock implementation to the global browser object in the test environment.
@@ -244,12 +252,39 @@ describe('DashboardPage', () => {
   });
 
   describe('Session Actions', () => {
-    it('does not render a logout button in the extension popup', async () => {
+    it('renders a sign-out button that clears auth data and emits sessionExpired', async () => {
       wrapper = mount(DashboardPage);
       await flushPromises();
 
-      expect(wrapper.find('[title="Logout"]').exists()).toBe(false);
-      expect(mockClearAllPending).not.toHaveBeenCalled();
+      const signOutButton = wrapper.find('[title="Sign Out"]');
+      expect(signOutButton.exists()).toBe(true);
+
+      await signOutButton.trigger('click');
+      await flushPromises();
+
+      expect(mockClearAuthData).toHaveBeenCalledOnce();
+      expect(wrapper.emitted('sessionExpired')).toBeTruthy();
+    });
+
+    it('emits sessionExpired even if clearAuthData fails on sign-out', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockClearAuthData.mockRejectedValue(new Error('Storage corrupted'));
+
+      wrapper = mount(DashboardPage);
+      await flushPromises();
+
+      const signOutButton = wrapper.find('[title="Sign Out"]');
+      await signOutButton.trigger('click');
+      await flushPromises();
+
+      expect(mockClearAuthData).toHaveBeenCalledOnce();
+      expect(wrapper.emitted('sessionExpired')).toBeTruthy();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[Vela] Failed to clear auth data on sign out:',
+        expect.any(Error),
+      );
+
+      consoleSpy.mockRestore();
     });
   });
 

--- a/apps/vela-ext/tests/popup/DashboardPage.test.ts
+++ b/apps/vela-ext/tests/popup/DashboardPage.test.ts
@@ -12,19 +12,13 @@ const { mockGetPendingQueueCount } = vi.hoisted(() => ({
   mockGetPendingQueueCount: vi.fn(),
 }));
 
-const {
-  mockGetValidIdToken,
-  mockRefreshIdToken,
-  mockGetUserEmail,
-  mockClearAuthData,
-  mockClearAllPending,
-} = vi.hoisted(() => ({
-  mockGetValidIdToken: vi.fn(),
-  mockRefreshIdToken: vi.fn(),
-  mockGetUserEmail: vi.fn(),
-  mockClearAuthData: vi.fn(),
-  mockClearAllPending: vi.fn().mockResolvedValue(undefined),
-}));
+const { mockGetValidIdToken, mockRefreshIdToken, mockGetUserEmail, mockClearAllPending } =
+  vi.hoisted(() => ({
+    mockGetValidIdToken: vi.fn(),
+    mockRefreshIdToken: vi.fn(),
+    mockGetUserEmail: vi.fn(),
+    mockClearAllPending: vi.fn().mockResolvedValue(undefined),
+  }));
 
 vi.mock('../../entrypoints/utils/api', () => ({
   getMyDictionaries: mockGetMyDictionaries,
@@ -38,7 +32,6 @@ vi.mock('../../entrypoints/utils/storage', () => ({
   getValidIdToken: mockGetValidIdToken,
   refreshIdToken: mockRefreshIdToken,
   getUserEmail: mockGetUserEmail,
-  clearAuthData: mockClearAuthData,
 }));
 
 vi.mock('../../entrypoints/utils/idb', () => ({
@@ -97,7 +90,6 @@ describe('DashboardPage', () => {
     mockGetValidIdToken.mockClear();
     mockRefreshIdToken.mockClear();
     mockGetUserEmail.mockClear();
-    mockClearAuthData.mockClear();
     mockClearAllPending.mockClear();
     mockGetPendingQueueCount.mockClear();
 
@@ -251,30 +243,13 @@ describe('DashboardPage', () => {
     });
   });
 
-  describe('Logout Functionality', () => {
-    it('should call clearAuthData (but NOT clear pending queue) when logout button is clicked', async () => {
+  describe('Session Actions', () => {
+    it('does not render a logout button in the extension popup', async () => {
       wrapper = mount(DashboardPage);
       await flushPromises();
 
-      const logoutButton = wrapper.find('[title="Logout"]');
-      await logoutButton.trigger('click');
-      await flushPromises();
-
-      expect(mockClearAuthData).toHaveBeenCalled();
-      // Pending queue is NOT cleared on logout — flushQueue handles
-      // cross-account cleanup via userEmail ownership checks.
+      expect(wrapper.find('[title="Logout"]').exists()).toBe(false);
       expect(mockClearAllPending).not.toHaveBeenCalled();
-    });
-
-    it('should emit logout event when logout button is clicked', async () => {
-      wrapper = mount(DashboardPage);
-      await flushPromises();
-
-      const logoutButton = wrapper.find('[title="Logout"]');
-      await logoutButton.trigger('click');
-
-      expect(wrapper.emitted('logout')).toBeTruthy();
-      expect(wrapper.emitted('logout')?.length).toBe(1);
     });
   });
 
@@ -566,7 +541,7 @@ describe('DashboardPage', () => {
       expect(mockGetMyDictionaries).toHaveBeenCalledTimes(2);
     });
 
-    it('should logout user after 2 seconds when session expired', async () => {
+    it('reports an expired session after 2 seconds without clearing extension auth data directly', async () => {
       vi.useFakeTimers();
 
       try {
@@ -577,13 +552,11 @@ describe('DashboardPage', () => {
 
         expect(wrapper.find('.error-message').exists()).toBe(true);
 
-        // Fast-forward time by 2 seconds to trigger the logout timeout
+        // Fast-forward time by 2 seconds to trigger the expired-session transition
         await vi.advanceTimersByTimeAsync(2000);
 
-        expect(mockClearAuthData).toHaveBeenCalled();
-        // Pending queue should NOT be cleared on session-expiry auto-logout
         expect(mockClearAllPending).not.toHaveBeenCalled();
-        expect(wrapper.emitted('logout')).toBeTruthy();
+        expect(wrapper.emitted('sessionExpired')).toBeTruthy();
       } finally {
         vi.useRealTimers();
       }

--- a/apps/vela-ext/tests/popup/DashboardPage.test.ts
+++ b/apps/vela-ext/tests/popup/DashboardPage.test.ts
@@ -18,12 +18,14 @@ const {
   mockGetUserEmail,
   mockClearAllPending,
   mockClearAuthData,
+  mockSetExplicitSignout,
 } = vi.hoisted(() => ({
   mockGetValidIdToken: vi.fn(),
   mockRefreshIdToken: vi.fn(),
   mockGetUserEmail: vi.fn(),
   mockClearAllPending: vi.fn().mockResolvedValue(undefined),
   mockClearAuthData: vi.fn().mockResolvedValue(undefined),
+  mockSetExplicitSignout: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../../entrypoints/utils/api', () => ({
@@ -39,6 +41,7 @@ vi.mock('../../entrypoints/utils/storage', () => ({
   refreshIdToken: mockRefreshIdToken,
   getUserEmail: mockGetUserEmail,
   clearAuthData: mockClearAuthData,
+  setExplicitSignout: mockSetExplicitSignout,
 }));
 
 vi.mock('../../entrypoints/utils/idb', () => ({
@@ -100,6 +103,7 @@ describe('DashboardPage', () => {
     mockClearAllPending.mockClear();
     mockGetPendingQueueCount.mockClear();
     mockClearAuthData.mockClear().mockResolvedValue(undefined);
+    mockSetExplicitSignout.mockClear().mockResolvedValue(undefined);
 
     // Set up browser API mocks
     // Using 'as any' to assign mock implementation to the global browser object in the test environment.
@@ -263,6 +267,7 @@ describe('DashboardPage', () => {
       await flushPromises();
 
       expect(mockClearAuthData).toHaveBeenCalledOnce();
+      expect(mockSetExplicitSignout).toHaveBeenCalledOnce();
       expect(wrapper.emitted('sessionExpired')).toBeTruthy();
     });
 
@@ -279,6 +284,8 @@ describe('DashboardPage', () => {
 
       expect(mockClearAuthData).toHaveBeenCalledOnce();
       expect(wrapper.emitted('sessionExpired')).toBeTruthy();
+      // setExplicitSignout should still be called even if clearAuthData fails
+      expect(mockSetExplicitSignout).not.toHaveBeenCalled();
       expect(consoleSpy).toHaveBeenCalledWith(
         '[Vela] Failed to clear auth data on sign out:',
         expect.any(Error),

--- a/apps/vela-ext/tests/popup/LoginPage.test.ts
+++ b/apps/vela-ext/tests/popup/LoginPage.test.ts
@@ -15,6 +15,14 @@ vi.mock('../../entrypoints/utils/webappSession', () => ({
   getWebappLoginUrl: mockGetWebappLoginUrl,
 }));
 
+const { mockClearExplicitSignout } = vi.hoisted(() => ({
+  mockClearExplicitSignout: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../entrypoints/utils/storage', () => ({
+  clearExplicitSignout: mockClearExplicitSignout,
+}));
+
 const storageState: Record<string, unknown> = {};
 
 function setupBrowserMocks() {
@@ -46,6 +54,7 @@ describe('LoginPage', () => {
     mockImportWebappSession.mockReset();
     mockOpenWebappLogin.mockReset();
     mockGetWebappLoginUrl.mockReset().mockReturnValue('https://vela.cwchanap.dev/auth/login');
+    mockClearExplicitSignout.mockClear().mockResolvedValue(undefined);
     setupBrowserMocks();
   });
 
@@ -144,7 +153,19 @@ describe('LoginPage', () => {
       await flushPromises();
 
       expect(mockImportWebappSession).toHaveBeenCalledOnce();
+      expect(mockClearExplicitSignout).toHaveBeenCalledOnce();
       expect(wrapper.emitted('loginSuccess')).toBeTruthy();
+    });
+
+    it('does not clear explicit signout flag when import fails', async () => {
+      mockImportWebappSession.mockResolvedValue(false);
+      wrapper = mount(LoginPage);
+      await flushPromises();
+
+      await wrapper.find('.web-session-button').trigger('click');
+      await flushPromises();
+
+      expect(mockClearExplicitSignout).not.toHaveBeenCalled();
     });
 
     it('shows a readable message when no web-app session can be imported', async () => {

--- a/apps/vela-ext/tests/popup/LoginPage.test.ts
+++ b/apps/vela-ext/tests/popup/LoginPage.test.ts
@@ -3,26 +3,16 @@ import { mount, flushPromises, VueWrapper } from '@vue/test-utils';
 import type { ComponentPublicInstance } from 'vue';
 import LoginPage from '../../entrypoints/popup/LoginPage.vue';
 
-const { mockSignIn, mockSaveAuthTokens, mockImportWebappSession, mockOpenWebappLogin } = vi.hoisted(
-  () => ({
-    mockSignIn: vi.fn(),
-    mockSaveAuthTokens: vi.fn(),
-    mockImportWebappSession: vi.fn(),
-    mockOpenWebappLogin: vi.fn(),
-  }),
-);
-
-vi.mock('../../entrypoints/utils/api', () => ({
-  signIn: mockSignIn,
-}));
-
-vi.mock('../../entrypoints/utils/storage', () => ({
-  saveAuthTokens: mockSaveAuthTokens,
+const { mockImportWebappSession, mockOpenWebappLogin, mockGetWebappLoginUrl } = vi.hoisted(() => ({
+  mockImportWebappSession: vi.fn(),
+  mockOpenWebappLogin: vi.fn(),
+  mockGetWebappLoginUrl: vi.fn(),
 }));
 
 vi.mock('../../entrypoints/utils/webappSession', () => ({
   importWebappSession: mockImportWebappSession,
   openWebappLogin: mockOpenWebappLogin,
+  getWebappLoginUrl: mockGetWebappLoginUrl,
 }));
 
 const storageState: Record<string, unknown> = {};
@@ -53,10 +43,9 @@ describe('LoginPage', () => {
 
   beforeEach(() => {
     Object.keys(storageState).forEach((k) => delete storageState[k]);
-    mockSignIn.mockReset();
-    mockSaveAuthTokens.mockReset();
     mockImportWebappSession.mockReset();
     mockOpenWebappLogin.mockReset();
+    mockGetWebappLoginUrl.mockReset().mockReturnValue('https://vela.cwchanap.dev/auth/login');
     setupBrowserMocks();
   });
 
@@ -68,35 +57,19 @@ describe('LoginPage', () => {
   });
 
   describe('rendering', () => {
-    it('renders the login form', () => {
+    it('renders a web-app login redirect URL instead of an extension credential form', () => {
       wrapper = mount(LoginPage);
-      expect(wrapper.find('form').exists()).toBe(true);
-      expect(wrapper.find('#email').exists()).toBe(true);
-      expect(wrapper.find('#password').exists()).toBe(true);
-      expect(wrapper.find('button[type="submit"]').exists()).toBe(true);
-    });
 
-    it('shows "Sign In" text on submit button by default', () => {
-      wrapper = mount(LoginPage);
-      expect(wrapper.find('button[type="submit"]').text()).toBe('Sign In');
+      expect(wrapper.text()).toContain('https://vela.cwchanap.dev/auth/login');
+      expect(wrapper.find('form').exists()).toBe(false);
+      expect(wrapper.find('#email').exists()).toBe(false);
+      expect(wrapper.find('#password').exists()).toBe(false);
+      expect(wrapper.find('button[type="submit"]').exists()).toBe(false);
     });
 
     it('renders the page title', () => {
       wrapper = mount(LoginPage);
-      expect(wrapper.text()).toContain('Vela Login');
-    });
-
-    it('marks credentials fields for browser and password-manager autofill', () => {
-      wrapper = mount(LoginPage);
-
-      expect(wrapper.find('#email').attributes()).toMatchObject({
-        name: 'username',
-        autocomplete: 'username',
-      });
-      expect(wrapper.find('#password').attributes()).toMatchObject({
-        name: 'password',
-        autocomplete: 'current-password',
-      });
+      expect(wrapper.text()).toContain('Sign in on Vela');
     });
 
     it('does not show error message initially', () => {
@@ -129,17 +102,6 @@ describe('LoginPage', () => {
       expect(wrapper.find('.login-container').classes()).toContain('dark');
     });
 
-    it('toggles back to light mode on second click', async () => {
-      wrapper = mount(LoginPage);
-      await flushPromises();
-
-      const themeBtn = wrapper.find('.theme-toggle');
-      await themeBtn.trigger('click');
-      await themeBtn.trigger('click');
-
-      expect(wrapper.find('.login-container').classes()).not.toContain('dark');
-    });
-
     it('persists theme preference to storage on change', async () => {
       wrapper = mount(LoginPage);
       await flushPromises();
@@ -149,188 +111,20 @@ describe('LoginPage', () => {
 
       expect(browser.storage.local.set).toHaveBeenCalledWith({ theme_preference: 'dark' });
     });
-
-    it('shows moon emoji in light mode', async () => {
-      wrapper = mount(LoginPage);
-      await flushPromises();
-      expect(wrapper.find('.theme-toggle').text()).toBe('🌙');
-    });
-
-    it('shows sun emoji in dark mode', async () => {
-      wrapper = mount(LoginPage);
-      await flushPromises();
-
-      await wrapper.find('.theme-toggle').trigger('click');
-
-      expect(wrapper.find('.theme-toggle').text()).toBe('☀️');
-    });
   });
 
-  describe('form submission', () => {
-    const mockTokens = { accessToken: 'acc', refreshToken: 'ref', idToken: 'id' };
-
-    it('calls signIn with email and password on submit', async () => {
-      mockSignIn.mockResolvedValue(mockTokens);
+  describe('web-app session actions', () => {
+    it('opens the web-app login URL when requested', async () => {
       wrapper = mount(LoginPage);
       await flushPromises();
 
-      await wrapper.find('#email').setValue('user@example.com');
-      await wrapper.find('#password').setValue('password123');
-      await wrapper.find('form').trigger('submit');
+      await wrapper.find('.open-webapp-button').trigger('click');
       await flushPromises();
 
-      expect(mockSignIn).toHaveBeenCalledWith('user@example.com', 'password123');
+      expect(mockOpenWebappLogin).toHaveBeenCalledOnce();
     });
 
-    it('saves tokens and emits loginSuccess on successful login', async () => {
-      mockSignIn.mockResolvedValue(mockTokens);
-      mockSaveAuthTokens.mockResolvedValue(undefined);
-      wrapper = mount(LoginPage);
-      await flushPromises();
-
-      await wrapper.find('#email').setValue('user@example.com');
-      await wrapper.find('#password').setValue('pass');
-      await wrapper.find('form').trigger('submit');
-      await flushPromises();
-
-      expect(mockSaveAuthTokens).toHaveBeenCalledWith(mockTokens, 'user@example.com');
-      expect(wrapper.emitted('loginSuccess')).toBeTruthy();
-    });
-
-    it('shows error message when signIn throws', async () => {
-      mockSignIn.mockRejectedValue(new Error('Invalid credentials'));
-      wrapper = mount(LoginPage);
-      await flushPromises();
-
-      await wrapper.find('#email').setValue('user@example.com');
-      await wrapper.find('#password').setValue('wrong');
-      await wrapper.find('form').trigger('submit');
-      await flushPromises();
-
-      expect(wrapper.find('.error-message').exists()).toBe(true);
-      expect(wrapper.find('.error-message').text()).toBe('Invalid credentials');
-    });
-
-    it('shows generic error when non-Error is thrown', async () => {
-      mockSignIn.mockRejectedValue('unexpected');
-      wrapper = mount(LoginPage);
-      await flushPromises();
-
-      await wrapper.find('#email').setValue('user@example.com');
-      await wrapper.find('#password').setValue('pass');
-      await wrapper.find('form').trigger('submit');
-      await flushPromises();
-
-      expect(wrapper.find('.error-message').text()).toBe('Login failed');
-    });
-
-    it('shows loading state during sign in', async () => {
-      let resolve: (_value: any) => void;
-      const promise = new Promise((res) => {
-        resolve = res;
-      });
-      mockSignIn.mockReturnValue(promise);
-      wrapper = mount(LoginPage);
-      await flushPromises();
-
-      await wrapper.find('#email').setValue('user@example.com');
-      await wrapper.find('#password').setValue('pass');
-
-      const submitBtn = wrapper.find('button[type="submit"]');
-      await wrapper.find('form').trigger('submit');
-      await wrapper.vm.$nextTick();
-
-      expect(submitBtn.text()).toBe('Signing in...');
-      expect(submitBtn.attributes('disabled')).toBeDefined();
-
-      resolve!(mockTokens);
-      await flushPromises();
-    });
-
-    it('disables inputs during loading', async () => {
-      let resolve: (_value: any) => void;
-      const promise = new Promise((res) => {
-        resolve = res;
-      });
-      mockSignIn.mockReturnValue(promise);
-      wrapper = mount(LoginPage);
-      await flushPromises();
-
-      await wrapper.find('#email').setValue('user@example.com');
-      await wrapper.find('#password').setValue('pass');
-
-      await wrapper.find('form').trigger('submit');
-      await wrapper.vm.$nextTick();
-
-      expect(wrapper.find('#email').attributes('disabled')).toBeDefined();
-      expect(wrapper.find('#password').attributes('disabled')).toBeDefined();
-
-      resolve!(mockTokens);
-      await flushPromises();
-    });
-
-    it('re-enables submit button after failed login', async () => {
-      mockSignIn.mockRejectedValue(new Error('Failed'));
-      wrapper = mount(LoginPage);
-      await flushPromises();
-
-      await wrapper.find('#email').setValue('user@example.com');
-      await wrapper.find('#password').setValue('pass');
-      await wrapper.find('form').trigger('submit');
-      await flushPromises();
-
-      const submitBtn = wrapper.find('button[type="submit"]');
-      expect(submitBtn.text()).toBe('Sign In');
-      expect(submitBtn.attributes('disabled')).toBeUndefined();
-    });
-
-    it('shows validation error when email is empty', async () => {
-      wrapper = mount(LoginPage);
-      await flushPromises();
-
-      await wrapper.find('#password').setValue('pass');
-      await wrapper.find('form').trigger('submit');
-      await flushPromises();
-
-      expect(wrapper.find('.error-message').exists()).toBe(true);
-      expect(wrapper.find('.error-message').text()).toContain('email and password');
-      expect(mockSignIn).not.toHaveBeenCalled();
-    });
-
-    it('shows validation error when password is empty', async () => {
-      wrapper = mount(LoginPage);
-      await flushPromises();
-
-      await wrapper.find('#email').setValue('user@example.com');
-      await wrapper.find('form').trigger('submit');
-      await flushPromises();
-
-      expect(wrapper.find('.error-message').exists()).toBe(true);
-      expect(wrapper.find('.error-message').text()).toContain('email and password');
-      expect(mockSignIn).not.toHaveBeenCalled();
-    });
-
-    it('does not prevent native paste events on credential inputs', async () => {
-      wrapper = mount(LoginPage);
-      await flushPromises();
-
-      const preventEmailPaste = vi.fn();
-      const preventPasswordPaste = vi.fn();
-
-      await wrapper.find('#email').trigger('paste', {
-        clipboardData: { getData: () => 'pasted@example.com' },
-        preventDefault: preventEmailPaste,
-      });
-      await wrapper.find('#password').trigger('paste', {
-        clipboardData: { getData: () => 'pasted-password' },
-        preventDefault: preventPasswordPaste,
-      });
-
-      expect(preventEmailPaste).not.toHaveBeenCalled();
-      expect(preventPasswordPaste).not.toHaveBeenCalled();
-    });
-
-    it('imports the web-app session when the user clicks use web app session', async () => {
+    it('imports the web-app session when the user has signed in there', async () => {
       mockImportWebappSession.mockResolvedValue(true);
       wrapper = mount(LoginPage);
       await flushPromises();
@@ -350,8 +144,29 @@ describe('LoginPage', () => {
       await wrapper.find('.web-session-button').trigger('click');
       await flushPromises();
 
-      expect(wrapper.find('.error-message').text()).toContain('Open Vela in a browser tab');
+      expect(wrapper.find('.error-message').text()).toContain('Sign in at the URL above');
       expect(wrapper.emitted('loginSuccess')).toBeUndefined();
+    });
+
+    it('shows refresh loading state while checking for the web-app session', async () => {
+      let resolve: (_value: boolean) => void = () => {};
+      mockImportWebappSession.mockReturnValue(
+        new Promise<boolean>((promiseResolve) => {
+          resolve = promiseResolve;
+        }),
+      );
+      wrapper = mount(LoginPage);
+      await flushPromises();
+
+      const importButton = wrapper.find('.web-session-button');
+      await importButton.trigger('click');
+      await wrapper.vm.$nextTick();
+
+      expect(importButton.text()).toBe('Checking...');
+      expect(importButton.attributes('disabled')).toBeDefined();
+
+      resolve(true);
+      await flushPromises();
     });
   });
 });

--- a/apps/vela-ext/tests/popup/LoginPage.test.ts
+++ b/apps/vela-ext/tests/popup/LoginPage.test.ts
@@ -124,6 +124,17 @@ describe('LoginPage', () => {
       expect(mockOpenWebappLogin).toHaveBeenCalledOnce();
     });
 
+    it('shows error when opening webapp login fails', async () => {
+      mockOpenWebappLogin.mockRejectedValue(new Error('tabs.create failed'));
+      wrapper = mount(LoginPage);
+      await flushPromises();
+
+      await wrapper.find('.open-webapp-button').trigger('click');
+      await flushPromises();
+
+      expect(wrapper.find('.error-message').text()).toBe('tabs.create failed');
+    });
+
     it('imports the web-app session when the user has signed in there', async () => {
       mockImportWebappSession.mockResolvedValue(true);
       wrapper = mount(LoginPage);

--- a/apps/vela-ext/tests/test-setup.ts
+++ b/apps/vela-ext/tests/test-setup.ts
@@ -27,6 +27,7 @@ vi.stubGlobal('browser', {
   },
   contextMenus: {
     create: vi.fn(),
+    removeAll: vi.fn(async () => undefined),
     onClicked: {
       addListener: vi.fn(),
     },

--- a/apps/vela-ext/tests/utils/api.test.ts
+++ b/apps/vela-ext/tests/utils/api.test.ts
@@ -1,6 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  signIn,
   checkSession,
   refreshToken,
   saveDictionaryEntry,
@@ -23,86 +22,12 @@ function mockJsonResponse(data: unknown, status = 200) {
   };
 }
 
-function mockHtmlErrorResponse(status = 502) {
-  return {
-    ok: false,
-    status,
-    headers: {
-      get: vi.fn((name: string) => (name.toLowerCase() === 'content-type' ? 'text/html' : null)),
-    },
-    text: vi.fn().mockResolvedValue('<!doctype html><title>Bad Gateway</title>'),
-    json: vi.fn().mockRejectedValue(new SyntaxError('Unexpected token < in JSON')),
-  };
-}
-
 beforeEach(() => {
   mockFetch.mockReset();
 });
 
 afterAll(() => {
   vi.unstubAllGlobals();
-});
-
-describe('signIn', () => {
-  it('returns tokens on successful sign in', async () => {
-    const tokens = { accessToken: 'access', refreshToken: 'refresh', idToken: 'id' };
-    mockFetch.mockResolvedValue(mockJsonResponse({ tokens }));
-
-    const result = await signIn('user@example.com', 'password123');
-
-    expect(result).toEqual(tokens);
-    expect(mockFetch).toHaveBeenCalledOnce();
-    const [url, options] = mockFetch.mock.calls[0];
-    expect(url).toContain('/auth/signin');
-    expect(options.method).toBe('POST');
-    expect(JSON.parse(options.body)).toEqual({
-      email: 'user@example.com',
-      password: 'password123',
-    });
-  });
-
-  it('throws an error with message from response when sign in fails', async () => {
-    mockFetch.mockResolvedValue(mockJsonResponse({ error: 'Invalid credentials' }, 401));
-
-    await expect(signIn('bad@example.com', 'wrong')).rejects.toThrow('Invalid credentials');
-  });
-
-  it('throws generic error with status when response has no error field', async () => {
-    mockFetch.mockResolvedValue(mockJsonResponse({}, 500));
-
-    await expect(signIn('user@example.com', 'pass')).rejects.toThrow('Sign in failed (HTTP 500)');
-  });
-
-  it('throws a readable error when the sign in endpoint returns non-JSON HTML', async () => {
-    mockFetch.mockResolvedValue(mockHtmlErrorResponse(502));
-
-    await expect(signIn('user@example.com', 'pass')).rejects.toThrow('Sign in failed (HTTP 502)');
-  });
-
-  it('throws a readable error when a successful sign in response is not JSON', async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      status: 200,
-      headers: {
-        get: vi.fn((name: string) => (name.toLowerCase() === 'content-type' ? 'text/html' : null)),
-      },
-      json: vi.fn().mockRejectedValue(new SyntaxError('Unexpected token < in JSON')),
-    });
-
-    await expect(signIn('user@example.com', 'pass')).rejects.toThrow(
-      'Sign in failed: invalid response from server',
-    );
-  });
-
-  it('sends Content-Type: application/json header', async () => {
-    const tokens = { accessToken: 'a', refreshToken: 'r', idToken: 'i' };
-    mockFetch.mockResolvedValue(mockJsonResponse({ tokens }));
-
-    await signIn('user@example.com', 'pass');
-
-    const [, options] = mockFetch.mock.calls[0];
-    expect(options.headers['Content-Type']).toBe('application/json');
-  });
 });
 
 describe('checkSession', () => {

--- a/apps/vela-ext/tests/utils/storage.test.ts
+++ b/apps/vela-ext/tests/utils/storage.test.ts
@@ -6,6 +6,9 @@ import {
   clearAuthData,
   getValidAccessToken,
   refreshAccessToken,
+  setExplicitSignout,
+  isExplicitSignout,
+  clearExplicitSignout,
 } from '../../entrypoints/utils/storage';
 import type { AuthTokens } from '../../entrypoints/utils/api';
 
@@ -123,5 +126,28 @@ describe('storage utils', () => {
       idToken: 'refresh-token-id',
     });
     expect(mockRefreshToken).toHaveBeenCalledWith('refresh-token');
+  });
+
+  describe('explicit signout flag', () => {
+    it('is false by default', async () => {
+      await expect(isExplicitSignout()).resolves.toBe(false);
+    });
+
+    it('is true after setExplicitSignout is called', async () => {
+      await setExplicitSignout();
+      await expect(isExplicitSignout()).resolves.toBe(true);
+    });
+
+    it('is false after clearExplicitSignout is called', async () => {
+      await setExplicitSignout();
+      await clearExplicitSignout();
+      await expect(isExplicitSignout()).resolves.toBe(false);
+    });
+
+    it('is not affected by clearAuthData', async () => {
+      await setExplicitSignout();
+      await clearAuthData();
+      await expect(isExplicitSignout()).resolves.toBe(true);
+    });
   });
 });

--- a/apps/vela-ext/tests/utils/webappSession.test.ts
+++ b/apps/vela-ext/tests/utils/webappSession.test.ts
@@ -17,6 +17,7 @@ vi.mock('../../entrypoints/utils/storage', () => ({
 }));
 
 import {
+  getWebappLoginUrl,
   importWebappSession,
   readCognitoSessionFromStorage,
 } from '../../entrypoints/utils/webappSession';
@@ -64,6 +65,12 @@ describe('readCognitoSessionFromStorage', () => {
     });
 
     expect(readCognitoSessionFromStorage(storage)).toBeNull();
+  });
+});
+
+describe('getWebappLoginUrl', () => {
+  it('returns the web-app auth redirect URL for unauthenticated extension users', () => {
+    expect(getWebappLoginUrl()).toBe('https://vela.cwchanap.dev/auth/login');
   });
 });
 

--- a/apps/vela-ext/wxt.config.ts
+++ b/apps/vela-ext/wxt.config.ts
@@ -1,10 +1,18 @@
 import { defineConfig } from 'wxt';
 
+const isExtensionTestMode = process.env.VELA_EXT_TEST_MODE === '1';
+
 // See https://wxt.dev/api/config.html
 export default defineConfig({
   modules: ['@wxt-dev/module-vue'],
-  runner: {
-    disabled: true, // Don't automatically open browser on dev server start
+  webExt: {
+    disabled: !isExtensionTestMode,
+    startUrls: ['http://localhost:9000/auth/login', 'http://localhost:9000/extension-test.html'],
+    chromiumArgs: [
+      '--user-data-dir=.wxt/chrome-data',
+      '--remote-debugging-port=9222',
+      '--window-size=1280,900',
+    ],
   },
   manifest: {
     name: 'Vela Japanese Dictionary',

--- a/apps/vela/package.json
+++ b/apps/vela/package.json
@@ -18,6 +18,7 @@
     "test:debug": "playwright test --debug",
     "test:report": "playwright show-report",
     "dev": "quasar dev",
+    "dev:extension-test": "bun run dev",
     "build": "quasar build",
     "postinstall": "quasar prepare"
   },

--- a/apps/vela/public/extension-test.html
+++ b/apps/vela/public/extension-test.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vela Extension Test Fixture</title>
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        color: #1f2933;
+        background: #f6f8fb;
+      }
+
+      main {
+        max-width: 760px;
+        margin: 0 auto;
+        padding: 48px 24px;
+      }
+
+      h1 {
+        margin: 0 0 12px;
+        font-size: 28px;
+      }
+
+      .hint {
+        margin: 0 0 28px;
+        color: #52606d;
+      }
+
+      .sample {
+        padding: 20px;
+        border: 1px solid #d9e2ec;
+        border-radius: 8px;
+        background: #ffffff;
+        font-size: 18px;
+        line-height: 1.8;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Vela Extension Test Fixture</h1>
+      <p class="hint">Select a sentence, right-click, then choose Add vocab to Vela.</p>
+      <div class="sample">
+        <p>今日は新しい単語を三つ覚えました。</p>
+        <p>明日の朝、図書館で日本語の本を読みます。</p>
+        <p>この文章は拡張機能の保存テストに使います。</p>
+      </div>
+    </main>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "turbo build",
     "dev": "turbo dev --parallel",
+    "dev:extension-test": "turbo run dev:extension-test --parallel --filter=./apps/vela --filter=./apps/vela-api --filter=./apps/vela-ext",
     "dev:vela-ext": "turbo run dev --filter=./apps/vela-ext",
     "build:vela-ext": "turbo run build --filter=./apps/vela-ext",
     "zip:vela-ext": "turbo run zip --filter=./apps/vela-ext",

--- a/turbo.json
+++ b/turbo.json
@@ -14,6 +14,10 @@
       "cache": false,
       "persistent": true
     },
+    "dev:extension-test": {
+      "cache": false,
+      "persistent": true
+    },
     "lint": {
       "dependsOn": ["^lint"]
     },


### PR DESCRIPTION
## Summary

- **Remove email/password login form** from the extension popup and replace it with a web-app session import flow — users sign in on the Vela web app and the extension imports the active session cookies/tokens
- **Add `registerContextMenus()` helper** that runs on both `onInstalled` and background script start, ensuring context menus are reliably created without duplication
- **Rename context menu item** from "Save to My Dictionaries" to "Add vocab to Vela"
- **Add `dev:extension-test` monorepo script** that starts the Vela app, API, and WXT extension runner together with a persistent Chrome profile for local testing
- **Update all tests** to reflect the new session-import login flow, remove credential-based test cases, and add coverage for `registerContextMenus` and `getWebappLoginUrl`

## Changes

- `apps/vela-ext/entrypoints/popup/LoginPage.vue` — replaced credential form with web-app redirect UI
- `apps/vela-ext/entrypoints/popup/DashboardPage.vue` — removed logout button, added `isAuthenticationError` helper, emits `sessionExpired` instead of `logout`
- `apps/vela-ext/entrypoints/popup/App.vue` — wired `sessionExpired` event
- `apps/vela-ext/entrypoints/background.ts` — extracted `registerContextMenus()`, renamed menu IDs
- `apps/vela-ext/entrypoints/utils/api.ts` — removed `signIn()` function
- `apps/vela-ext/entrypoints/utils/webappSession.ts` — added `getWebappLoginUrl()` export
- `apps/vela-ext/wxt.config.ts` — added WXT runner config for extension test mode
- `package.json`, `turbo.json`, `apps/vela/package.json`, `apps/vela-api/package.json` — added `dev:extension-test` script
- All test files updated accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Switch extension sign-in to import an active Vela web-app session.
  * Right-click action renamed to "Add vocab to Vela".
  * Popup now distinguishes explicit sign-out and session-expiry flows.

* **Bug Fixes**
  * More reliable session-expiration detection and recovery with clearer error handling.
  * Prevent duplicate context-menu registrations.

* **Documentation**
  * Updated setup/development and usage instructions to reflect new session workflow.

* **Chores**
  * Improved local extension dev/test workflow and fixtures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cwchanap/Vela/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->