### PR TITLE
feat(ui): refresh auth and extension popup with wa-modern design system

### DIFF
--- a/apps/vela-ext/entrypoints/popup/App.vue
+++ b/apps/vela-ext/entrypoints/popup/App.vue
@@ -47,11 +47,12 @@ async function handleSessionExpired() {
 </script>
 
 <template>
-  <div v-if="loading" class="vela-loading">
+  <div v-if="loading" class="vela-loading" role="status" aria-label="Loading Vela">
     <div class="loading-blob" aria-hidden="true"></div>
     <div class="loading-stack">
       <span class="loading-mark" aria-hidden="true">辞</span>
       <span class="loading-label">Vela</span>
+      <span class="sr-only">Loading…</span>
       <span class="loading-bar" aria-hidden="true">
         <span class="loading-bar-fill"></span>
       </span>
@@ -151,5 +152,17 @@ async function handleSessionExpired() {
   100% {
     transform: translateX(350%);
   }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 </style>

--- a/apps/vela-ext/entrypoints/popup/App.vue
+++ b/apps/vela-ext/entrypoints/popup/App.vue
@@ -16,7 +16,6 @@ onMounted(async () => {
       if (!signedOut) {
         authenticated.value = await importWebappSession();
         if (authenticated.value) {
-          // Notify the background script so it can flush any queued offline saves.
           browser.runtime.sendMessage({ type: 'LOGIN_SUCCESS' }).catch(() => {
             // Background may not be listening during tests or development reloads.
           });
@@ -32,7 +31,6 @@ onMounted(async () => {
 
 function handleLoginSuccess() {
   authenticated.value = true;
-  // Notify the background script so it can flush any queued offline saves.
   browser.runtime.sendMessage({ type: 'LOGIN_SUCCESS' }).catch(() => {
     // Ignore — background may not be listening (e.g. during development).
   });
@@ -49,21 +47,109 @@ async function handleSessionExpired() {
 </script>
 
 <template>
-  <div v-if="loading" class="loading">Loading...</div>
+  <div v-if="loading" class="vela-loading">
+    <div class="loading-blob" aria-hidden="true"></div>
+    <div class="loading-stack">
+      <span class="loading-mark" aria-hidden="true">辞</span>
+      <span class="loading-label">Vela</span>
+      <span class="loading-bar" aria-hidden="true">
+        <span class="loading-bar-fill"></span>
+      </span>
+    </div>
+  </div>
   <LoginPage v-else-if="!authenticated" @login-success="handleLoginSuccess" />
   <DashboardPage v-else @session-expired="handleSessionExpired" />
 </template>
 
 <style scoped>
-.loading {
+.vela-loading {
+  position: relative;
   width: 400px;
-  height: 100%;
+  height: 500px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-family:
-    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  color: #a0a0a0;
-  background-color: #1e1e1e;
+  background:
+    radial-gradient(circle at 50% 40%, rgba(123, 97, 255, 0.22), transparent 60%), var(--bg-page);
+  overflow: hidden;
+  color: var(--text-primary);
+}
+
+.loading-blob {
+  position: absolute;
+  width: 280px;
+  height: 280px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  filter: blur(80px);
+  opacity: 0.35;
+  animation: vela-blob-drift 10s ease-in-out infinite;
+}
+
+.loading-stack {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.loading-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-sakura) 130%);
+  color: white;
+  font-family: var(--font-jp);
+  font-weight: 700;
+  font-size: 1.6rem;
+  box-shadow: 0 8px 24px rgba(123, 97, 255, 0.45);
+  animation: vela-pulse 1.6s ease-in-out infinite;
+}
+
+.loading-label {
+  font-family: var(--font-display);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.36em;
+  text-transform: uppercase;
+  color: var(--color-primary-soft);
+}
+
+.loading-bar {
+  width: 120px;
+  height: 3px;
+  border-radius: 3px;
+  background: rgba(123, 97, 255, 0.16);
+  overflow: hidden;
+  position: relative;
+}
+
+.loading-bar-fill {
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--color-primary),
+    var(--color-sakura),
+    transparent
+  );
+  border-radius: 3px;
+  animation: loading-slide 1.3s ease-in-out infinite;
+}
+
+@keyframes loading-slide {
+  0% {
+    transform: translateX(-150%);
+  }
+  100% {
+    transform: translateX(350%);
+  }
 }
 </style>

--- a/apps/vela-ext/entrypoints/popup/DashboardPage.vue
+++ b/apps/vela-ext/entrypoints/popup/DashboardPage.vue
@@ -112,6 +112,7 @@
                 v-if="item.source_url"
                 :href="item.source_url"
                 target="_blank"
+                rel="noopener noreferrer"
                 class="source-link"
                 title="Open source"
                 aria-label="Open source page"
@@ -135,7 +136,9 @@
             </div>
             <div v-if="item.source_url" class="entry-source">
               <span class="source-label">Source</span>
-              <a :href="item.source_url" target="_blank">{{ item.source_url }}</a>
+              <a :href="item.source_url" target="_blank" rel="noopener noreferrer">{{
+                item.source_url
+              }}</a>
             </div>
             <div class="entry-meta">
               <span class="entry-date">{{ formatDate(item.created_at) }}</span>

--- a/apps/vela-ext/entrypoints/popup/DashboardPage.vue
+++ b/apps/vela-ext/entrypoints/popup/DashboardPage.vue
@@ -23,6 +23,8 @@
         <button
           type="button"
           class="instructions-header"
+          :aria-expanded="instructionsExpanded"
+          aria-controls="instructions-panel"
           @click="instructionsExpanded = !instructionsExpanded"
         >
           <span class="instructions-kanji" aria-hidden="true">選</span>
@@ -45,7 +47,13 @@
             </svg>
           </span>
         </button>
-        <ol v-show="instructionsExpanded" class="instructions-list">
+        <ol
+          id="instructions-panel"
+          v-show="instructionsExpanded"
+          class="instructions-list"
+          role="region"
+          aria-label="Instructions"
+        >
           <li><span class="step-num">1</span>Select any text on a webpage</li>
           <li><span class="step-num">2</span>Right-click to open the context menu</li>
           <li><span class="step-num">3</span>Click <em>"Add vocab to Vela"</em></li>

--- a/apps/vela-ext/entrypoints/popup/DashboardPage.vue
+++ b/apps/vela-ext/entrypoints/popup/DashboardPage.vue
@@ -12,8 +12,8 @@
           <span class="brand-sub">Dictionary</span>
         </div>
       </div>
-      <div v-if="userEmail" class="header-actions">
-        <div class="user-pill" :title="userEmail">
+      <div class="header-actions">
+        <div v-if="userEmail" class="user-pill" :title="userEmail">
           <span class="user-dot"></span>
           <span class="user-email">{{ userEmail }}</span>
         </div>

--- a/apps/vela-ext/entrypoints/popup/DashboardPage.vue
+++ b/apps/vela-ext/entrypoints/popup/DashboardPage.vue
@@ -1,104 +1,156 @@
 <template>
-  <div class="dashboard-container" :class="{ dark: isDarkMode }">
-    <div class="dashboard-card">
-      <div class="dashboard-header">
-        <div class="header-top">
-          <h2>Vela Dictionary</h2>
-          <div class="header-actions">
-            <button @click="handleSignOut" class="icon-button" title="Sign Out">🚪</button>
-            <button
-              @click="toggleTheme"
-              class="icon-button"
-              :title="isDarkMode ? 'Switch to Light Mode' : 'Switch to Dark Mode'"
-            >
-              {{ isDarkMode ? '☀️' : '🌙' }}
-            </button>
-          </div>
-        </div>
-        <p>Logged in as: {{ userEmail }}</p>
-      </div>
-
-      <div class="dashboard-content">
-        <div class="instructions">
-          <div class="instructions-header" @click="instructionsExpanded = !instructionsExpanded">
-            <h3>How to save entries</h3>
-            <button class="collapse-icon" type="button">
-              {{ instructionsExpanded ? '▼' : '▶' }}
-            </button>
-          </div>
-          <ol v-show="instructionsExpanded">
-            <li>Select any text on a webpage</li>
-            <li>Right-click to open the context menu</li>
-            <li>Click "Add vocab to Vela"</li>
-          </ol>
-        </div>
-
-        <div class="my-dictionaries">
-          <div class="section-header">
-            <h3>
-              Your Dictionary Entries<span
-                v-if="pendingCount > 0"
-                class="pending-badge"
-                :title="`${pendingCount} sentence(s) waiting to sync`"
-              >
-                {{ pendingCount }}
-              </span>
-            </h3>
-            <button @click="loadEntries" :disabled="loading" class="refresh-button">
-              {{ loading ? 'Loading...' : 'Refresh' }}
-            </button>
-          </div>
-
-          <div v-if="error" class="error-message">
-            {{ error }}
-          </div>
-
-          <button @click="openWebapp" class="view-all-button" v-if="entries.length > 0">
-            Open in Web App →
-          </button>
-
-          <div v-if="entries.length === 0 && !loading" class="empty-state">
-            No dictionary entries yet. Start by selecting text on any webpage!
-          </div>
-
-          <div v-else class="entries-list">
-            <div v-for="item in recentEntries" :key="item.sentence_id" class="entry-item">
-              <div class="entry-header">
-                <div class="entry-text">{{ item.sentence }}</div>
-                <a
-                  v-if="item.source_url"
-                  :href="item.source_url"
-                  target="_blank"
-                  class="source-link"
-                  title="Open source"
-                >
-                  🔗
-                </a>
-              </div>
-              <div v-if="item.source_url" class="entry-meta">
-                Source: <a :href="item.source_url" target="_blank">{{ item.source_url }}</a>
-              </div>
-              <div class="entry-date">
-                {{ formatDate(item.created_at) }}
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+  <div class="vela-popup dashboard">
+    <div class="ambient" aria-hidden="true">
+      <div class="blob blob-a"></div>
     </div>
+
+    <header class="dash-header">
+      <div class="brand-cluster">
+        <span class="brand-mark" aria-hidden="true">辞</span>
+        <div class="brand-text">
+          <span class="brand-name">Vela</span>
+          <span class="brand-sub">Dictionary</span>
+        </div>
+      </div>
+      <div v-if="userEmail" class="user-pill" :title="userEmail">
+        <span class="user-dot"></span>
+        <span class="user-email">{{ userEmail }}</span>
+      </div>
+    </header>
+
+    <main class="dash-body">
+      <section class="instructions" :class="{ expanded: instructionsExpanded }">
+        <button
+          type="button"
+          class="instructions-header"
+          @click="instructionsExpanded = !instructionsExpanded"
+        >
+          <span class="instructions-kanji" aria-hidden="true">選</span>
+          <span class="instructions-title">How to save entries</span>
+          <span class="instructions-chevron" :class="{ open: instructionsExpanded }">
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 12 12"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M3 4.5L6 7.5L9 4.5"
+                stroke="currentColor"
+                stroke-width="1.6"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </span>
+        </button>
+        <ol v-show="instructionsExpanded" class="instructions-list">
+          <li><span class="step-num">1</span>Select any text on a webpage</li>
+          <li><span class="step-num">2</span>Right-click to open the context menu</li>
+          <li><span class="step-num">3</span>Click <em>"Add vocab to Vela"</em></li>
+        </ol>
+      </section>
+
+      <section class="entries-section">
+        <div class="section-head">
+          <div class="section-title">
+            <h2>Your Dictionary</h2>
+            <span
+              v-if="pendingCount > 0"
+              class="pending-badge"
+              :title="`${pendingCount} sentence(s) waiting to sync`"
+            >
+              {{ pendingCount }} pending
+            </span>
+          </div>
+          <button @click="loadEntries" :disabled="loading" class="refresh-btn" type="button">
+            <span class="refresh-icon" :class="{ spinning: loading }">
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M21 12a9 9 0 11-3.51-7.12M21 4v5h-5"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </span>
+            <span>{{ loading ? 'Loading' : 'Refresh' }}</span>
+          </button>
+        </div>
+
+        <div v-if="error" class="error-banner">
+          <span class="error-dot"></span>
+          {{ error }}
+        </div>
+
+        <button v-if="entries.length > 0" @click="openWebapp" class="view-all-btn" type="button">
+          <span>Open in Web App</span>
+          <span class="btn-arrow">↗</span>
+        </button>
+
+        <div v-if="entries.length === 0 && !loading" class="empty-state">
+          <span class="empty-kanji" aria-hidden="true">空</span>
+          <p class="empty-title">No entries yet</p>
+          <p class="empty-copy">
+            Select text on any webpage and right-click to start your dictionary.
+          </p>
+        </div>
+
+        <div v-else class="entries-list">
+          <article v-for="item in recentEntries" :key="item.sentence_id" class="entry">
+            <div class="entry-head">
+              <p class="entry-sentence">{{ item.sentence }}</p>
+              <a
+                v-if="item.source_url"
+                :href="item.source_url"
+                target="_blank"
+                class="source-link"
+                title="Open source"
+                aria-label="Open source page"
+              >
+                <svg
+                  width="13"
+                  height="13"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 14L21 3M21 3H15M21 3V9M21 13V19C21 20.1 20.1 21 19 21H5C3.9 21 3 20.1 3 19V5C3 3.9 3.9 3 5 3H11"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </a>
+            </div>
+            <div v-if="item.source_url" class="entry-source">
+              <span class="source-label">Source</span>
+              <a :href="item.source_url" target="_blank">{{ item.source_url }}</a>
+            </div>
+            <div class="entry-meta">
+              <span class="entry-date">{{ formatDate(item.created_at) }}</span>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, watch, computed } from 'vue';
+import { ref, onMounted, onUnmounted, computed } from 'vue';
 import { getMyDictionaries } from '../utils/api';
-import {
-  getValidIdToken,
-  refreshIdToken,
-  getUserEmail,
-  clearAuthData,
-  setExplicitSignout,
-} from '../utils/storage';
+import { getValidIdToken, refreshIdToken, getUserEmail } from '../utils/storage';
 import { getPendingQueueCount } from '../utils/pendingQueue';
 
 const emit = defineEmits<{
@@ -109,7 +161,6 @@ const userEmail = ref('');
 const entries = ref<any[]>([]);
 const loading = ref(false);
 const error = ref('');
-const isDarkMode = ref(false);
 const instructionsExpanded = ref(false);
 const pendingCount = ref(0);
 
@@ -137,21 +188,12 @@ onMounted(async () => {
     userEmail.value = email;
   }
 
-  // Load theme preference
-  const savedTheme = await browser.storage.local.get('theme_preference');
-  isDarkMode.value = savedTheme.theme_preference === 'dark';
-
   browser.runtime.onMessage.addListener(handleRuntimeMessage);
   await loadEntries();
 });
 
 onUnmounted(() => {
   browser.runtime.onMessage.removeListener(handleRuntimeMessage);
-});
-
-// Watch for theme changes and persist to storage
-watch(isDarkMode, async (newValue) => {
-  await browser.storage.local.set({ theme_preference: newValue ? 'dark' : 'light' });
 });
 
 async function loadEntries() {
@@ -165,14 +207,12 @@ async function loadEntries() {
       const data = await getMyDictionaries(idToken);
       entries.value = data;
     } catch (apiError: any) {
-      // If unauthorized, try to refresh token and retry once
       if (
         apiError.message?.includes('Unauthorized') ||
         apiError.message?.includes('expired token')
       ) {
         idToken = await refreshIdToken();
 
-        // Validate the refreshed token before proceeding
         if (!idToken) {
           throw new Error('Session expired. Please log in again.');
         }
@@ -197,20 +237,6 @@ async function loadEntries() {
   }
 }
 
-function toggleTheme() {
-  isDarkMode.value = !isDarkMode.value;
-}
-
-async function handleSignOut() {
-  try {
-    await clearAuthData();
-  } catch (error: unknown) {
-    console.error('[Vela] Failed to clear auth data on sign out:', error);
-  }
-  await setExplicitSignout();
-  emit('sessionExpired');
-}
-
 function isAuthenticationError(error: Error): boolean {
   return [
     'Session expired',
@@ -222,344 +248,565 @@ function isAuthenticationError(error: Error): boolean {
 
 function formatDate(timestamp: number): string {
   const date = new Date(timestamp);
-  return date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
+  return date.toLocaleDateString() + ' · ' + date.toLocaleTimeString();
 }
 
 function openWebapp() {
-  // Use localhost in dev mode, production URL in production
   const isDev = import.meta.env.MODE === 'development';
   const baseUrl = isDev ? 'http://localhost:9000' : 'https://vela.cwchanap.dev';
   browser.tabs.create({ url: `${baseUrl}/my-dictionaries` });
 }
 
-// Computed property to show only first 5 entries
 const recentEntries = computed(() => {
   return entries.value.slice(0, 5);
 });
 </script>
 
 <style scoped>
-/* CSS Variables for theming */
-.dashboard-container {
-  --bg-primary: #ffffff;
-  --bg-secondary: #f8f9fa;
-  --bg-hover: #f5f5f5;
-  --text-primary: #1a1a1a;
-  --text-secondary: #333;
-  --text-tertiary: #666;
-  --text-muted: #888;
-  --border-color: #ddd;
-  --border-hover: #ccc;
-  --accent-color: #4a90e2;
-  --accent-hover: #357abd;
-  --error-bg: #fee;
-  --error-border: #fcc;
-  --error-text: #c33;
-}
-
-.dashboard-container.dark {
-  --bg-primary: #1e1e1e;
-  --bg-secondary: #2a2a2a;
-  --bg-hover: #353535;
-  --text-primary: #e4e4e4;
-  --text-secondary: #d0d0d0;
-  --text-tertiary: #a0a0a0;
-  --text-muted: #808080;
-  --border-color: #404040;
-  --border-hover: #505050;
-  --accent-color: #5ba3f5;
-  --accent-hover: #4a90e2;
-  --error-bg: #3d1a1a;
-  --error-border: #5c2828;
-  --error-text: #ff6b6b;
-}
-
-.dashboard-container {
+.vela-popup.dashboard {
+  position: relative;
   width: 400px;
   height: 100%;
-  font-family:
-    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  overflow: hidden;
   display: flex;
   flex-direction: column;
-  background-color: var(--bg-primary);
-}
-
-.dashboard-card {
-  background-color: var(--bg-primary);
-  flex: 1;
-  display: flex;
-  flex-direction: column;
+  background:
+    radial-gradient(circle at 90% -5%, rgba(123, 97, 255, 0.16), transparent 50%), var(--bg-page);
   overflow: hidden;
 }
 
-.dashboard-header {
-  padding: 20px;
-  border-bottom: 1px solid var(--border-color);
+/* Ambient */
+.ambient {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 0;
 }
 
-.header-top {
+.blob {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(70px);
+  opacity: 0.22;
+  will-change: transform;
+}
+
+.blob-a {
+  width: 240px;
+  height: 240px;
+  background: var(--color-primary);
+  top: -90px;
+  right: -90px;
+  animation: vela-blob-drift 14s ease-in-out infinite;
+}
+
+/* Header */
+.dash-header {
+  position: relative;
+  z-index: 1;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 8px;
+  gap: 10px;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: linear-gradient(180deg, rgba(28, 26, 50, 0.4), transparent);
 }
 
-.dashboard-header h2 {
-  margin: 0;
-  font-size: 24px;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.header-actions {
+.brand-cluster {
   display: flex;
-  gap: 8px;
-}
-
-.icon-button {
-  padding: 6px 12px;
-  background-color: var(--bg-secondary);
-  color: var(--text-primary);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  font-size: 18px;
-  cursor: pointer;
-  transition: all 0.2s;
-  line-height: 1;
-}
-
-.icon-button:hover {
-  background-color: var(--bg-hover);
-  border-color: var(--border-hover);
-}
-
-.dashboard-header p {
-  margin: 0 0 12px;
-  font-size: 14px;
-  color: var(--text-tertiary);
-}
-
-.dashboard-content {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  padding: 20px;
-  overflow-y: auto;
-  flex: 1;
-}
-
-.instructions {
-  padding: 12px 16px;
-  background-color: var(--bg-secondary);
-  border-radius: 6px;
-  border: 1px solid var(--border-color);
-}
-
-.instructions-header {
-  display: flex;
-  justify-content: space-between;
   align-items: center;
-  cursor: pointer;
-  user-select: none;
+  gap: 10px;
 }
 
-.instructions-header:hover {
-  opacity: 0.8;
-}
-
-.instructions h3 {
-  margin: 0;
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.collapse-icon {
-  background: none;
-  border: none;
-  color: var(--text-secondary);
-  font-size: 14px;
-  cursor: pointer;
-  padding: 0;
-  width: 20px;
-  height: 20px;
-  display: flex;
+.brand-mark {
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  pointer-events: none;
-}
-
-.instructions ol {
-  margin: 12px 0 0;
-  padding-left: 20px;
-}
-
-.instructions li {
-  margin: 6px 0;
-  font-size: 14px;
-  color: var(--text-secondary);
-}
-
-.my-dictionaries {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.section-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.section-header h3 {
-  margin: 0;
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.refresh-button {
-  padding: 6px 12px;
-  background-color: var(--accent-color);
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-sakura) 130%);
   color: white;
-  border: none;
-  border-radius: 6px;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background-color 0.2s;
+  font-family: var(--font-jp);
+  font-weight: 700;
+  font-size: 1.1rem;
+  box-shadow: 0 4px 14px rgba(123, 97, 255, 0.4);
 }
 
-.refresh-button:hover:not(:disabled) {
-  background-color: var(--accent-hover);
-}
-
-.refresh-button:disabled {
-  background-color: var(--border-color);
-  cursor: not-allowed;
-  opacity: 0.6;
-}
-
-.error-message {
-  padding: 12px;
-  background-color: var(--error-bg);
-  border: 1px solid var(--error-border);
-  border-radius: 6px;
-  color: var(--error-text);
-  font-size: 14px;
-}
-
-.empty-state {
-  padding: 32px 24px;
-  text-align: center;
-  color: var(--text-muted);
-  font-size: 14px;
-}
-
-.entries-list {
+.brand-text {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  line-height: 1.05;
 }
 
-.entry-item {
-  padding: 12px;
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  background: var(--bg-secondary);
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.entry-item:hover {
-  border-color: var(--accent-color);
-  background-color: var(--bg-hover);
-}
-
-.entry-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 8px;
-  margin-bottom: 8px;
-}
-
-.entry-text {
-  font-size: 14px;
-  line-height: 1.5;
+.brand-name {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  font-weight: 700;
   color: var(--text-primary);
-  word-break: break-word;
-  flex: 1;
+  letter-spacing: -0.01em;
 }
 
-.source-link {
-  font-size: 16px;
-  text-decoration: none;
-  opacity: 0.6;
-  transition: opacity 0.2s;
+.brand-sub {
+  font-family: var(--font-display);
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--color-primary-soft);
+}
+
+.user-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px 5px 8px;
+  border-radius: 999px;
+  background: var(--glass-bg-subtle);
+  border: 1px solid var(--glass-border);
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  max-width: 180px;
+}
+
+.user-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-success);
+  box-shadow: 0 0 0 3px rgba(0, 204, 136, 0.18);
   flex-shrink: 0;
 }
 
-.source-link:hover {
-  opacity: 1;
+.user-email {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.entry-meta {
-  font-size: 12px;
-  color: var(--text-secondary);
-  word-break: break-all;
+/* Body */
+.dash-body {
+  position: relative;
+  z-index: 1;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 18px 18px;
+  overflow-y: auto;
 }
 
-.entry-meta a {
-  color: var(--accent-color);
-  text-decoration: none;
-  transition: opacity 0.2s;
+/* Instructions */
+.instructions {
+  background: var(--glass-bg-subtle);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  transition: background 0.25s ease;
 }
 
-.entry-meta a:hover {
-  opacity: 0.8;
-  text-decoration: underline;
+.instructions.expanded {
+  background: var(--glass-bg);
 }
 
-.entry-date {
-  font-size: 12px;
-  color: var(--text-secondary);
-}
-
-.view-all-button {
+.instructions-header {
   width: 100%;
-  padding: 12px;
-  margin-bottom: 12px;
-  background-color: var(--accent-color);
-  color: white;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 14px;
+  background: transparent;
   border: none;
-  border-radius: 6px;
-  font-size: 14px;
-  font-weight: 500;
+  color: var(--text-primary);
+  text-align: left;
   cursor: pointer;
-  transition: background-color 0.2s;
 }
 
-.view-all-button:hover {
-  background-color: var(--accent-hover);
+.instructions-kanji {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  background: rgba(123, 97, 255, 0.15);
+  color: var(--color-primary-soft);
+  font-family: var(--font-jp);
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+
+.instructions-title {
+  flex: 1;
+  font-family: var(--font-display);
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--text-primary);
+}
+
+.instructions-chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-tertiary);
+  transition:
+    transform 0.25s ease,
+    color 0.2s ease;
+}
+
+.instructions-chevron.open {
+  transform: rotate(180deg);
+  color: var(--color-primary-soft);
+}
+
+.instructions-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 14px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  animation: vela-fade-up 0.25s ease-out both;
+}
+
+.instructions-list li {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.instructions-list em {
+  font-style: normal;
+  color: var(--color-primary-soft);
+  font-weight: 600;
+}
+
+.step-num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(123, 97, 255, 0.18);
+  color: var(--color-primary-soft);
+  font-family: var(--font-display);
+  font-size: 0.65rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+/* Section head */
+.entries-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+}
+
+.section-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.section-title h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: -0.005em;
+  color: var(--text-primary);
 }
 
 .pending-badge {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  background-color: #e55;
-  color: #fff;
-  border-radius: 10px;
-  padding: 0 7px;
-  font-size: 11px;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(255, 107, 163, 0.18), rgba(123, 97, 255, 0.18));
+  border: 1px solid rgba(255, 107, 163, 0.3);
+  color: var(--color-sakura);
+  font-family: var(--font-display);
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.refresh-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  font-size: 0.72rem;
   font-weight: 600;
-  min-width: 18px;
-  height: 18px;
-  margin-left: 6px;
-  vertical-align: middle;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.refresh-btn:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  color: var(--color-primary-soft);
+  background: var(--bg-elevated);
+}
+
+.refresh-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.refresh-icon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--color-primary-soft);
+}
+
+.refresh-icon.spinning {
+  animation: spin 0.9s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Error banner */
+.error-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  background: rgba(255, 84, 112, 0.1);
+  border: 1px solid rgba(255, 84, 112, 0.3);
+  border-radius: var(--radius-md);
+  color: var(--color-error);
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.error-dot {
+  flex-shrink: 0;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-error);
+  box-shadow: 0 0 0 3px rgba(255, 84, 112, 0.15);
+}
+
+/* View-all */
+.view-all-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 11px 14px;
+  background: linear-gradient(
+    135deg,
+    var(--color-primary) 0%,
+    #9b7bff 50%,
+    var(--color-sakura) 130%
+  );
+  color: white;
+  border: none;
+  border-radius: var(--radius-md);
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  box-shadow:
+    var(--shadow-button),
+    inset 0 1px 0 rgba(255, 255, 255, 0.14);
+  transition:
+    transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 0.25s ease;
+}
+
+.view-all-btn:hover {
+  transform: translateY(-2px);
+  box-shadow:
+    0 10px 28px rgba(123, 97, 255, 0.5),
+    inset 0 1px 0 rgba(255, 255, 255, 0.18);
+}
+
+.btn-arrow {
+  font-size: 1rem;
+  transition: transform 0.2s ease;
+}
+
+.view-all-btn:hover .btn-arrow {
+  transform: translate(2px, -2px);
+}
+
+/* Empty state */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 28px 16px 20px;
+  border: 1px dashed var(--glass-border);
+  border-radius: var(--radius-md);
+  background: var(--glass-bg-subtle);
+}
+
+.empty-kanji {
+  font-family: var(--font-jp);
+  font-weight: 300;
+  font-size: 3.2rem;
+  line-height: 1;
+  color: var(--color-primary);
+  opacity: 0.35;
+  margin-bottom: 6px;
+}
+
+.empty-title {
+  margin: 4px 0 4px;
+  font-family: var(--font-display);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.empty-copy {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--text-tertiary);
+  max-width: 28ch;
+  line-height: 1.45;
+}
+
+/* Entries list */
+.entries-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.entry {
+  position: relative;
+  padding: 11px 12px;
+  background: var(--glass-bg-subtle);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  transition:
+    border-color 0.2s ease,
+    background 0.2s ease,
+    transform 0.2s ease;
+}
+
+.entry:hover {
+  border-color: var(--border-strong);
+  background: var(--glass-bg);
+  transform: translateY(-1px);
+}
+
+.entry-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.entry-sentence {
+  margin: 0;
+  flex: 1;
+  font-family: var(--font-jp);
+  font-weight: 500;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.source-link {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
+  background: rgba(255, 107, 163, 0.1);
+  color: var(--color-sakura);
+  transition:
+    background 0.2s ease,
+    color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.source-link:hover {
+  background: rgba(255, 107, 163, 0.2);
+  color: var(--color-sakura);
+  transform: translate(1px, -1px);
+}
+
+.entry-source {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 0.7rem;
+  color: var(--text-tertiary);
+  word-break: break-all;
+  line-height: 1.35;
+}
+
+.source-label {
+  flex-shrink: 0;
+  font-family: var(--font-display);
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-primary-soft);
+}
+
+.entry-source a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.entry-source a:hover {
+  color: var(--color-primary-soft);
+  text-decoration: underline;
+}
+
+.entry-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.entry-date {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
 }
 </style>

--- a/apps/vela-ext/entrypoints/popup/DashboardPage.vue
+++ b/apps/vela-ext/entrypoints/popup/DashboardPage.vue
@@ -12,9 +12,34 @@
           <span class="brand-sub">Dictionary</span>
         </div>
       </div>
-      <div v-if="userEmail" class="user-pill" :title="userEmail">
-        <span class="user-dot"></span>
-        <span class="user-email">{{ userEmail }}</span>
+      <div v-if="userEmail" class="header-actions">
+        <div class="user-pill" :title="userEmail">
+          <span class="user-dot"></span>
+          <span class="user-email">{{ userEmail }}</span>
+        </div>
+        <button
+          type="button"
+          class="sign-out-btn"
+          title="Sign Out"
+          aria-label="Sign Out"
+          @click="handleSignOut"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M9 21H5C3.9 21 3 20.1 3 19V5C3 3.9 3.9 3 5 3H9M16 17L21 12M21 12L16 7M21 12H9"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </button>
       </div>
     </header>
 
@@ -161,7 +186,13 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, computed } from 'vue';
 import { getMyDictionaries } from '../utils/api';
-import { getValidIdToken, refreshIdToken, getUserEmail } from '../utils/storage';
+import {
+  getValidIdToken,
+  refreshIdToken,
+  getUserEmail,
+  clearAuthData,
+  setExplicitSignout,
+} from '../utils/storage';
 import { getPendingQueueCount } from '../utils/pendingQueue';
 
 const emit = defineEmits<{
@@ -266,6 +297,16 @@ function openWebapp() {
   const isDev = import.meta.env.MODE === 'development';
   const baseUrl = isDev ? 'http://localhost:9000' : 'https://vela.cwchanap.dev';
   browser.tabs.create({ url: `${baseUrl}/my-dictionaries` });
+}
+
+async function handleSignOut() {
+  try {
+    await clearAuthData();
+  } catch (err) {
+    console.error('[Vela] Failed to clear auth data on sign out:', err);
+  }
+  await setExplicitSignout();
+  emit('sessionExpired');
 }
 
 const recentEntries = computed(() => {
@@ -395,6 +436,35 @@ const recentEntries = computed(() => {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sign-out-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  color: var(--text-tertiary);
+  cursor: pointer;
+  transition:
+    color 0.2s ease,
+    border-color 0.2s ease,
+    background 0.2s ease;
+}
+
+.sign-out-btn:hover {
+  color: var(--color-error);
+  border-color: rgba(255, 84, 112, 0.4);
+  background: rgba(255, 84, 112, 0.08);
 }
 
 /* Body */

--- a/apps/vela-ext/entrypoints/popup/LoginPage.vue
+++ b/apps/vela-ext/entrypoints/popup/LoginPage.vue
@@ -1,56 +1,80 @@
 <template>
-  <div class="login-container" :class="{ dark: isDarkMode }">
-    <div class="login-card">
-      <div class="login-header">
-        <div class="header-top">
-          <h2>Sign in on Vela</h2>
-          <button
-            @click="toggleTheme"
-            class="theme-toggle"
-            type="button"
-            :title="isDarkMode ? 'Switch to Light Mode' : 'Switch to Dark Mode'"
-          >
-            {{ isDarkMode ? '☀️' : '🌙' }}
-          </button>
-        </div>
-        <p>Save Japanese sentences to your dictionary</p>
-      </div>
-
-      <div class="session-panel">
-        <p class="session-copy">Sign in with the Vela web app, then return here.</p>
-        <a class="login-url" :href="loginUrl" @click.prevent="handleOpenWebappLogin">
-          {{ loginUrl }}
-        </a>
-
-        <div v-if="error" class="error-message">
-          {{ error }}
-        </div>
-
-        <div class="web-session-actions">
-          <button
-            type="button"
-            class="open-webapp-button"
-            :disabled="webSessionLoading"
-            @click="handleOpenWebappLogin"
-          >
-            Open Vela Login
-          </button>
-          <button
-            type="button"
-            class="web-session-button"
-            :disabled="webSessionLoading"
-            @click="handleUseWebappSession"
-          >
-            {{ webSessionLoading ? 'Checking...' : 'Refresh Session' }}
-          </button>
-        </div>
-      </div>
+  <div class="vela-popup login">
+    <div class="ambient" aria-hidden="true">
+      <div class="blob blob-a"></div>
+      <div class="blob blob-b"></div>
     </div>
+    <div class="kanji-mark" aria-hidden="true">辞典</div>
+
+    <header class="brand">
+      <span class="brand-eyebrow">
+        <span class="brand-dot"></span>
+        Vela &middot; ヴェラ
+      </span>
+      <h1 class="brand-title">辞書拡張</h1>
+      <p class="brand-tagline">Save Japanese sentences to your dictionary</p>
+    </header>
+
+    <section class="card">
+      <div class="card-row">
+        <span class="card-label">Step 1</span>
+        <p class="card-copy">Sign in to the Vela web app, then return to this popup.</p>
+      </div>
+
+      <a class="login-url" :href="loginUrl" @click.prevent="handleOpenWebappLogin">
+        <span class="url-icon">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 14L21 3M21 3H15M21 3V9M21 13V19C21 20.1 20.1 21 19 21H5C3.9 21 3 20.1 3 19V5C3 3.9 3.9 3 5 3H11"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </span>
+        <span class="url-text">{{ loginUrl }}</span>
+      </a>
+
+      <div v-if="error" class="error-banner">
+        <span class="error-dot"></span>
+        {{ error }}
+      </div>
+
+      <div class="actions">
+        <button
+          type="button"
+          class="btn btn-primary"
+          :disabled="webSessionLoading"
+          @click="handleOpenWebappLogin"
+        >
+          <span class="btn-label">Open Vela Login</span>
+          <span class="btn-arrow">→</span>
+        </button>
+        <button
+          type="button"
+          class="btn btn-ghost"
+          :disabled="webSessionLoading"
+          @click="handleUseWebappSession"
+        >
+          <span v-if="webSessionLoading" class="spinner" aria-hidden="true"></span>
+          {{ webSessionLoading ? 'Checking…' : 'Refresh Session' }}
+        </button>
+      </div>
+    </section>
+
+    <p class="footnote">Secure session import &middot; No password stored</p>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue';
+import { ref } from 'vue';
 import { getWebappLoginUrl, importWebappSession, openWebappLogin } from '../utils/webappSession';
 import { clearExplicitSignout } from '../utils/storage';
 
@@ -60,23 +84,7 @@ const emit = defineEmits<{
 
 const webSessionLoading = ref(false);
 const error = ref('');
-const isDarkMode = ref(false);
 const loginUrl = getWebappLoginUrl();
-
-onMounted(async () => {
-  // Load theme preference
-  const savedTheme = await browser.storage.local.get('theme_preference');
-  isDarkMode.value = savedTheme.theme_preference === 'dark';
-});
-
-// Watch for theme changes and persist to storage
-watch(isDarkMode, async (newValue) => {
-  await browser.storage.local.set({ theme_preference: newValue ? 'dark' : 'light' });
-});
-
-function toggleTheme() {
-  isDarkMode.value = !isDarkMode.value;
-}
 
 async function handleOpenWebappLogin() {
   error.value = '';
@@ -110,163 +118,332 @@ async function handleUseWebappSession() {
 </script>
 
 <style scoped>
-/* CSS Variables for theming */
-.login-container {
-  --bg-primary: #ffffff;
-  --bg-secondary: #f8f9fa;
-  --bg-hover: #f5f5f5;
-  --text-primary: #1a1a1a;
-  --text-secondary: #333;
-  --text-tertiary: #666;
-  --border-color: #ddd;
-  --accent-color: #4a90e2;
-  --accent-hover: #357abd;
-  --error-bg: #fee;
-  --error-border: #fcc;
-  --error-text: #c33;
-}
-
-.login-container.dark {
-  --bg-primary: #1e1e1e;
-  --bg-secondary: #2a2a2a;
-  --bg-hover: #353535;
-  --text-primary: #e4e4e4;
-  --text-secondary: #d0d0d0;
-  --text-tertiary: #a0a0a0;
-  --border-color: #404040;
-  --accent-color: #5ba3f5;
-  --accent-hover: #4a90e2;
-  --error-bg: #3d1a1a;
-  --error-border: #5c2828;
-  --error-text: #ff6b6b;
-}
-
-.login-container {
-  min-width: 320px;
+.vela-popup.login {
+  position: relative;
   width: 400px;
-  height: 100%;
-  font-family:
-    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  min-height: 500px;
   display: flex;
   flex-direction: column;
-  background-color: var(--bg-primary);
+  padding: 24px 22px 20px;
+  gap: 22px;
+  background:
+    radial-gradient(circle at 15% 8%, rgba(123, 97, 255, 0.16), transparent 55%),
+    radial-gradient(circle at 92% 92%, rgba(255, 107, 163, 0.1), transparent 55%), var(--bg-page);
+  overflow: hidden;
 }
 
-.login-card {
-  background: var(--bg-primary);
-  flex: 1;
+/* Ambient blobs */
+.ambient {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 0;
+}
+
+.blob {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(60px);
+  opacity: 0.32;
+  will-change: transform;
+}
+
+.blob-a {
+  width: 260px;
+  height: 260px;
+  background: var(--color-primary);
+  top: -80px;
+  right: -60px;
+  animation: vela-blob-drift 14s ease-in-out infinite;
+}
+
+.blob-b {
+  width: 200px;
+  height: 200px;
+  background: var(--color-sakura);
+  bottom: -60px;
+  left: -40px;
+  animation: vela-blob-drift 18s ease-in-out infinite reverse;
+}
+
+/* Background kanji mark */
+.kanji-mark {
+  position: absolute;
+  top: 45%;
+  right: -30px;
+  font-family: var(--font-jp);
+  font-weight: 700;
+  font-size: 14rem;
+  color: var(--color-primary);
+  opacity: 0.05;
+  line-height: 0.8;
+  letter-spacing: -0.04em;
+  z-index: 0;
+  pointer-events: none;
+  user-select: none;
+}
+
+/* Brand */
+.brand {
+  position: relative;
+  z-index: 1;
   display: flex;
   flex-direction: column;
-  overflow-y: auto;
-  padding: 20px;
-}
-
-.login-header {
-  margin-bottom: 24px;
-}
-
-.header-top {
-  display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin-bottom: 8px;
-}
-
-.login-header h2 {
-  margin: 0;
-  font-size: 24px;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.theme-toggle {
-  padding: 6px 12px;
-  background-color: var(--bg-secondary);
-  color: var(--text-primary);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  font-size: 18px;
-  cursor: pointer;
-  transition: all 0.2s;
-  line-height: 1;
-}
-
-.theme-toggle:hover {
-  background-color: var(--bg-hover);
-}
-
-.login-header p {
-  margin: 0;
-  font-size: 14px;
-  color: var(--text-tertiary);
+  gap: 4px;
   text-align: center;
+  animation: vela-fade-up 0.5s ease-out both;
 }
 
-.session-panel {
+.brand-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--glass-border);
+  background: var(--glass-bg-subtle);
+  font-family: var(--font-display);
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--color-primary-soft);
+}
+
+.brand-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--color-primary-soft);
+  box-shadow: 0 0 0 3px rgba(123, 97, 255, 0.18);
+  animation: vela-pulse 2.2s ease-in-out infinite;
+}
+
+.brand-title {
+  font-family: var(--font-jp);
+  font-weight: 700;
+  font-size: 2rem;
+  margin: 6px 0 2px;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  background: linear-gradient(135deg, #b89aff, #ff6ba3);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.brand-tagline {
+  margin: 0;
+  font-size: 0.82rem;
+  font-weight: 400;
+  letter-spacing: 0.01em;
+  color: var(--text-secondary);
+}
+
+/* Card */
+.card {
+  position: relative;
+  z-index: 1;
+  background: var(--glass-bg);
+  backdrop-filter: blur(20px) saturate(1.4);
+  -webkit-backdrop-filter: blur(20px) saturate(1.4);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  padding: 18px;
+  box-shadow: var(--shadow-card);
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
+  animation: vela-fade-up 0.55s ease-out 0.08s both;
 }
 
-.session-copy {
+.card-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.card-label {
+  font-family: var(--font-display);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--color-primary-soft);
+}
+
+.card-copy {
   margin: 0;
-  font-size: 14px;
+  font-size: 0.86rem;
   line-height: 1.45;
   color: var(--text-secondary);
 }
 
+/* URL chip */
 .login-url {
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: 10px;
   padding: 10px 12px;
-  background-color: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  color: var(--accent-color);
-  font-size: 13px;
-  line-height: 1.35;
-  text-decoration: none;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 0.76rem;
+  line-height: 1.3;
+  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
   word-break: break-all;
+  transition:
+    border-color 0.2s ease,
+    background 0.2s ease;
 }
 
 .login-url:hover {
-  background-color: var(--bg-hover);
+  border-color: var(--border-strong);
+  background: var(--bg-elevated);
+  color: var(--color-primary-soft);
 }
 
-.error-message {
-  padding: 12px;
-  background-color: var(--error-bg);
-  border: 1px solid var(--error-border);
+.url-icon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
   border-radius: 6px;
-  color: var(--error-text);
-  font-size: 14px;
+  background: rgba(123, 97, 255, 0.15);
+  color: var(--color-primary-soft);
 }
 
-.web-session-actions {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+.url-text {
+  flex: 1;
+}
+
+/* Error banner */
+.error-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  background: rgba(255, 84, 112, 0.1);
+  border: 1px solid rgba(255, 84, 112, 0.3);
+  border-radius: var(--radius-md);
+  color: var(--color-error);
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+.error-dot {
+  flex-shrink: 0;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-error);
+  box-shadow: 0 0 0 3px rgba(255, 84, 112, 0.15);
+}
+
+/* Actions */
+.actions {
+  display: flex;
+  flex-direction: column;
   gap: 8px;
 }
 
-.web-session-button,
-.open-webapp-button {
-  padding: 10px 8px;
-  background-color: var(--bg-secondary);
-  color: var(--text-primary);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  font-size: 13px;
+.btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 18px;
+  border-radius: var(--radius-md);
+  font-family: var(--font-display);
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  border: none;
   cursor: pointer;
-  transition: all 0.2s;
+  transition:
+    transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 0.25s ease,
+    background 0.25s ease,
+    color 0.2s ease;
 }
 
-.web-session-button:hover:not(:disabled),
-.open-webapp-button:hover:not(:disabled) {
-  background-color: var(--bg-hover);
-}
-
-.web-session-button:disabled,
-.open-webapp-button:disabled {
+.btn:disabled {
+  opacity: 0.55;
   cursor: not-allowed;
-  opacity: 0.6;
+}
+
+.btn-primary {
+  background: linear-gradient(
+    135deg,
+    var(--color-primary) 0%,
+    #9b7bff 50%,
+    var(--color-sakura) 130%
+  );
+  color: white;
+  box-shadow:
+    var(--shadow-button),
+    inset 0 1px 0 rgba(255, 255, 255, 0.14);
+}
+
+.btn-primary:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow:
+    0 10px 28px rgba(123, 97, 255, 0.5),
+    inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+
+.btn-primary:hover:not(:disabled) .btn-arrow {
+  transform: translateX(3px);
+}
+
+.btn-arrow {
+  font-size: 1rem;
+  transition: transform 0.2s ease;
+}
+
+.btn-ghost {
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  border: 1px solid var(--border-subtle);
+}
+
+.btn-ghost:hover:not(:disabled) {
+  background: var(--bg-elevated);
+  border-color: var(--border-strong);
+  color: var(--color-primary-soft);
+}
+
+.spinner {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid rgba(123, 97, 255, 0.25);
+  border-top-color: var(--color-primary-soft);
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Footnote */
+.footnote {
+  position: relative;
+  z-index: 1;
+  margin: auto 0 0;
+  text-align: center;
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  opacity: 0.8;
+  animation: vela-fade-up 0.6s ease-out 0.16s both;
 }
 </style>

--- a/apps/vela-ext/entrypoints/popup/index.html
+++ b/apps/vela-ext/entrypoints/popup/index.html
@@ -3,8 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Default Popup Title</title>
+    <title>Vela Dictionary</title>
     <meta name="manifest.type" content="browser_action" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Syne:wght@500;600;700;800&family=Figtree:wght@400;500;600;700&family=Noto+Serif+JP:wght@300;500;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="app"></div>

--- a/apps/vela-ext/entrypoints/popup/style.css
+++ b/apps/vela-ext/entrypoints/popup/style.css
@@ -168,3 +168,15 @@ button:focus-visible {
     opacity: 1;
   }
 }
+
+/* Respect user motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/apps/vela-ext/entrypoints/popup/style.css
+++ b/apps/vela-ext/entrypoints/popup/style.css
@@ -1,5 +1,65 @@
+/* ============================================
+   Vela Extension — Wa-Modern Dark Design System
+   Mirrors apps/vela tokens for visual cohesion.
+   ============================================ */
+
 * {
   box-sizing: border-box;
+}
+
+:root {
+  /* Brand colors (dark palette, fixed) */
+  --color-primary: #7b61ff;
+  --color-primary-soft: #9b7bff;
+  --color-sakura: #ff6ba3;
+  --color-success: #00cc88;
+  --color-streak: #ffb347;
+  --color-error: #ff5470;
+
+  /* Surfaces */
+  --bg-page: #080714;
+  --bg-card: #11101e;
+  --bg-surface: #161428;
+  --bg-elevated: #1c1a32;
+
+  /* Text */
+  --text-primary: #e8e4f4;
+  --text-secondary: #aaa3c2;
+  --text-tertiary: #7a7592;
+  --text-muted: #585570;
+
+  /* Borders & glass */
+  --border-subtle: rgba(123, 97, 255, 0.14);
+  --border-strong: rgba(123, 97, 255, 0.28);
+  --glass-bg: rgba(28, 26, 50, 0.72);
+  --glass-bg-subtle: rgba(28, 26, 50, 0.45);
+  --glass-border: rgba(123, 97, 255, 0.16);
+
+  /* Shadows */
+  --shadow-card: 0 2px 4px rgba(0, 0, 0, 0.45), 0 6px 20px rgba(0, 0, 0, 0.3);
+  --shadow-card-hover: 0 4px 8px rgba(0, 0, 0, 0.5), 0 12px 32px rgba(123, 97, 255, 0.22);
+  --shadow-button: 0 6px 18px rgba(123, 97, 255, 0.42);
+  --glow-primary: rgba(123, 97, 255, 0.35);
+
+  /* Radius */
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+
+  /* Typography */
+  --font-display: 'Syne', system-ui, sans-serif;
+  --font-body: 'Figtree', system-ui, sans-serif;
+  --font-jp: 'Noto Serif JP', serif;
+
+  font-family: var(--font-body);
+  line-height: 1.5;
+  font-weight: 400;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-text-size-adjust: 100%;
+  color: var(--text-primary);
 }
 
 html {
@@ -8,28 +68,7 @@ html {
   min-height: 500px;
   max-height: 600px;
   overflow: hidden;
-  background-color: #1e1e1e;
-}
-
-:root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+  background-color: var(--bg-page);
 }
 
 body {
@@ -40,35 +79,9 @@ body {
   min-height: 500px;
   max-height: 600px;
   overflow: hidden;
-  background-color: #1e1e1e;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-.card {
-  padding: 2em;
+  background-color: var(--bg-page);
+  color: var(--text-primary);
+  font-family: var(--font-body);
 }
 
 #app {
@@ -81,22 +94,77 @@ button:focus-visible {
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  background-color: #1e1e1e;
+  background-color: var(--bg-page);
+  position: relative;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
+a {
+  color: var(--color-primary-soft);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+a:hover {
+  color: var(--color-sakura);
+}
+
+button {
+  font-family: var(--font-body);
+  cursor: pointer;
+}
+
+button:focus,
+button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/* Vela themed scrollbar */
+::-webkit-scrollbar {
+  width: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(123, 97, 255, 0.25);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(123, 97, 255, 0.5);
+}
+
+/* Animations shared across popup */
+@keyframes vela-blob-drift {
+  0%,
+  100% {
+    transform: translate(0, 0) scale(1);
   }
-  html,
-  body,
-  #app {
-    background-color: #ffffff;
+  50% {
+    transform: translate(15px, -10px) scale(1.05);
   }
-  a:hover {
-    color: #747bff;
+}
+
+@keyframes vela-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
   }
-  button {
-    background-color: #f9f9f9;
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes vela-pulse {
+  0%,
+  100% {
+    opacity: 0.85;
+  }
+  50% {
+    opacity: 1;
   }
 }

--- a/apps/vela-ext/tests/popup/App.test.ts
+++ b/apps/vela-ext/tests/popup/App.test.ts
@@ -170,4 +170,18 @@ describe('popup App', () => {
     expect(mockImportWebappSession).toHaveBeenCalledOnce();
     expect(wrapper.find('[data-testid="login-page"]').exists()).toBe(true);
   });
+
+  it('announces loading state to screen readers', async () => {
+    // Keep loading true by never resolving isAuthenticated
+    mockIsAuthenticated.mockReturnValue(new Promise(() => {}));
+
+    const wrapper = mount(App);
+    // Don't flushPromises — we want loading to stay true
+
+    const loadingEl = wrapper.find('.vela-loading');
+    expect(loadingEl.exists()).toBe(true);
+    expect(loadingEl.attributes('role')).toBe('status');
+    expect(loadingEl.attributes('aria-label')).toBe('Loading Vela');
+    expect(wrapper.find('.sr-only').text()).toBe('Loading…');
+  });
 });

--- a/apps/vela-ext/tests/popup/DashboardPage.test.ts
+++ b/apps/vela-ext/tests/popup/DashboardPage.test.ts
@@ -342,6 +342,24 @@ describe('DashboardPage', () => {
       await wrapper.vm.$nextTick();
       expect(collapseIcon.text()).toBe('▼');
     });
+
+    it('should have ARIA disclosure attributes on the instructions accordion', async () => {
+      wrapper = mount(DashboardPage);
+      await flushPromises();
+
+      const button = wrapper.find('.instructions-header');
+      expect(button.attributes('aria-expanded')).toBe('false');
+      expect(button.attributes('aria-controls')).toBe('instructions-panel');
+
+      const panel = wrapper.find('#instructions-panel');
+      expect(panel.exists()).toBe(true);
+      expect(panel.attributes('role')).toBe('region');
+
+      // Click to expand
+      await button.trigger('click');
+      await wrapper.vm.$nextTick();
+      expect(button.attributes('aria-expanded')).toBe('true');
+    });
   });
 
   describe('Dictionary Entries Display', () => {

--- a/apps/vela-ext/tests/popup/DashboardPage.test.ts
+++ b/apps/vela-ext/tests/popup/DashboardPage.test.ts
@@ -181,78 +181,6 @@ describe('DashboardPage', () => {
 
       expect(wrapper.find('.pending-badge').text()).toContain('3');
     });
-
-    it('should load theme preference from storage on mount', async () => {
-      storageState.theme_preference = 'dark';
-
-      wrapper = mount(DashboardPage);
-      await flushPromises();
-
-      const container = wrapper.find('.dashboard-container');
-      expect(container.classes()).toContain('dark');
-    });
-
-    it('should default to light theme if no preference is saved', async () => {
-      wrapper = mount(DashboardPage);
-      await flushPromises();
-
-      const container = wrapper.find('.dashboard-container');
-      expect(container.classes()).not.toContain('dark');
-    });
-  });
-
-  describe('Theme Toggle', () => {
-    it('should toggle theme when theme button is clicked', async () => {
-      wrapper = mount(DashboardPage);
-      await flushPromises();
-
-      // Find the button by title attribute instead of array index
-      const themeButton = wrapper.find('[title="Switch to Dark Mode"]');
-      expect(themeButton.exists()).toBe(true);
-
-      // Trigger the click event
-      await themeButton.trigger('click');
-      await flushPromises();
-
-      // Verify the dark class is applied
-      const container = wrapper.find('.dashboard-container');
-      const classes = container.classes();
-      expect(classes).toContain('dark');
-    });
-
-    it('should persist theme preference to storage when changed', async () => {
-      wrapper = mount(DashboardPage);
-      await flushPromises();
-
-      const themeButton = wrapper.find('[title="Switch to Dark Mode"]');
-      await themeButton.trigger('click');
-      await flushPromises();
-
-      expect(browser.storage.local.set).toHaveBeenCalledWith({
-        theme_preference: 'dark',
-      });
-    });
-
-    it('should display correct emoji for light mode', async () => {
-      wrapper = mount(DashboardPage);
-      await flushPromises();
-
-      const themeButton = wrapper.find('[title="Switch to Dark Mode"]');
-      expect(themeButton.text()).toBe('🌙');
-    });
-
-    it('should display correct emoji for dark mode', async () => {
-      wrapper = mount(DashboardPage);
-      await flushPromises();
-
-      const themeButton = wrapper.find('[title="Switch to Dark Mode"]');
-      await themeButton.trigger('click');
-      await flushPromises();
-
-      // After clicking, the title changes to "Switch to Light Mode"
-      const updatedButton = wrapper.find('[title="Switch to Light Mode"]');
-      expect(updatedButton.text()).toBe('☀️');
-    });
   });
 
   describe('Session Actions', () => {
@@ -327,20 +255,20 @@ describe('DashboardPage', () => {
       expect(instructionsList.element.style.display).toBe('none');
     });
 
-    it('should display correct collapse icon based on expanded state', async () => {
+    it('should rotate the chevron icon based on expanded state', async () => {
       wrapper = mount(DashboardPage);
       await flushPromises();
 
       const instructionsHeader = wrapper.find('.instructions-header');
-      const collapseIcon = wrapper.find('.collapse-icon');
+      const chevron = wrapper.find('.instructions-chevron');
 
-      // Initially collapsed
-      expect(collapseIcon.text()).toBe('▶');
+      // Initially collapsed — no "open" class
+      expect(chevron.classes()).not.toContain('open');
 
       // After expanding
       await instructionsHeader.trigger('click');
       await wrapper.vm.$nextTick();
-      expect(collapseIcon.text()).toBe('▼');
+      expect(chevron.classes()).toContain('open');
     });
 
     it('should have ARIA disclosure attributes on the instructions accordion', async () => {
@@ -373,8 +301,8 @@ describe('DashboardPage', () => {
       wrapper = mount(DashboardPage);
       await flushPromises();
 
-      // Check that the refresh button shows "Loading..."
-      const refreshButton = wrapper.find('.refresh-button');
+      // Check that the refresh button shows "Loading"
+      const refreshButton = wrapper.find('.refresh-btn');
       expect(refreshButton.text()).toContain('Loading');
 
       // Resolve the promise
@@ -386,7 +314,7 @@ describe('DashboardPage', () => {
       wrapper = mount(DashboardPage);
       await flushPromises();
 
-      const entries = wrapper.findAll('.entry-item');
+      const entries = wrapper.findAll('.entry');
       expect(entries.length).toBe(5); // Only first 5 entries
     });
 
@@ -394,11 +322,11 @@ describe('DashboardPage', () => {
       wrapper = mount(DashboardPage);
       await flushPromises();
 
-      const entries = wrapper.findAll('.entry-item');
+      const entries = wrapper.findAll('.entry');
       expect(entries.length).toBe(5);
 
       // Verify the 6th entry is not displayed
-      const allEntryTexts = entries.map((e) => e.find('.entry-text').text());
+      const allEntryTexts = entries.map((e) => e.find('.entry-sentence').text());
       expect(allEntryTexts).not.toContain('いただきます'); // 6th entry
     });
 
@@ -409,15 +337,15 @@ describe('DashboardPage', () => {
       await flushPromises();
 
       expect(wrapper.find('.empty-state').exists()).toBe(true);
-      expect(wrapper.text()).toContain('No dictionary entries yet');
+      expect(wrapper.text()).toContain('No entries yet');
     });
 
     it('should display entry text correctly', async () => {
       wrapper = mount(DashboardPage);
       await flushPromises();
 
-      const entries = wrapper.findAll('.entry-item');
-      const entryTexts = entries.map((entry) => entry.find('.entry-text').text());
+      const entries = wrapper.findAll('.entry');
+      const entryTexts = entries.map((entry) => entry.find('.entry-sentence').text());
       expect(entryTexts).toContain('こんにちは');
     });
 
@@ -425,10 +353,10 @@ describe('DashboardPage', () => {
       wrapper = mount(DashboardPage);
       await flushPromises();
 
-      const entries = wrapper.findAll('.entry-item');
+      const entries = wrapper.findAll('.entry');
       // Find entry with 'こんにちは' which has a source URL in mockEntries
       const entryWithSource = entries.find(
-        (entry) => entry.find('.entry-text').text() === 'こんにちは',
+        (entry) => entry.find('.entry-sentence').text() === 'こんにちは',
       );
 
       if (!entryWithSource) {
@@ -444,10 +372,10 @@ describe('DashboardPage', () => {
       wrapper = mount(DashboardPage);
       await flushPromises();
 
-      const entries = wrapper.findAll('.entry-item');
+      const entries = wrapper.findAll('.entry');
       // Find entry with 'さようなら' which has no source URL in mockEntries
       const entryWithoutSource = entries.find(
-        (entry) => entry.find('.entry-text').text() === 'さようなら',
+        (entry) => entry.find('.entry-sentence').text() === 'さようなら',
       );
 
       if (!entryWithoutSource) {
@@ -462,7 +390,7 @@ describe('DashboardPage', () => {
       wrapper = mount(DashboardPage);
       await flushPromises();
 
-      const entries = wrapper.findAll('.entry-item');
+      const entries = wrapper.findAll('.entry');
       expect(entries.length).toBeGreaterThan(0);
 
       // Check that all entries have date elements
@@ -474,22 +402,22 @@ describe('DashboardPage', () => {
       });
     });
 
-    it('should display "View All" button when entries exist', async () => {
+    it('should display "Open in Web App" button when entries exist', async () => {
       wrapper = mount(DashboardPage);
       await flushPromises();
 
-      const viewAllButton = wrapper.find('.view-all-button');
+      const viewAllButton = wrapper.find('.view-all-btn');
       expect(viewAllButton.exists()).toBe(true);
       expect(viewAllButton.text()).toContain('Open in Web App');
     });
 
-    it('should not display "View All" button when no entries exist', async () => {
+    it('should not display "Open in Web App" button when no entries exist', async () => {
       mockGetMyDictionaries.mockResolvedValue([]);
 
       wrapper = mount(DashboardPage);
       await flushPromises();
 
-      const viewAllButton = wrapper.find('.view-all-button');
+      const viewAllButton = wrapper.find('.view-all-btn');
       expect(viewAllButton.exists()).toBe(false);
     });
   });
@@ -501,7 +429,7 @@ describe('DashboardPage', () => {
 
       mockGetMyDictionaries.mockClear();
 
-      const refreshButton = wrapper.find('.refresh-button');
+      const refreshButton = wrapper.find('.refresh-btn');
       await refreshButton.trigger('click');
 
       expect(mockGetMyDictionaries).toHaveBeenCalled();
@@ -514,7 +442,7 @@ describe('DashboardPage', () => {
       await flushPromises();
       expect(wrapper.find('.pending-badge').text()).toContain('2');
 
-      const refreshButton = wrapper.find('.refresh-button');
+      const refreshButton = wrapper.find('.refresh-btn');
       await refreshButton.trigger('click');
       await flushPromises();
 
@@ -553,7 +481,7 @@ describe('DashboardPage', () => {
       wrapper = mount(DashboardPage);
       await flushPromises();
 
-      const refreshButton = wrapper.find('.refresh-button');
+      const refreshButton = wrapper.find('.refresh-btn');
       // The :disabled selector checks if the disabled attribute exists
       expect(refreshButton.attributes()).toHaveProperty('disabled');
 
@@ -564,13 +492,13 @@ describe('DashboardPage', () => {
   });
 
   describe('Error Handling', () => {
-    it('should display error message when loading entries fails', async () => {
+    it('should display error banner when loading entries fails', async () => {
       mockGetMyDictionaries.mockRejectedValue(new Error('Network error'));
 
       wrapper = mount(DashboardPage);
       await flushPromises();
 
-      expect(wrapper.find('.error-message').exists()).toBe(true);
+      expect(wrapper.find('.error-banner').exists()).toBe(true);
       expect(wrapper.text()).toContain('Network error');
     });
 
@@ -610,7 +538,7 @@ describe('DashboardPage', () => {
         wrapper = mount(DashboardPage);
         await flushPromises();
 
-        expect(wrapper.find('.error-message').exists()).toBe(true);
+        expect(wrapper.find('.error-banner').exists()).toBe(true);
 
         // Fast-forward time by 2 seconds to trigger the expired-session transition
         await vi.advanceTimersByTimeAsync(2000);
@@ -629,7 +557,7 @@ describe('DashboardPage', () => {
       wrapper = mount(DashboardPage);
       await flushPromises();
 
-      expect(wrapper.find('.error-message').exists()).toBe(true);
+      expect(wrapper.find('.error-banner').exists()).toBe(true);
     });
   });
 
@@ -638,7 +566,7 @@ describe('DashboardPage', () => {
       wrapper = mount(DashboardPage);
       await flushPromises();
 
-      const viewAllButton = wrapper.find('.view-all-button');
+      const viewAllButton = wrapper.find('.view-all-btn');
       await viewAllButton.trigger('click');
 
       expect(browser.tabs.create).toHaveBeenCalled();

--- a/apps/vela-ext/tests/popup/DashboardPage.test.ts
+++ b/apps/vela-ext/tests/popup/DashboardPage.test.ts
@@ -199,6 +199,26 @@ describe('DashboardPage', () => {
       expect(wrapper.emitted('sessionExpired')).toBeTruthy();
     });
 
+    it('renders sign-out button even when no email is stored', async () => {
+      mockGetUserEmail.mockResolvedValue(null);
+
+      wrapper = mount(DashboardPage);
+      await flushPromises();
+
+      expect(wrapper.find('[title="Sign Out"]').exists()).toBe(true);
+      expect(wrapper.find('.user-pill').exists()).toBe(false);
+    });
+
+    it('renders user-pill only when email is available', async () => {
+      mockGetUserEmail.mockResolvedValue('user@example.com');
+
+      wrapper = mount(DashboardPage);
+      await flushPromises();
+
+      expect(wrapper.find('.user-pill').exists()).toBe(true);
+      expect(wrapper.find('.user-pill').text()).toContain('user@example.com');
+    });
+
     it('emits sessionExpired even if clearAuthData fails on sign-out', async () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       mockClearAuthData.mockRejectedValue(new Error('Storage corrupted'));

--- a/apps/vela-ext/tests/popup/LoginPage.test.ts
+++ b/apps/vela-ext/tests/popup/LoginPage.test.ts
@@ -76,49 +76,14 @@ describe('LoginPage', () => {
       expect(wrapper.find('button[type="submit"]').exists()).toBe(false);
     });
 
-    it('renders the page title', () => {
+    it('renders the brand title', () => {
       wrapper = mount(LoginPage);
-      expect(wrapper.text()).toContain('Sign in on Vela');
+      expect(wrapper.text()).toContain('辞書拡張');
     });
 
-    it('does not show error message initially', () => {
+    it('does not show error banner initially', () => {
       wrapper = mount(LoginPage);
-      expect(wrapper.find('.error-message').exists()).toBe(false);
-    });
-  });
-
-  describe('theme toggle', () => {
-    it('defaults to light mode', async () => {
-      wrapper = mount(LoginPage);
-      await flushPromises();
-      expect(wrapper.find('.login-container').classes()).not.toContain('dark');
-    });
-
-    it('loads dark mode from storage when preference is "dark"', async () => {
-      storageState.theme_preference = 'dark';
-      wrapper = mount(LoginPage);
-      await flushPromises();
-      expect(wrapper.find('.login-container').classes()).toContain('dark');
-    });
-
-    it('toggles to dark mode when theme button is clicked', async () => {
-      wrapper = mount(LoginPage);
-      await flushPromises();
-
-      const themeBtn = wrapper.find('.theme-toggle');
-      await themeBtn.trigger('click');
-
-      expect(wrapper.find('.login-container').classes()).toContain('dark');
-    });
-
-    it('persists theme preference to storage on change', async () => {
-      wrapper = mount(LoginPage);
-      await flushPromises();
-
-      await wrapper.find('.theme-toggle').trigger('click');
-      await flushPromises();
-
-      expect(browser.storage.local.set).toHaveBeenCalledWith({ theme_preference: 'dark' });
+      expect(wrapper.find('.error-banner').exists()).toBe(false);
     });
   });
 
@@ -127,7 +92,7 @@ describe('LoginPage', () => {
       wrapper = mount(LoginPage);
       await flushPromises();
 
-      await wrapper.find('.open-webapp-button').trigger('click');
+      await wrapper.find('.btn-primary').trigger('click');
       await flushPromises();
 
       expect(mockOpenWebappLogin).toHaveBeenCalledOnce();
@@ -138,10 +103,10 @@ describe('LoginPage', () => {
       wrapper = mount(LoginPage);
       await flushPromises();
 
-      await wrapper.find('.open-webapp-button').trigger('click');
+      await wrapper.find('.btn-primary').trigger('click');
       await flushPromises();
 
-      expect(wrapper.find('.error-message').text()).toBe('tabs.create failed');
+      expect(wrapper.find('.error-banner').text()).toBe('tabs.create failed');
     });
 
     it('imports the web-app session when the user has signed in there', async () => {
@@ -149,7 +114,7 @@ describe('LoginPage', () => {
       wrapper = mount(LoginPage);
       await flushPromises();
 
-      await wrapper.find('.web-session-button').trigger('click');
+      await wrapper.find('.btn-ghost').trigger('click');
       await flushPromises();
 
       expect(mockImportWebappSession).toHaveBeenCalledOnce();
@@ -162,7 +127,7 @@ describe('LoginPage', () => {
       wrapper = mount(LoginPage);
       await flushPromises();
 
-      await wrapper.find('.web-session-button').trigger('click');
+      await wrapper.find('.btn-ghost').trigger('click');
       await flushPromises();
 
       expect(mockClearExplicitSignout).not.toHaveBeenCalled();
@@ -173,10 +138,10 @@ describe('LoginPage', () => {
       wrapper = mount(LoginPage);
       await flushPromises();
 
-      await wrapper.find('.web-session-button').trigger('click');
+      await wrapper.find('.btn-ghost').trigger('click');
       await flushPromises();
 
-      expect(wrapper.find('.error-message').text()).toContain('Sign in at the URL above');
+      expect(wrapper.find('.error-banner').text()).toContain('Sign in at the URL above');
       expect(wrapper.emitted('loginSuccess')).toBeUndefined();
     });
 
@@ -190,11 +155,11 @@ describe('LoginPage', () => {
       wrapper = mount(LoginPage);
       await flushPromises();
 
-      const importButton = wrapper.find('.web-session-button');
+      const importButton = wrapper.find('.btn-ghost');
       await importButton.trigger('click');
       await wrapper.vm.$nextTick();
 
-      expect(importButton.text()).toBe('Checking...');
+      expect(importButton.text()).toContain('Checking');
       expect(importButton.attributes('disabled')).toBeDefined();
 
       resolve(true);

--- a/apps/vela/src/components/auth/AuthForm.vue
+++ b/apps/vela/src/components/auth/AuthForm.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="auth-form">
-    <div class="auth-header text-center q-mb-lg">
-      <div class="text-h5 q-mb-sm auth-title">Welcome to Vela</div>
-      <div class="text-subtitle2 auth-subtitle">
-        Continue with Google to start learning Japanese
-      </div>
+    <div class="auth-header">
+      <span class="auth-kana" aria-hidden="true">ようこそ</span>
+      <h2 class="auth-title">Welcome to Vela</h2>
+      <p class="auth-subtitle">Continue with Google to start learning Japanese</p>
+      <span class="auth-divider" aria-hidden="true"></span>
     </div>
 
-    <div class="q-gutter-md">
-      <q-banner v-if="authStore.error" class="text-white bg-negative" rounded>
+    <div class="auth-body">
+      <q-banner v-if="authStore.error" class="auth-error" rounded>
         <template v-slot:avatar>
           <q-icon name="error" />
         </template>
@@ -16,15 +16,41 @@
       </q-banner>
 
       <q-btn
-        label="Continue with Google"
-        icon="login"
-        color="primary"
-        size="lg"
-        class="full-width"
+        class="google-cta full-width"
+        unelevated
+        no-caps
         :loading="authStore.isLoading"
         :disable="authStore.isLoading"
         @click="handleGoogleSignIn"
-      />
+      >
+        <span class="google-icon" aria-hidden="true">
+          <svg width="20" height="20" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+            <path
+              fill="#FFC107"
+              d="M43.611 20.083H42V20H24v8h11.303c-1.649 4.657-6.08 8-11.303 8c-6.627 0-12-5.373-12-12s5.373-12 12-12c3.059 0 5.842 1.154 7.961 3.039l5.657-5.657C34.046 6.053 29.268 4 24 4C12.955 4 4 12.955 4 24s8.955 20 20 20s20-8.955 20-20c0-1.341-.138-2.65-.389-3.917z"
+            />
+            <path
+              fill="#FF3D00"
+              d="M6.306 14.691l6.571 4.819C14.655 15.108 18.961 12 24 12c3.059 0 5.842 1.154 7.961 3.039l5.657-5.657C34.046 6.053 29.268 4 24 4C16.318 4 9.656 8.337 6.306 14.691z"
+            />
+            <path
+              fill="#4CAF50"
+              d="M24 44c5.166 0 9.86-1.977 13.409-5.192l-6.19-5.238A11.91 11.91 0 0 1 24 36c-5.202 0-9.619-3.317-11.283-7.946l-6.522 5.025C9.505 39.556 16.227 44 24 44z"
+            />
+            <path
+              fill="#1976D2"
+              d="M43.611 20.083H42V20H24v8h11.303a12.04 12.04 0 0 1-4.087 5.571l.003-.002l6.19 5.238C36.971 39.205 44 34 44 24c0-1.341-.138-2.65-.389-3.917z"
+            />
+          </svg>
+        </span>
+        <span class="google-label">Continue with Google</span>
+        <span class="google-arrow" aria-hidden="true">→</span>
+      </q-btn>
+
+      <p class="auth-fine">
+        <q-icon name="lock" size="0.9rem" />
+        <span>Secured by Cognito &middot; Your data stays yours</span>
+      </p>
     </div>
   </div>
 </template>
@@ -57,37 +83,199 @@ const handleGoogleSignIn = async () => {
 };
 </script>
 
-<style scoped>
+<style scoped lang="scss">
 .auth-form {
   width: 100%;
+  position: relative;
+  z-index: 1;
+}
+
+.auth-header {
+  text-align: center;
+  margin-bottom: 1.5rem;
+  position: relative;
+}
+
+.auth-kana {
+  display: inline-block;
+  font-family: 'Noto Serif JP', serif;
+  font-size: 0.78rem;
+  font-weight: 300;
+  letter-spacing: 0.5em;
+  color: var(--color-primary);
+  opacity: 0.7;
+  margin-bottom: 0.45rem;
+  padding-left: 0.5em;
 }
 
 .auth-title {
-  color: #1a1a1a;
+  font-family: Syne, sans-serif;
+  font-size: 1.6rem;
   font-weight: 700;
+  letter-spacing: -0.015em;
+  color: var(--text-primary);
+  margin: 0 0 0.35rem;
+  line-height: 1.15;
 }
 
 .auth-subtitle {
-  color: #5a5a5a;
+  font-family: Figtree, sans-serif;
+  font-size: 0.9rem;
   font-weight: 400;
+  line-height: 1.45;
+  color: var(--text-secondary);
+  margin: 0 auto;
+  max-width: 32ch;
 }
 
-:deep(.q-btn.full-width) {
-  min-height: 56px;
+.auth-divider {
+  display: block;
+  width: 60px;
+  height: 2px;
+  margin: 1.1rem auto 0;
+  background: linear-gradient(90deg, transparent, var(--color-primary), transparent);
+  opacity: 0.5;
+  border-radius: 2px;
+}
+
+.auth-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* Error banner */
+.auth-error {
+  border-radius: var(--border-radius-md);
+  background: rgba(240, 75, 90, 0.08) !important;
+  color: var(--color-error) !important;
+  border: 1px solid rgba(240, 75, 90, 0.25);
+  font-family: Figtree, sans-serif;
+  font-size: 0.85rem;
+}
+
+body.body--dark .auth-error {
+  background: rgba(255, 84, 112, 0.12) !important;
+}
+
+/* Google CTA */
+:deep(.google-cta) {
+  position: relative;
+  min-height: 58px;
+  border-radius: var(--border-radius-md);
+  background: linear-gradient(
+    135deg,
+    var(--color-primary) 0%,
+    #6f5cff 50%,
+    var(--color-sakura) 130%
+  );
+  color: white;
+  font-family: Syne, sans-serif;
+  font-size: 0.98rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-transform: none;
+  box-shadow:
+    0 8px 24px rgba(91, 74, 247, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  overflow: hidden;
+  transition:
+    transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 0.3s ease;
+}
+
+:deep(.google-cta::before) {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    100deg,
+    transparent 30%,
+    rgba(255, 255, 255, 0.18) 50%,
+    transparent 70%
+  );
+  transform: translateX(-100%);
+  transition: transform 0.7s ease;
+}
+
+:deep(.google-cta:hover) {
+  transform: translateY(-2px);
+  box-shadow:
+    0 14px 36px rgba(91, 74, 247, 0.5),
+    0 0 0 1px rgba(255, 255, 255, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.22);
+}
+
+:deep(.google-cta:hover::before) {
+  transform: translateX(100%);
+}
+
+:deep(.google-cta .q-btn__content) {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.7rem;
+  width: 100%;
+}
+
+.google-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
   border-radius: 8px;
+  background: white;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+}
+
+.google-label {
+  font-family: Syne, sans-serif;
   font-size: 1rem;
   font-weight: 600;
-  letter-spacing: 0;
-  text-transform: none;
 }
 
-:deep(.q-banner) {
-  border-radius: 8px;
+.google-arrow {
+  margin-left: 0.15rem;
+  font-size: 1.1rem;
+  opacity: 0.85;
+  transition: transform 0.25s ease;
+}
+
+:deep(.google-cta:hover) .google-arrow {
+  transform: translateX(4px);
+}
+
+/* Fine print */
+.auth-fine {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  margin: 0.5rem 0 0;
+  font-family: Figtree, sans-serif;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  opacity: 0.75;
+}
+
+.auth-fine .q-icon {
+  color: var(--color-primary);
+  opacity: 0.7;
+}
+
+/* Full width helper for legacy class consumers */
+.full-width {
+  width: 100%;
 }
 
 @media (max-width: 480px) {
-  :deep(.q-btn.full-width) {
-    min-height: 52px;
+  :deep(.google-cta) {
+    min-height: 54px;
+    font-size: 0.92rem;
+  }
+  .auth-title {
+    font-size: 1.4rem;
   }
 }
 </style>

--- a/apps/vela/src/pages/auth/LoginPage.vue
+++ b/apps/vela/src/pages/auth/LoginPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-page class="auth-page">
+  <q-page class="login-page">
     <!-- Ambient indigo / sakura / jade blobs -->
     <div class="ambient-layer" aria-hidden="true">
       <div class="ambient-blob blob-primary"></div>
@@ -120,7 +120,7 @@ onMounted(async () => {
 /* ============================================
    Vela Auth — wa-modern ink + indigo bloom
    ============================================ */
-.auth-page {
+.login-page {
   min-height: 100vh;
   display: flex;
   align-items: center;
@@ -133,7 +133,7 @@ onMounted(async () => {
     radial-gradient(circle at 88% 82%, rgba(232, 68, 122, 0.16), transparent 55%), var(--bg-page);
 }
 
-body.body--dark .auth-page {
+body.body--dark .login-page {
   background:
     radial-gradient(circle at 12% 18%, rgba(123, 97, 255, 0.28), transparent 55%),
     radial-gradient(circle at 88% 82%, rgba(255, 107, 163, 0.18), transparent 55%), var(--bg-page);

--- a/apps/vela/src/pages/auth/LoginPage.vue
+++ b/apps/vela/src/pages/auth/LoginPage.vue
@@ -1,44 +1,58 @@
 <template>
-  <q-page class="modern-auth-page animated-bg">
-    <!-- Floating Decorative Elements -->
-    <div class="floating-shapes">
-      <div class="shape shape-1"></div>
-      <div class="shape shape-2"></div>
-      <div class="shape shape-3"></div>
+  <q-page class="auth-page">
+    <!-- Ambient indigo / sakura / jade blobs -->
+    <div class="ambient-layer" aria-hidden="true">
+      <div class="ambient-blob blob-primary"></div>
+      <div class="ambient-blob blob-sakura"></div>
+      <div class="ambient-blob blob-jade"></div>
     </div>
 
+    <!-- Decorative kanji watermark -->
+    <div class="kanji-deco kanji-watermark" aria-hidden="true">学</div>
+
+    <!-- Hairline grid background -->
+    <div class="grid-overlay" aria-hidden="true"></div>
+
     <div class="auth-container">
-      <div class="auth-content">
-        <!-- App Branding -->
-        <div class="brand-section">
-          <div class="brand-icon">
-            <q-icon name="school" size="3.5rem" color="white" />
-          </div>
-          <h1 class="brand-title">日本語学習</h1>
-          <p class="brand-tagline">Master Japanese with Interactive Learning</p>
-        </div>
+      <!-- Brand: eyebrow + stacked Japanese wordmark + tagline -->
+      <header class="brand anim-enter-1">
+        <span class="brand-eyebrow">
+          <span class="brand-dot"></span>
+          Vela &middot; ヴェラ
+        </span>
+        <h1 class="brand-title">日本語学習</h1>
+        <p class="brand-tagline">Master Japanese with Interactive Learning</p>
+      </header>
 
-        <!-- Authentication Card -->
-        <div class="auth-card">
-          <AuthForm :mode="authMode" :redirect-to="redirectTo" @error="handleAuthError" />
-        </div>
+      <!-- Glass-card sign-in -->
+      <section class="auth-card anim-enter-2">
+        <div class="auth-card-glow" aria-hidden="true"></div>
+        <AuthForm :mode="authMode" :redirect-to="redirectTo" @error="handleAuthError" />
+      </section>
 
-        <!-- Features Preview -->
-        <div class="features-section">
-          <div class="feature-pill">
-            <q-icon name="quiz" size="1.25rem" />
-            <span>Vocabulary Games</span>
-          </div>
-          <div class="feature-pill">
-            <q-icon name="psychology" size="1.25rem" />
-            <span>AI-Powered Tutor</span>
-          </div>
-          <div class="feature-pill">
-            <q-icon name="trending_up" size="1.25rem" />
-            <span>Track Progress</span>
-          </div>
-        </div>
-      </div>
+      <!-- Feature pills -->
+      <ul class="feature-rail anim-enter-3">
+        <li class="feature-pill pill-vocab">
+          <span class="pill-icon">
+            <q-icon name="quiz" size="1.1rem" />
+          </span>
+          <span class="pill-label">Vocabulary Games</span>
+        </li>
+        <li class="feature-pill pill-chat">
+          <span class="pill-icon">
+            <q-icon name="psychology" size="1.1rem" />
+          </span>
+          <span class="pill-label">AI-Powered Tutor</span>
+        </li>
+        <li class="feature-pill pill-streak">
+          <span class="pill-icon">
+            <q-icon name="trending_up" size="1.1rem" />
+          </span>
+          <span class="pill-label">Track Progress</span>
+        </li>
+      </ul>
+
+      <p class="auth-footnote anim-enter-4">Continue with Google &middot; No password required</p>
     </div>
   </q-page>
 </template>
@@ -50,17 +64,14 @@ import { useQuasar } from 'quasar';
 import { useAuthStore } from '../../stores/auth';
 import AuthForm from '../../components/auth/AuthForm.vue';
 
-// Composables
 const route = useRoute();
 const router = useRouter();
 const $q = useQuasar();
 const authStore = useAuthStore();
 
-// State
 const authMode = ref<'signin' | 'signup'>('signin');
 const redirectTo = ref('/');
 
-// Methods
 const getRouteRedirect = () => authStore.getSafeAuthRedirect(route.query.redirect);
 
 const getInitialRedirect = () => {
@@ -69,10 +80,6 @@ const getInitialRedirect = () => {
   return isAuthCallback ? authStore.consumePendingAuthRedirect(routeRedirect) : routeRedirect;
 };
 
-// Watch for authentication readiness after mount — the OAuth code exchange can
-// finish asynchronously via the Amplify listener, and loadUserProfile() runs
-// after setSession(). Protected routes check isAuthenticated (user + session),
-// so we must wait for the profile to load before redirecting to avoid a bounce.
 let navigated = false;
 
 const unwatchAuth = watch(
@@ -98,12 +105,8 @@ const handleAuthError = (message: string) => {
 onMounted(async () => {
   redirectTo.value = getInitialRedirect();
 
-  // Initialize auth store
   await authStore.initialize();
 
-  // Check if user is fully authenticated (session + profile loaded).
-  // Redirecting on session alone can bounce protected routes because the
-  // router guard requires isAuthenticated, which needs user to be set.
   if (authStore.isAuthenticated && !navigated) {
     navigated = true;
     unwatchAuth();
@@ -113,238 +116,279 @@ onMounted(async () => {
 });
 </script>
 
-<style scoped>
-/* Modern Authentication Page */
-.modern-auth-page {
+<style scoped lang="scss">
+/* ============================================
+   Vela Auth — wa-modern ink + indigo bloom
+   ============================================ */
+.auth-page {
   min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
   position: relative;
   overflow: hidden;
-  padding: 2rem 1rem;
+  padding: clamp(1.5rem, 4vw, 3rem) 1rem;
+  background:
+    radial-gradient(circle at 12% 18%, rgba(91, 74, 247, 0.18), transparent 55%),
+    radial-gradient(circle at 88% 82%, rgba(232, 68, 122, 0.16), transparent 55%), var(--bg-page);
 }
 
-/* Floating Background Shapes */
-.floating-shapes {
+body.body--dark .auth-page {
+  background:
+    radial-gradient(circle at 12% 18%, rgba(123, 97, 255, 0.28), transparent 55%),
+    radial-gradient(circle at 88% 82%, rgba(255, 107, 163, 0.18), transparent 55%), var(--bg-page);
+}
+
+/* Hairline graph grid */
+.grid-overlay {
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
   z-index: 0;
   pointer-events: none;
-  overflow: hidden;
+  background-image:
+    linear-gradient(rgba(91, 74, 247, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(91, 74, 247, 0.05) 1px, transparent 1px);
+  background-size: 56px 56px;
+  mask-image: radial-gradient(circle at center, black 30%, transparent 75%);
+  -webkit-mask-image: radial-gradient(circle at center, black 30%, transparent 75%);
 }
 
-.shape {
-  position: absolute;
-  border-radius: 50%;
-  filter: blur(80px);
-  opacity: 0.3;
-  animation: float 20s ease-in-out infinite;
+body.body--dark .grid-overlay {
+  background-image:
+    linear-gradient(rgba(123, 97, 255, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(123, 97, 255, 0.08) 1px, transparent 1px);
 }
 
-.shape-1 {
-  width: 400px;
-  height: 400px;
-  background: radial-gradient(circle, rgba(255, 107, 107, 0.4), rgba(255, 170, 65, 0.2));
-  top: -100px;
-  left: -100px;
-  animation-delay: 0s;
-}
-
-.shape-2 {
-  width: 350px;
-  height: 350px;
-  background: radial-gradient(circle, rgba(94, 114, 228, 0.4), rgba(130, 88, 255, 0.2));
-  bottom: -100px;
-  right: -100px;
-  animation-delay: 5s;
-}
-
-.shape-3 {
-  width: 300px;
-  height: 300px;
-  background: radial-gradient(circle, rgba(52, 211, 153, 0.3), rgba(33, 206, 153, 0.2));
+/* Watermark kanji */
+.kanji-watermark {
+  font-size: clamp(22rem, 55vw, 42rem);
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
-  animation-delay: 10s;
+  transform: translate(-50%, -52%);
+  z-index: 0;
+  opacity: 0.045;
+  letter-spacing: -0.05em;
 }
 
-@keyframes float {
-  0%,
-  100% {
-    transform: translate(0, 0) scale(1);
-  }
-  33% {
-    transform: translate(30px, -30px) scale(1.1);
-  }
-  66% {
-    transform: translate(-20px, 20px) scale(0.9);
-  }
+body.body--dark .kanji-watermark {
+  opacity: 0.07;
 }
 
-/* Main Container */
+/* Container */
 .auth-container {
   position: relative;
-  z-index: 1;
+  z-index: 2;
   width: 100%;
-  max-width: 420px;
-  animation: fadeInUp 0.6s ease-out;
-}
-
-@keyframes fadeInUp {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.auth-content {
+  max-width: 460px;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: clamp(1.5rem, 3vw, 2.25rem);
 }
 
-/* Brand Section */
-.brand-section {
+/* Brand */
+.brand {
   text-align: center;
-  color: white;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
 }
 
-.brand-icon {
-  margin-bottom: 1rem;
-  animation: pulse 2s ease-in-out infinite;
+.brand-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-family: Syne, sans-serif;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--color-primary);
+  padding: 0.45rem 0.95rem;
+  border-radius: 999px;
+  border: 1px solid var(--glass-border);
+  background: var(--glass-bg-subtle);
+  backdrop-filter: blur(8px);
 }
 
-@keyframes pulse {
-  0%,
-  100% {
-    transform: scale(1);
-    opacity: 1;
-  }
-  50% {
-    transform: scale(1.05);
-    opacity: 0.9;
-  }
+.brand-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  box-shadow: 0 0 0 4px rgba(91, 74, 247, 0.15);
+  animation: glow-pulse 2.4s ease-in-out infinite;
 }
 
 .brand-title {
-  font-size: 2.75rem;
+  font-family: 'Noto Serif JP', serif;
   font-weight: 700;
-  margin: 0 0 0.5rem 0;
-  color: white;
-  text-shadow: 0 2px 20px rgba(0, 0, 0, 0.3);
-  letter-spacing: 2px;
+  font-size: clamp(2.8rem, 7vw, 4rem);
+  letter-spacing: 0.02em;
+  margin: 0.3rem 0 0.15rem;
+  line-height: 1;
+  background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-sakura) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
 }
 
 .brand-tagline {
-  font-size: 1rem;
+  font-family: Figtree, sans-serif;
+  font-size: 0.95rem;
   font-weight: 400;
+  letter-spacing: 0.01em;
+  color: var(--text-secondary);
   margin: 0;
-  color: rgba(255, 255, 255, 0.9);
-  text-shadow: 0 1px 10px rgba(0, 0, 0, 0.2);
+  max-width: 28ch;
 }
 
-/* Authentication Card */
+/* Card */
 .auth-card {
-  background: rgba(255, 255, 255, 0.95);
-  backdrop-filter: blur(10px);
-  border-radius: 20px;
-  padding: 2.5rem;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  border: 1px solid rgba(255, 255, 255, 0.5);
-  transition: all 0.3s ease;
+  position: relative;
+  background: var(--glass-bg);
+  backdrop-filter: var(--glass-backdrop);
+  -webkit-backdrop-filter: var(--glass-backdrop);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-xl);
+  padding: clamp(1.75rem, 4vw, 2.25rem) clamp(1.5rem, 4vw, 2.25rem) clamp(1.5rem, 3vw, 2rem);
+  box-shadow: var(--shadow-medium);
+  overflow: hidden;
 }
 
-.auth-card:hover {
-  box-shadow: 0 25px 70px rgba(0, 0, 0, 0.4);
-  transform: translateY(-2px);
+/* Subtle indigo halo behind card */
+.auth-card-glow {
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(
+    135deg,
+    rgba(91, 74, 247, 0.4),
+    transparent 35%,
+    transparent 65%,
+    rgba(232, 68, 122, 0.3)
+  );
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  pointer-events: none;
 }
 
-/* Features Section */
-.features-section {
+/* Feature rail */
+.feature-rail {
+  list-style: none;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
   justify-content: center;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
 }
 
 .feature-pill {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.75rem 1.25rem;
-  background: rgba(255, 255, 255, 0.15);
-  backdrop-filter: blur(10px);
-  border-radius: 50px;
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  color: white;
-  font-size: 0.875rem;
-  font-weight: 500;
+  padding: 0.55rem 0.95rem;
+  border-radius: 999px;
+  background: var(--glass-bg-subtle);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(8px);
+  font-family: Syne, sans-serif;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-primary);
   cursor: default;
-  text-shadow: 0 1px 5px rgba(0, 0, 0, 0.2);
+  transition:
+    transform 0.25s ease,
+    border-color 0.25s ease,
+    color 0.25s ease;
 }
 
-.feature-pill .q-icon {
-  opacity: 0.95;
+.feature-pill:hover {
+  transform: translateY(-2px);
 }
 
-/* Responsive Design */
+.pill-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  font-size: 0.7rem;
+}
+
+.pill-vocab .pill-icon {
+  background: rgba(91, 74, 247, 0.12);
+  color: var(--color-primary);
+}
+.pill-vocab:hover {
+  border-color: rgba(91, 74, 247, 0.3);
+}
+
+.pill-chat .pill-icon {
+  background: rgba(29, 184, 122, 0.12);
+  color: var(--color-success);
+}
+.pill-chat:hover {
+  border-color: rgba(29, 184, 122, 0.3);
+}
+
+.pill-streak .pill-icon {
+  background: rgba(232, 68, 122, 0.12);
+  color: var(--color-sakura);
+}
+.pill-streak:hover {
+  border-color: rgba(232, 68, 122, 0.3);
+}
+
+.pill-label {
+  line-height: 1;
+}
+
+/* Footnote */
+.auth-footnote {
+  text-align: center;
+  margin: 0;
+  font-family: Figtree, sans-serif;
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  opacity: 0.85;
+}
+
+/* Responsive */
 @media (max-width: 600px) {
-  .modern-auth-page {
-    padding: 1.5rem 1rem;
-  }
-
   .auth-container {
     max-width: 100%;
+    gap: 1.25rem;
   }
-
-  .brand-title {
-    font-size: 2.25rem;
+  .brand-eyebrow {
+    font-size: 0.65rem;
+    letter-spacing: 0.28em;
   }
-
-  .brand-tagline {
-    font-size: 0.9rem;
-  }
-
-  .auth-card {
-    padding: 2rem 1.5rem;
-    border-radius: 16px;
-  }
-
   .feature-pill {
-    font-size: 0.8rem;
-    padding: 0.625rem 1rem;
-  }
-
-  .feature-pill .q-icon {
-    font-size: 1.1rem;
+    font-size: 0.7rem;
+    padding: 0.45rem 0.75rem;
   }
 }
 
 @media (max-width: 400px) {
-  .brand-title {
-    font-size: 2rem;
-  }
-
   .auth-card {
-    padding: 1.75rem 1.25rem;
+    border-radius: var(--border-radius-lg);
   }
-
-  .features-section {
-    gap: 0.5rem;
-  }
-
-  .feature-pill {
-    font-size: 0.75rem;
-    padding: 0.5rem 0.875rem;
+  .feature-rail {
+    gap: 0.4rem;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- Redesign browser extension popup (App.vue, DashboardPage.vue, LoginPage.vue) with a unified dark wa-modern visual language
- Redesign web-app auth flows (AuthForm.vue, LoginPage.vue) to match the new design system
- Introduce shared design tokens in extension popup CSS (colors, fonts, glass effects, shadows, radius, animations)
- Add Google Fonts (Syne, Figtree, Noto Serif JP) to the extension popup
- Replace legacy light/dark theme toggles with a fixed dark aesthetic
- Add ambient blob animations, glass cards, gradient CTAs, and refined typography across auth and extension surfaces

#### Test plan
- [ ] Verify extension popup loads and renders correctly in Chrome/Firefox dev mode
- [ ] Verify auth login page renders correctly and Google sign-in button is functional
- [ ] Confirm no visual regressions in existing Quasar components

Generated with [Devin](https://cli.devin.ai/docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced loading screen with animated visual indicators during session initialization.
  * Entry cards now display dates and optional source links in the dashboard.

* **UI/Design Updates**
  * Redesigned popup interface with new visual branding and layout.
  * Redesigned login experience with updated styling and improved visual hierarchy.
  * Refined authentication form with enhanced sign-in button styling.
  * New design system featuring improved typography, animations, and visual effects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cwchanap/Vela/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->