### PR TITLE
Provision Cognito mobile OAuth client and register iOS deep-link scheme

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,9 +29,11 @@ CORS_ALLOWED_ORIGINS=http://localhost:9000,http://127.0.0.1:9000
 CORS_ALLOWED_EXTENSION_IDS=your_chrome_extension_id_here,your_firefox_extension_id_here
 
 # CDK deploy-time only (not read by the Quasar apps; do not mirror into apps/*/.env.example)
-# Override URIs MUST use the dev.cwchanap.vela.oauth:// scheme — CDK throws at synth time otherwise.
-COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth://oauth/callback
-COGNITO_MOBILE_LOGOUT_URLS=dev.cwchanap.vela.oauth://oauth/logout
+# Override URIs MUST use the dev.cwchanap.vela.oauth:/ scheme (RFC 8252 §7.1 private-use URI form,
+# single slash — no authority component) and an allowed path (/oauth/callback, /oauth/staging-callback
+# for callbacks; /oauth/logout, /oauth/staging-logout for logouts). CDK throws at synth time otherwise.
+COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth:/oauth/callback
+COGNITO_MOBILE_LOGOUT_URLS=dev.cwchanap.vela.oauth:/oauth/logout
 
 # Development Configuration
 VITE_DEV_MODE=true

--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,11 @@ VITE_API_URL=http://localhost:3001/api/
 CORS_ALLOWED_ORIGINS=http://localhost:9000,http://127.0.0.1:9000
 CORS_ALLOWED_EXTENSION_IDS=your_chrome_extension_id_here,your_firefox_extension_id_here
 
+# CDK deploy-time only (not read by the Quasar apps; do not mirror into apps/*/.env.example)
+# Override URIs MUST use the dev.cwchanap.vela.oauth:// scheme — CDK throws at synth time otherwise.
+COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth://oauth/callback
+COGNITO_MOBILE_LOGOUT_URLS=dev.cwchanap.vela.oauth://oauth/logout
+
 # Development Configuration
 VITE_DEV_MODE=true
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -49,6 +49,7 @@ jobs:
           else
             echo "Coverage file NOT found"
             find apps/vela -name "*.json" -path "*/coverage/*"
+            exit 1
           fi
 
       - name: Upload coverage to Codecov (web)
@@ -96,6 +97,7 @@ jobs:
           else
             echo "Coverage file NOT found"
             find apps/vela-api -name "*.info" -o -name "coverage" -type d
+            exit 1
           fi
 
       - name: Upload coverage to Codecov (api)
@@ -145,6 +147,7 @@ jobs:
           else
             echo "Coverage file NOT found"
             find apps/vela-ext -name "*.json" -path "*/coverage/*"
+            exit 1
           fi
 
       - name: Upload coverage to Codecov (ext)
@@ -173,6 +176,13 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Lint Info.plist XML well-formedness
+        # plutil -lint is macOS-only; ubuntu-latest has xmllint instead, which
+        # performs the same well-formedness check for XML plists. Catches
+        # broken XML before the Bun-based plist parser tests run.
+        shell: bash
+        run: xmllint --noout apps/vela-mobile/src-capacitor/ios/App/App/Info.plist
 
       - name: Run mobile unit tests with coverage
         shell: bash

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -179,6 +179,7 @@ jobs:
           else
             echo "Coverage file NOT found"
             find apps/vela-mobile -name "*.json" -path "*/coverage/*"
+            exit 1
           fi
 
       - name: Upload coverage to Codecov (mobile)

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   BUN_VERSION: '1.3.1'
-  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 # Top-level permissions restrict the auto-generated GITHUB_TOKEN to read-only
 # across every job in this workflow. Per-job `permissions:` overrides and
@@ -55,6 +54,12 @@ jobs:
       - name: Upload coverage to Codecov (web)
         if: hashFiles('apps/vela/coverage/coverage-final.json') != ''
         uses: codecov/codecov-action@v4
+        env:
+          # Scoped to this step only — defining CODECOV_TOKEN at workflow scope
+          # exposed it to `bun install` and test execution in every job, letting
+          # dependency lifecycle scripts and test code read a secret they don't
+          # need.
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           token: ${{ env.CODECOV_TOKEN }}
           files: ./apps/vela/coverage/coverage-final.json
@@ -96,6 +101,8 @@ jobs:
       - name: Upload coverage to Codecov (api)
         if: hashFiles('apps/vela-api/coverage/lcov.info') != ''
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           token: ${{ env.CODECOV_TOKEN }}
           files: ./apps/vela-api/coverage/lcov.info
@@ -143,6 +150,8 @@ jobs:
       - name: Upload coverage to Codecov (ext)
         if: hashFiles('apps/vela-ext/coverage/coverage-final.json') != ''
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           token: ${{ env.CODECOV_TOKEN }}
           files: ./apps/vela-ext/coverage/coverage-final.json
@@ -185,6 +194,8 @@ jobs:
       - name: Upload coverage to Codecov (mobile)
         if: hashFiles('apps/vela-mobile/coverage/coverage-final.json') != ''
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           token: ${{ env.CODECOV_TOKEN }}
           files: ./apps/vela-mobile/coverage/coverage-final.json

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -143,3 +143,44 @@ jobs:
           name: codecov-ext
           fail_ci_if_error: false
         continue-on-error: true
+
+  mobile-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run mobile unit tests with coverage
+        shell: bash
+        run: |
+          cd apps/vela-mobile
+          bun run test:unit --coverage
+
+      - name: Check coverage file exists (mobile)
+        run: |
+          if [ -f apps/vela-mobile/coverage/coverage-final.json ]; then
+            echo "Coverage file found"
+            ls -lh apps/vela-mobile/coverage/
+          else
+            echo "Coverage file NOT found"
+            find apps/vela-mobile -name "*.json" -path "*/coverage/*"
+          fi
+
+      - name: Upload coverage to Codecov (mobile)
+        if: hashFiles('apps/vela-mobile/coverage/coverage-final.json') != ''
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ env.CODECOV_TOKEN }}
+          files: ./apps/vela-mobile/coverage/coverage-final.json
+          flags: mobile
+          name: codecov-mobile
+          fail_ci_if_error: false
+        continue-on-error: true

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -146,9 +146,13 @@ jobs:
 
   mobile-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -187,9 +191,13 @@ jobs:
 
   cdk-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -184,3 +184,26 @@ jobs:
           name: codecov-mobile
           fail_ci_if_error: false
         continue-on-error: true
+
+  cdk-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run CDK unit tests
+        shell: bash
+        # CDK_SPA_DIST_PATH is set by the StaticWebStack tests themselves via
+        # mkdtempSync; no built SPA is required. ALLOW_LOCAL_OAUTH_PLACEHOLDERS
+        # is set by the AuthStack tests for the same reason.
+        run: |
+          cd packages/cdk
+          bun run test:unit

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -199,6 +199,16 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Build Lambda bundle
+        # ApiStack constructs Code.fromAsset(.../packages/cdk/dist/lambda), and
+        # Source.asset stats the directory at construct time. Both api-stack and
+        # static-web-stack tests instantiate ApiStack, so dist/lambda must exist
+        # before tests run or synth throws ValidationError before assertions.
+        shell: bash
+        run: |
+          cd packages/cdk
+          bun run lambda:build
+
       - name: Run CDK unit tests
         shell: bash
         # CDK_SPA_DIST_PATH is set by the StaticWebStack tests themselves via

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -178,11 +178,15 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Lint Info.plist XML well-formedness
-        # plutil -lint is macOS-only; ubuntu-latest has xmllint instead, which
-        # performs the same well-formedness check for XML plists. Catches
-        # broken XML before the Bun-based plist parser tests run.
+        # Use Python's standard-library XML parser so this check works on the
+        # stock ubuntu-latest image without installing xmllint/libxml2-utils.
         shell: bash
-        run: xmllint --noout apps/vela-mobile/src-capacitor/ios/App/App/Info.plist
+        run: |
+          python3 - <<'PY'
+          import xml.etree.ElementTree as ET
+
+          ET.parse('apps/vela-mobile/src-capacitor/ios/App/App/Info.plist')
+          PY
 
       - name: Run mobile unit tests with coverage
         shell: bash

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -11,6 +11,13 @@ env:
   BUN_VERSION: '1.3.1'
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+# Top-level permissions restrict the auto-generated GITHUB_TOKEN to read-only
+# across every job in this workflow. Per-job `permissions:` overrides and
+# `persist-credentials: false` on individual checkout steps are no longer
+# needed — the token cannot write even if checkout persists it.
+permissions:
+  contents: read
+
 jobs:
   web-tests:
     runs-on: ubuntu-latest
@@ -146,13 +153,9 @@ jobs:
 
   mobile-tests:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -191,13 +194,9 @@ jobs:
 
   cdk-tests:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,35 @@ Vela uses **Google-only OAuth** via Cognito Hosted UI. There is no password-base
 - **E2E tests**: Use the seeded-token fixture (`e2e/fixtures/auth.ts`) which calls `AdminInitiateAuth` via the AWS SDK to bypass Google's UI. This requires AWS credentials (`aws sso login` or env-injected) and the `VITE_COGNITO_TEST_CLIENT_ID` env var (see `.env.example`).
 - **Extension**: Imports tokens from the web app's localStorage via a content script restricted to Vela origins.
 
+### Mobile client (iOS)
+
+Vela Mobile authenticates against the same Cognito user pool as the web app, through a dedicated **public** app client (`vela-mobile-client`). The mobile OAuth flow uses authorization-code grant + PKCE; no client secret is bundled in the app binary.
+
+The iOS callback uses a custom URL scheme registered in `apps/vela-mobile/src-capacitor/ios/App/App/Info.plist`:
+
+| URI                                        | Purpose                                              |
+| ------------------------------------------ | ---------------------------------------------------- |
+| `dev.cwchanap.vela.oauth://oauth/callback` | Receives the authorization code after Google sign-in |
+| `dev.cwchanap.vela.oauth://oauth/logout`   | Receives the redirect after Cognito sign-out         |
+
+The scheme is rooted at `cwchanap.dev` (a project-controlled domain) rather than the bundle id, because `vela.app` is not a controlled namespace and custom URL schemes are an unowned namespace on iOS.
+
+`AppDelegate.application(_:open:options:)` already forwards opens to Capacitor's `ApplicationDelegateProxy`. This is only relevant if the M2 client-side flow uses `@capacitor/browser` + `@capacitor/app` — if M2 uses `ASWebAuthenticationSession` instead, the callback arrives through the session's completion handler and `AppDelegate` is bypassed entirely.
+
+CDK env vars (defaults shown):
+
+    COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth://oauth/callback
+    COGNITO_MOBILE_LOGOUT_URLS=dev.cwchanap.vela.oauth://oauth/logout
+
+Both accept comma-separated lists for dev/QA overrides. **Override URIs must use the `dev.cwchanap.vela.oauth://` scheme** — CDK validates this at synth time and throws otherwise, because iOS only registers that one scheme. Vary the path, not the scheme. The mobile client ID is published as the `CognitoMobileUserPoolClientId` CloudFormation output.
+
+The following M2 work is required before the mobile OAuth flow can complete end-to-end (out of scope for HPA-203):
+
+1. Widen the API JWT verifier to accept both web and mobile client audiences (`aws-jwt-verify` `clientId: [webId, mobileId]`).
+2. Wire the mobile client ID into the Capacitor build.
+3. If API calls go through WKWebView, add `capacitor://localhost` to the API CORS allow-list.
+4. Implement PKCE + `state` + `nonce` in the client-side OAuth flow.
+
 ## Testing
 
 - **E2E tests** require `TEST_EMAIL`, `TEST_PASSWORD`, and `VITE_COGNITO_TEST_CLIENT_ID` env vars (see `.env.example`). Also requires AWS credentials for `AdminInitiateAuth`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ The iOS callback uses a custom URL scheme registered in `apps/vela-mobile/src-ca
 | `dev.cwchanap.vela.oauth://oauth/callback` | Receives the authorization code after Google sign-in |
 | `dev.cwchanap.vela.oauth://oauth/logout`   | Receives the redirect after Cognito sign-out         |
 
-The scheme is rooted at `cwchanap.dev` (a project-controlled domain) rather than the bundle id, because `vela.app` is not a controlled namespace and custom URL schemes are an unowned namespace on iOS.
+The scheme is the reverse-DNS of the project-controlled `vela.cwchanap.dev` domain with an `.oauth` suffix (i.e. `dev.cwchanap.vela.oauth`), rather than the bundle id, because `vela.app` is not a controlled namespace and custom URL schemes are an unowned namespace on iOS.
 
 `AppDelegate.application(_:open:options:)` already forwards opens to Capacitor's `ApplicationDelegateProxy`. This is only relevant if the M2 client-side flow uses `@capacitor/browser` + `@capacitor/app` — if M2 uses `ASWebAuthenticationSession` instead, the callback arrives through the session's completion handler and `AppDelegate` is bypassed entirely.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,8 +153,10 @@ The scheme is rooted at `cwchanap.dev` (a project-controlled domain) rather than
 
 CDK env vars (defaults shown):
 
-    COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth://oauth/callback
-    COGNITO_MOBILE_LOGOUT_URLS=dev.cwchanap.vela.oauth://oauth/logout
+```dotenv
+COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth://oauth/callback
+COGNITO_MOBILE_LOGOUT_URLS=dev.cwchanap.vela.oauth://oauth/logout
+```
 
 Both accept comma-separated lists for dev/QA overrides. **Override URIs must use the `dev.cwchanap.vela.oauth://` scheme** — CDK validates this at synth time and throws otherwise, because iOS only registers that one scheme. Vary the path, not the scheme. The mobile client ID is published as the `CognitoMobileUserPoolClientId` CloudFormation output.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,23 +149,23 @@ Vela Mobile authenticates against the same Cognito user pool as the web app, thr
 
 The iOS callback uses a custom URL scheme registered in `apps/vela-mobile/src-capacitor/ios/App/App/Info.plist`:
 
-| URI                                        | Purpose                                              |
-| ------------------------------------------ | ---------------------------------------------------- |
-| `dev.cwchanap.vela.oauth://oauth/callback` | Receives the authorization code after Google sign-in |
-| `dev.cwchanap.vela.oauth://oauth/logout`   | Receives the redirect after Cognito sign-out         |
+| URI                                       | Purpose                                              |
+| ----------------------------------------- | ---------------------------------------------------- |
+| `dev.cwchanap.vela.oauth:/oauth/callback` | Receives the authorization code after Google sign-in |
+| `dev.cwchanap.vela.oauth:/oauth/logout`   | Receives the redirect after Cognito sign-out         |
 
-The scheme is the reverse-DNS of the project-controlled `vela.cwchanap.dev` domain with an `.oauth` suffix (i.e. `dev.cwchanap.vela.oauth`), rather than the bundle id, because `vela.app` is not a controlled namespace and custom URL schemes are an unowned namespace on iOS.
+The scheme is the reverse-DNS of the project-controlled `vela.cwchanap.dev` domain with an `.oauth` suffix (i.e. `dev.cwchanap.vela.oauth`), rather than the bundle id, because `vela.app` is not a controlled namespace and custom URL schemes are an unowned namespace on iOS. The URIs use the RFC 8252 §7.1 private-use URI form (single slash, no authority component) — `scheme:/path`, not `scheme://host/path` — because there is no naming authority for custom URL schemes.
 
 `AppDelegate.application(_:open:options:)` already forwards opens to Capacitor's `ApplicationDelegateProxy`. This is only relevant if the M2 client-side flow uses `@capacitor/browser` + `@capacitor/app` — if M2 uses `ASWebAuthenticationSession` instead, the callback arrives through the session's completion handler and `AppDelegate` is bypassed entirely.
 
 CDK env vars (defaults shown):
 
 ```dotenv
-COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth://oauth/callback
-COGNITO_MOBILE_LOGOUT_URLS=dev.cwchanap.vela.oauth://oauth/logout
+COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth:/oauth/callback
+COGNITO_MOBILE_LOGOUT_URLS=dev.cwchanap.vela.oauth:/oauth/logout
 ```
 
-Both accept comma-separated lists for dev/QA overrides. **Override URIs must use the `dev.cwchanap.vela.oauth://` scheme** — CDK validates this at synth time and throws otherwise, because iOS only registers that one scheme. Vary the path, not the scheme. The mobile client ID is published as the `CognitoMobileUserPoolClientId` CloudFormation output.
+Both accept comma-separated lists for dev/QA overrides. **Override URIs must use the `dev.cwchanap.vela.oauth:/` scheme** (RFC 8252 §7.1 private-use form, single slash) and an allowed path (`/oauth/callback` or `/oauth/staging-callback` for callbacks; `/oauth/logout` or `/oauth/staging-logout` for logouts) — CDK validates both at synth time and throws otherwise, because iOS only registers that one scheme and the app's router only handles known paths. Vary the path within the allowlist, not the scheme or URI form. The mobile client ID is published as the `CognitoMobileUserPoolClientId` CloudFormation output.
 
 The following M2 work is required before the mobile OAuth flow can complete end-to-end (out of scope for HPA-203):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ Vela uses **Google-only OAuth** via Cognito Hosted UI. There is no password-base
 
 ### Mobile client (iOS)
 
-Vela Mobile authenticates against the same Cognito user pool as the web app, through a dedicated **public** app client (`vela-mobile-client`). The mobile OAuth flow uses authorization-code grant + PKCE; no client secret is bundled in the app binary.
+Vela Mobile authenticates against the same Cognito user pool as the web app, through a dedicated **public** app client (`vela-mobile-client`). The client is configured for authorization-code grant with no client secret bundled in the app binary. PKCE, `state`, and `nonce` validation are implemented client-side in M2 (see below) before mobile sign-in is enabled; the M1 client is PKCE-_compatible_ (public, auth-code grant) but does not yet perform the PKCE flow.
 
 The iOS callback uses a custom URL scheme registered in `apps/vela-mobile/src-capacitor/ios/App/App/Info.plist`:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,7 @@ The following M2 work is required before the mobile OAuth flow can complete end-
 2. Wire the mobile client ID into the Capacitor build.
 3. If API calls go through WKWebView, add `capacitor://localhost` to the API CORS allow-list.
 4. Implement PKCE + `state` + `nonce` in the client-side OAuth flow.
+5. Route the authorization request with `identity_provider=Google` (the web app's established pattern via `signInWithRedirect({ provider: 'Google' })`) so the Cognito `/oauth2/authorize` endpoint redirects straight to Google and never renders the Cognito login selection page. Neither the web nor the mobile app pool client has a `CfnManagedLoginBranding` or `CfnUserPoolUICustomizationAttachment` resource — the Cognito Hosted UI / managed-login page is intentionally unused. If M2 instead opens the interactive Cognito page (e.g. without the `identity_provider` parameter), add a branding resource for the mobile client first, or add an authorization-endpoint smoke test that proves the direct-provider redirect.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,13 @@ bun cdk:deploy   # Deploy to AWS
 bun lambda:build # Build Lambda bundle via esbuild
 ```
 
+`CDK_SPA_DIST_PATH` env var overrides the SPA dist path that `StaticWebStack`
+deploys. `Source.asset` stats the directory at synth time, so a fresh checkout
+without a built SPA (`bun run build` in `apps/vela`) fails before any test
+runs. The CDK unit tests set `CDK_SPA_DIST_PATH` to a temp directory to break
+that dependency; set it explicitly when running `cdk:synth` against a non-default
+build output.
+
 ## Architecture
 
 ### Key cross-package pattern

--- a/apps/vela-mobile/src-capacitor/ios/App/App/Info.plist
+++ b/apps/vela-mobile/src-capacitor/ios/App/App/Info.plist
@@ -45,5 +45,18 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>dev.cwchanap.vela.oauth</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/apps/vela-mobile/src/ios/info-plist.test.ts
+++ b/apps/vela-mobile/src/ios/info-plist.test.ts
@@ -25,16 +25,59 @@ function extractSchemes(xml: string): string[] {
 // been observed to drop while leaving CFBundleURLSchemes intact.
 //
 // The CFBundleURLTypes <array> contains a nested <array> (CFBundleURLSchemes),
-// so a non-greedy match on the outer array would stop at the inner </array>.
-// Anchor on `</array>\s*</dict>\s*</plist>` — the root plist dict close — to
-// uniquely identify the outer CFBundleURLTypes array.
+// so a non-greedy regex on the outer array would stop at the inner </array>.
+// Tracking <array>/</array> depth from the CFBundleURLTypes key is robust to
+// any sibling keys appended after it (NSAppTransportSecurity, etc.) — a
+// previous regex anchored on `</dict>\s*</plist>` and would silently return
+// null (false alarm) the moment CFBundleURLTypes was no longer the last key.
 function extractUrlTypeEntry(xml: string): string | null {
-  const blockMatch = xml.match(
-    /<key>CFBundleURLTypes<\/key>\s*<array>([\s\S]*?)<\/array>\s*<\/dict>\s*<\/plist>/,
-  );
-  if (!blockMatch) return null;
-  const dictMatch = blockMatch[1].match(/<dict>([\s\S]*?)<\/dict>/);
-  return dictMatch ? dictMatch[1] : null;
+  const keyIdx = xml.indexOf('<key>CFBundleURLTypes</key>');
+  if (keyIdx === -1) return null;
+  const afterKey = xml.slice(keyIdx);
+  const arrayOpen = afterKey.match(/\s*<array>/);
+  if (!arrayOpen) return null;
+  const start = keyIdx + afterKey.indexOf('<array>') + '<array>'.length;
+
+  // Walk <array>/</array> tags to find the matching close of the outer array.
+  let depth = 1;
+  let i = start;
+  const tag = /<\/?array>/g;
+  tag.lastIndex = start;
+  let match: RegExpExecArray | null;
+  while ((match = tag.exec(xml)) !== null) {
+    depth += match[0] === '<array>' ? 1 : -1;
+    if (depth === 0) {
+      i = match.index;
+      break;
+    }
+  }
+  if (depth !== 0) return null;
+  const outerArrayBody = xml.slice(start, i);
+
+  // Extract the first top-level <dict>...</dict> inside the outer array,
+  // tracking <dict>/</dict> depth so nested dicts don't trip the match.
+  const dictOpenIdx = outerArrayBody.indexOf('<dict>');
+  if (dictOpenIdx === -1) return null;
+  let d = 0;
+  let dictStart = -1;
+  let dictEnd = -1;
+  const dt = /<\/?dict>/g;
+  dt.lastIndex = dictOpenIdx;
+  let dm: RegExpExecArray | null;
+  while ((dm = dt.exec(outerArrayBody)) !== null) {
+    if (dm[0] === '<dict>') {
+      if (d === 0) dictStart = dm.index + '<dict>'.length;
+      d += 1;
+    } else {
+      d -= 1;
+      if (d === 0) {
+        dictEnd = dm.index;
+        break;
+      }
+    }
+  }
+  if (dictStart === -1 || dictEnd === -1) return null;
+  return outerArrayBody.slice(dictStart, dictEnd);
 }
 
 function extractKeyValue(xml: string, key: string): string | null {

--- a/apps/vela-mobile/src/ios/info-plist.test.ts
+++ b/apps/vela-mobile/src/ios/info-plist.test.ts
@@ -20,9 +20,50 @@ function extractSchemes(xml: string): string[] {
   return schemes;
 }
 
+// Extract the first <dict> inside CFBundleURLTypes so we can assert on the
+// sibling keys (CFBundleURLName, CFBundleTypeRole) that Capacitor syncs have
+// been observed to drop while leaving CFBundleURLSchemes intact.
+//
+// The CFBundleURLTypes <array> contains a nested <array> (CFBundleURLSchemes),
+// so a non-greedy match on the outer array would stop at the inner </array>.
+// Anchor on `</array>\s*</dict>\s*</plist>` — the root plist dict close — to
+// uniquely identify the outer CFBundleURLTypes array.
+function extractUrlTypeEntry(xml: string): string | null {
+  const blockMatch = xml.match(
+    /<key>CFBundleURLTypes<\/key>\s*<array>([\s\S]*?)<\/array>\s*<\/dict>\s*<\/plist>/,
+  );
+  if (!blockMatch) return null;
+  const dictMatch = blockMatch[1].match(/<dict>([\s\S]*?)<\/dict>/);
+  return dictMatch ? dictMatch[1] : null;
+}
+
+function extractKeyValue(xml: string, key: string): string | null {
+  const re = new RegExp(`<key>${key}</key>\\s*<string>([^<]+)</string>`);
+  const m = xml.match(re);
+  return m ? m[1] : null;
+}
+
 describe('iOS Info.plist', () => {
   test('registers the dev.cwchanap.vela.oauth custom URL scheme', () => {
     const schemes = extractSchemes(plistContent);
     expect(schemes).toContain('dev.cwchanap.vela.oauth');
+  });
+
+  test('CFBundleURLTypes entry declares CFBundleURLName and CFBundleTypeRole', () => {
+    const entry = extractUrlTypeEntry(plistContent);
+    expect(
+      entry,
+      'CFBundleURLTypes dict entry missing — Capacitor sync may have wiped it',
+    ).not.toBeNull();
+    if (!entry) return;
+
+    const urlName = extractKeyValue(entry, 'CFBundleURLName');
+    const typeRole = extractKeyValue(entry, 'CFBundleTypeRole');
+
+    expect(urlName, 'CFBundleURLName missing inside CFBundleURLTypes dict').not.toBeNull();
+    expect(typeRole, 'CFBundleTypeRole missing inside CFBundleURLTypes dict').not.toBeNull();
+    // Editor is the correct role for an app that handles OAuth callbacks it
+    // initiates; Viewer would still work but Editor is the documented convention.
+    expect(typeRole).toBe('Editor');
   });
 });

--- a/apps/vela-mobile/src/ios/info-plist.test.ts
+++ b/apps/vela-mobile/src/ios/info-plist.test.ts
@@ -8,6 +8,17 @@ import { describe, expect, test } from 'vitest';
 const plistPath = resolve(__dirname, '../../src-capacitor/ios/App/App/Info.plist');
 const plistContent = readFileSync(plistPath, 'utf8');
 
+// Binary plists start with `bplist00`. Xcode occasionally converts Info.plist
+// to binary format (e.g. after a merge conflict resolution or an Xcode
+// version upgrade). The regex-based extractors below return null/empty on
+// binary plists, which would surface as misleading "Capacitor sync wiped
+// CFBundleURLTypes" failures. Fail fast with a clear message instead.
+if (plistContent.startsWith('bplist')) {
+  throw new Error(
+    `${plistPath} is a binary plist. Convert it back to XML: plutil -convert xml1 "${plistPath}". The Info.plist test assumes XML text.`,
+  );
+}
+
 function extractSchemes(xml: string): string[] {
   const schemes: string[] = [];
   const blockMatch = xml.match(/<key>CFBundleURLSchemes<\/key>\s*<array>([\s\S]*?)<\/array>/);

--- a/apps/vela-mobile/src/ios/info-plist.test.ts
+++ b/apps/vela-mobile/src/ios/info-plist.test.ts
@@ -73,20 +73,20 @@ function extractUrlTypeEntry(xml: string): string | null {
   // tracking <dict>/</dict> depth so nested dicts don't trip the match.
   const dictOpenIdx = outerArrayBody.indexOf('<dict>');
   if (dictOpenIdx === -1) return null;
-  let d = 0;
+  let dictDepth = 0;
   let dictStart = -1;
   let dictEnd = -1;
-  const dt = /<\/?dict>/g;
-  dt.lastIndex = dictOpenIdx;
-  let dm: RegExpExecArray | null;
-  while ((dm = dt.exec(outerArrayBody)) !== null) {
-    if (dm[0] === '<dict>') {
-      if (d === 0) dictStart = dm.index + '<dict>'.length;
-      d += 1;
+  const dictTagRegex = /<\/?dict>/g;
+  dictTagRegex.lastIndex = dictOpenIdx;
+  let dictMatch: RegExpExecArray | null;
+  while ((dictMatch = dictTagRegex.exec(outerArrayBody)) !== null) {
+    if (dictMatch[0] === '<dict>') {
+      if (dictDepth === 0) dictStart = dictMatch.index + '<dict>'.length;
+      dictDepth += 1;
     } else {
-      d -= 1;
-      if (d === 0) {
-        dictEnd = dm.index;
+      dictDepth -= 1;
+      if (dictDepth === 0) {
+        dictEnd = dictMatch.index;
         break;
       }
     }

--- a/apps/vela-mobile/src/ios/info-plist.test.ts
+++ b/apps/vela-mobile/src/ios/info-plist.test.ts
@@ -12,12 +12,10 @@ const plistContent = readFileSync(plistPath, 'utf8');
 // to binary format (e.g. after a merge conflict resolution or an Xcode
 // version upgrade). The regex-based extractors below return null/empty on
 // binary plists, which would surface as misleading "Capacitor sync wiped
-// CFBundleURLTypes" failures. Fail fast with a clear message instead.
-if (plistContent.startsWith('bplist')) {
-  throw new Error(
-    `${plistPath} is a binary plist. Convert it back to XML: plutil -convert xml1 "${plistPath}". The Info.plist test assumes XML text.`,
-  );
-}
+// CFBundleURLTypes" failures. Wrapped in a test() so a binary plist surfaces
+// as a named per-test failure with a clear remediation message, instead of a
+// module-load error that obscures which test file failed.
+const isBinaryPlist = plistContent.startsWith('bplist');
 
 function extractSchemes(xml: string): string[] {
   const schemes: string[] = [];
@@ -102,6 +100,16 @@ function extractKeyValue(xml: string, key: string): string | null {
 }
 
 describe('iOS Info.plist', () => {
+  test('Info.plist is XML, not binary', () => {
+    // Fail fast with a clear remediation message before the regex-based
+    // assertions below would produce misleading "Capacitor sync wiped
+    // CFBundleURLTypes" failures on a binary plist.
+    expect(
+      !isBinaryPlist,
+      `${plistPath} is a binary plist. Convert it back to XML: plutil -convert xml1 "${plistPath}". The Info.plist test assumes XML text.`,
+    ).toBe(true);
+  });
+
   test('registers the dev.cwchanap.vela.oauth custom URL scheme', () => {
     const schemes = extractSchemes(plistContent);
     expect(schemes).toContain('dev.cwchanap.vela.oauth');

--- a/apps/vela-mobile/src/ios/info-plist.test.ts
+++ b/apps/vela-mobile/src/ios/info-plist.test.ts
@@ -47,8 +47,11 @@ function extractUrlTypeEntry(xml: string): string | null {
   if (keyIdx === -1) return null;
   const afterKey = xml.slice(keyIdx);
   const arrayOpen = afterKey.match(/\s*<array>/);
-  if (!arrayOpen) return null;
-  const start = keyIdx + afterKey.indexOf('<array>') + '<array>'.length;
+  if (!arrayOpen || arrayOpen.index === undefined) return null;
+  // arrayOpen.index points at the start of the leading whitespace; arrayOpen[0]
+  // is the full match including that whitespace, so its length lands us right
+  // after the opening <array> tag.
+  const start = keyIdx + arrayOpen.index + arrayOpen[0].length;
 
   // Walk <array>/</array> tags to find the matching close of the outer array.
   let depth = 1;

--- a/apps/vela-mobile/src/ios/info-plist.test.ts
+++ b/apps/vela-mobile/src/ios/info-plist.test.ts
@@ -22,11 +22,12 @@ if (plistContent.startsWith('bplist')) {
 function extractSchemes(xml: string): string[] {
   const schemes: string[] = [];
   const blockMatch = xml.match(/<key>CFBundleURLSchemes<\/key>\s*<array>([\s\S]*?)<\/array>/);
-  if (!blockMatch) return schemes;
+  if (!blockMatch || blockMatch[1] === undefined) return schemes;
+  const blockBody = blockMatch[1];
   const stringRegex = /<string>([^<]+)<\/string>/g;
   let match: RegExpExecArray | null;
-  while ((match = stringRegex.exec(blockMatch[1])) !== null) {
-    schemes.push(match[1]);
+  while ((match = stringRegex.exec(blockBody)) !== null) {
+    if (match[1] !== undefined) schemes.push(match[1]);
   }
   return schemes;
 }
@@ -94,7 +95,7 @@ function extractUrlTypeEntry(xml: string): string | null {
 function extractKeyValue(xml: string, key: string): string | null {
   const re = new RegExp(`<key>${key}</key>\\s*<string>([^<]+)</string>`);
   const m = xml.match(re);
-  return m ? m[1] : null;
+  return m && m[1] !== undefined ? m[1] : null;
 }
 
 describe('iOS Info.plist', () => {

--- a/apps/vela-mobile/src/ios/info-plist.test.ts
+++ b/apps/vela-mobile/src/ios/info-plist.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+// Parse the plist as XML without adding a runtime dependency.
+// The Info.plist is small and stable; a regex on the raw text is enough
+// to catch "a Capacitor sync wiped the CFBundleURLTypes entry".
+const plistPath = resolve(__dirname, '../../src-capacitor/ios/App/App/Info.plist');
+const plistContent = readFileSync(plistPath, 'utf8');
+
+function extractSchemes(xml: string): string[] {
+  const schemes: string[] = [];
+  const blockMatch = xml.match(/<key>CFBundleURLSchemes<\/key>\s*<array>([\s\S]*?)<\/array>/);
+  if (!blockMatch) return schemes;
+  const stringRegex = /<string>([^<]+)<\/string>/g;
+  let match: RegExpExecArray | null;
+  while ((match = stringRegex.exec(blockMatch[1])) !== null) {
+    schemes.push(match[1]);
+  }
+  return schemes;
+}
+
+describe('iOS Info.plist', () => {
+  test('registers the dev.cwchanap.vela.oauth custom URL scheme', () => {
+    const schemes = extractSchemes(plistContent);
+    expect(schemes).toContain('dev.cwchanap.vela.oauth');
+  });
+});

--- a/docs/superpowers/plans/2026-07-19-mobile-mvp-m1-cognito-mobile-oauth-client.md
+++ b/docs/superpowers/plans/2026-07-19-mobile-mvp-m1-cognito-mobile-oauth-client.md
@@ -14,10 +14,10 @@
 
 - Custom OAuth scheme is **`dev.cwchanap.vela.oauth`** (reverse-DNS of the controlled `vela.cwchanap.dev` domain; do NOT use `com.vela.app` — that's the bundle id, separate namespace).
 - Bundle id stays `com.vela.app`; only the OAuth scheme changes.
-- Callback URI: `dev.cwchanap.vela.oauth://oauth/callback`. Logout URI: `dev.cwchanap.vela.oauth://oauth/logout`.
+- Callback URI: `dev.cwchanap.vela.oauth:/oauth/callback`. Logout URI: `dev.cwchanap.vela.oauth:/oauth/logout`.
 - The mobile client MUST be public: `generateSecret: false` (explicit, not implicit default).
 - Web and test client behaviour must remain unchanged. Existing tests that count clients or use unpinned `hasResourceProperties` must be updated to pin `ClientName: 'vela-web-client'` where they were implicitly asserting the web client's contract.
-- Mobile callback/logout URI overrides via `COGNITO_MOBILE_CALLBACK_URLS` / `COGNITO_MOBILE_LOGOUT_URLS` MUST be validated to use the registered scheme; a typo like `dev.cwchanap.vela.dev://...` must throw at synth time, not deploy silently.
+- Mobile callback/logout URI overrides via `COGNITO_MOBILE_CALLBACK_URLS` / `COGNITO_MOBILE_LOGOUT_URLS` MUST be validated to use the registered scheme; a typo like `dev.cwchanap.vela.dev:/...` must throw at synth time, not deploy silently.
 - Documentation target is **`CLAUDE.md`** at the repo root (`AGENTS.md` is a symlink to it).
 - M2 prerequisites (API JWT verifier widening, mobile client ID injection, Capacitor OAuth integration, `state`/`nonce`) are **out of scope** — the spec documents them, this plan does not implement them.
 
@@ -53,7 +53,7 @@
 **Interfaces:**
 
 - Produces: `AuthStack.mobileUserPoolClient: UserPoolClient` (new public readonly field). Consumed by `StaticWebStack` in Task 3.
-- Produces: synth-time `Error` from `assertMobileScheme()` when `COGNITO_MOBILE_CALLBACK_URLS` / `COGNITO_MOBILE_LOGOUT_URLS` contains a URI that does not start with `dev.cwchanap.vela.oauth://`.
+- Produces: synth-time `Error` from `assertMobileRedirect()` when `COGNITO_MOBILE_CALLBACK_URLS` / `COGNITO_MOBILE_LOGOUT_URLS` contains a URI that does not start with `dev.cwchanap.vela.oauth:/`.
 
 - [ ] **Step 1: Refactor the test helper to expose the stack instance**
 
@@ -91,8 +91,8 @@ test('mobile client uses the iOS custom-scheme callback and logout URIs', () => 
 
   template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
     ClientName: 'vela-mobile-client',
-    CallbackURLs: ['dev.cwchanap.vela.oauth://oauth/callback'],
-    LogoutURLs: ['dev.cwchanap.vela.oauth://oauth/logout'],
+    CallbackURLs: ['dev.cwchanap.vela.oauth:/oauth/callback'],
+    LogoutURLs: ['dev.cwchanap.vela.oauth:/oauth/logout'],
   });
 });
 
@@ -115,8 +115,8 @@ test('creates a dedicated public mobile client with PKCE-compatible OAuth', () =
 
 test('mobile callback/logout URIs are overridable via env vars (same-scheme only)', () => {
   process.env.COGNITO_MOBILE_CALLBACK_URLS =
-    'dev.cwchanap.vela.oauth://oauth/staging-callback,dev.cwchanap.vela.oauth://oauth/callback';
-  process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://oauth/staging-logout';
+    'dev.cwchanap.vela.oauth:/oauth/staging-callback,dev.cwchanap.vela.oauth:/oauth/callback';
+  process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth:/oauth/staging-logout';
 
   const template = synthesizeTemplate();
   const clients = template.findResources('AWS::Cognito::UserPoolClient');
@@ -125,10 +125,10 @@ test('mobile callback/logout URIs are overridable via env vars (same-scheme only
 
   const mobile = byName('vela-mobile-client');
   expect(mobile!.Properties.CallbackURLs).toEqual([
-    'dev.cwchanap.vela.oauth://oauth/staging-callback',
-    'dev.cwchanap.vela.oauth://oauth/callback',
+    'dev.cwchanap.vela.oauth:/oauth/staging-callback',
+    'dev.cwchanap.vela.oauth:/oauth/callback',
   ]);
-  expect(mobile!.Properties.LogoutURLs).toEqual(['dev.cwchanap.vela.oauth://oauth/staging-logout']);
+  expect(mobile!.Properties.LogoutURLs).toEqual(['dev.cwchanap.vela.oauth:/oauth/staging-logout']);
 
   const web = byName('vela-web-client');
   expect(web!.Properties.CallbackURLs).toEqual(
@@ -153,23 +153,23 @@ test('mobile callback/logout URIs fall back to defaults when env vars are empty'
 
   template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
     ClientName: 'vela-mobile-client',
-    CallbackURLs: ['dev.cwchanap.vela.oauth://oauth/callback'],
-    LogoutURLs: ['dev.cwchanap.vela.oauth://oauth/logout'],
+    CallbackURLs: ['dev.cwchanap.vela.oauth:/oauth/callback'],
+    LogoutURLs: ['dev.cwchanap.vela.oauth:/oauth/logout'],
   });
 });
 
 test('rejects mobile callback/logout URIs that do not use the registered scheme', () => {
-  process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.dev://oauth/callback';
+  process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.dev:/oauth/callback';
 
   expect(() => synthesizeTemplate()).toThrow(
-    /COGNITO_MOBILE_CALLBACK_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme/,
+    /COGNITO_MOBILE_CALLBACK_URLS must use the dev\.cwchanap\.vela\.oauth:\/ scheme/,
   );
 
   process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
-  process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.dev://oauth/logout';
+  process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.dev:/oauth/logout';
 
   expect(() => synthesizeTemplate()).toThrow(
-    /COGNITO_MOBILE_LOGOUT_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme/,
+    /COGNITO_MOBILE_LOGOUT_URLS must use the dev\.cwchanap\.vela\.oauth:\/ scheme/,
   );
 });
 
@@ -233,23 +233,23 @@ In `packages/cdk/lib/auth-stack.ts`, immediately after the existing `LOCAL_LOGOU
 
 ```ts
 const MOBILE_OAUTH_SCHEME = 'dev.cwchanap.vela.oauth';
-const DEFAULT_MOBILE_CALLBACK_URLS = [`${MOBILE_OAUTH_SCHEME}://oauth/callback`];
-const DEFAULT_MOBILE_LOGOUT_URLS = [`${MOBILE_OAUTH_SCHEME}://oauth/logout`];
+const DEFAULT_MOBILE_CALLBACK_URLS = [`${MOBILE_OAUTH_SCHEME}:/oauth/callback`];
+const DEFAULT_MOBILE_LOGOUT_URLS = [`${MOBILE_OAUTH_SCHEME}:/oauth/logout`];
+
+const MOBILE_CALLBACK_PATHS = ['/oauth/callback', '/oauth/staging-callback'];
+const MOBILE_LOGOUT_PATHS = ['/oauth/logout', '/oauth/staging-logout'];
 
 /**
- * Reject mobile callback/logout URIs that do not use the registered iOS scheme
- * or that use the right scheme with an empty/invalid path. `parseCommaList` is
- * permissive on its own; without this guard a typo like
- * `dev.cwchanap.vela.dev://...` (wrong scheme) or
- * `dev.cwchanap.vela.oauth://` (empty path) would synthesise + deploy
- * successfully and then fail silently on-device: a wrong scheme means iOS
- * would not dispatch the URL to this app at all, and an empty path means
- * iOS would deliver the URL but the app's router would have no matching
- * route.
+ * Reject mobile callback/logout URIs that do not use the registered iOS
+ * scheme, the RFC 8252 §7.1 private-use URI form, or an allowed route path.
+ * `parseCommaList` is permissive on its own; without this guard a typo like
+ * `dev.cwchanap.vela.dev:/...` (wrong scheme) or
+ * `dev.cwchanap.vela.oauth:/oauth/typo` (path not in allowlist) would
+ * synthesise + deploy successfully and then fail silently on-device.
  *
- * Four checks, in order: case-sensitive scheme prefix, raw-string fragment
+ * Checks, in order: case-sensitive scheme prefix, raw-string fragment
  * (`#`), raw-string whitespace, then a WHATWG URL parse for structural
- * validation (non-empty path).
+ * validation (no authority + path in allowlist).
  *
  * The raw-string fragment and whitespace checks come BEFORE `new URL()`
  * because the WHATWG parser normalises away exactly the characters Cognito
@@ -259,20 +259,17 @@ const DEFAULT_MOBILE_LOGOUT_URLS = [`${MOBILE_OAUTH_SCHEME}://oauth/logout`];
  * through; the raw string is what Cognito receives, so it is what must be
  * checked.
  *
- * Structural validation uses `new URL()` rather than a regex because a
- * regex like `[^\s?#]+` cannot distinguish authority from path in a custom
- * scheme. `dev.cwchanap.vela.oauth://oauth` (authority-only, empty
- * pathname) would pass such a regex — `oauth` matches the path character
- * class — but WHATWG assigns `oauth` to `host` and leaves `pathname` empty.
- * That authority-only case is exactly the kind of fat-fingered config
- * (missing `/callback` or `/logout`) this validator exists to catch.
+ * URI form: RFC 8252 §7.1 requires the single-slash form (`scheme:/path`)
+ * for private-use URI schemes because there is no naming authority. The
+ * `scheme://host/path` (authority) form is rejected — `parsed.host !== ''`
+ * catches it after parsing.
  */
-function assertMobileScheme(label: string, uris: string[]): void {
-  const schemePrefix = `${MOBILE_OAUTH_SCHEME}://`;
+function assertMobileRedirect(label: string, uris: string[], allowedPaths: string[]): void {
+  const schemePrefix = `${MOBILE_OAUTH_SCHEME}:/`;
   for (const uri of uris) {
     if (!uri.startsWith(schemePrefix)) {
       throw new Error(
-        `${label} must use the ${MOBILE_OAUTH_SCHEME}:// scheme (Info.plist only registers that scheme). Got: ${uri}`,
+        `${label} must use the ${MOBILE_OAUTH_SCHEME}:/ scheme (Info.plist only registers that scheme). Got: ${uri}`,
       );
     }
     if (uri.includes('#')) {
@@ -290,12 +287,17 @@ function assertMobileScheme(label: string, uris: string[]): void {
       parsed = new URL(uri);
     } catch {
       throw new Error(
-        `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path; the app's router would have no matching route). Got: ${uri}`,
+        `${label} must include a valid path after ${MOBILE_OAUTH_SCHEME}:/ (the app's router has no matching route for other paths). Got: ${uri}`,
       );
     }
-    if (parsed.pathname === '' || parsed.pathname === '/') {
+    if (parsed.host !== '') {
       throw new Error(
-        `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path; the app's router would have no matching route). Got: ${uri}`,
+        `${label} must use the ${MOBILE_OAUTH_SCHEME}:/ form (no authority component), not ${MOBILE_OAUTH_SCHEME}://. RFC 8252 §7.1 requires a single slash for private-use URI schemes. Got: ${uri}`,
+      );
+    }
+    if (!allowedPaths.includes(parsed.pathname)) {
+      throw new Error(
+        `${label} path must be one of [${allowedPaths.join(', ')}] (the app's router has no matching route for other paths). Got: ${uri}`,
       );
     }
   }
@@ -323,8 +325,8 @@ const mobileLogoutUrls = parseCommaList(
   process.env.COGNITO_MOBILE_LOGOUT_URLS,
   DEFAULT_MOBILE_LOGOUT_URLS,
 );
-assertMobileScheme('COGNITO_MOBILE_CALLBACK_URLS', mobileCallbackUrls);
-assertMobileScheme('COGNITO_MOBILE_LOGOUT_URLS', mobileLogoutUrls);
+assertMobileRedirect('COGNITO_MOBILE_CALLBACK_URLS', mobileCallbackUrls, MOBILE_CALLBACK_PATHS);
+assertMobileRedirect('COGNITO_MOBILE_LOGOUT_URLS', mobileLogoutUrls, MOBILE_LOGOUT_PATHS);
 
 const mobileUserPoolClient = new UserPoolClient(this, 'VelaMobileUserPoolClient', {
   userPool,
@@ -408,7 +410,7 @@ git commit -m "feat(cdk): add vela-mobile-client for iOS OAuth (HPA-203)
   no client secret (generateSecret: false explicit).
 - Add synth-time scheme validation: throws if COGNITO_MOBILE_CALLBACK_URLS
   or COGNITO_MOBILE_LOGOUT_URLS contains a URI that does not use the
-  registered dev.cwchanap.vela.oauth:// scheme.
+  registered dev.cwchanap.vela.oauth:/ scheme.
 - Pin three existing nameless hasResourceProperties tests to
   ClientName: 'vela-web-client' to avoid multi-match ambiguity.
 - Update two literal-count assertions (2 -> 3 clients)."
@@ -563,7 +565,7 @@ reference VelaMobileUserPoolClient, not the web or test client."
 
 **Interfaces:**
 
-- Produces: an iOS custom URL scheme declaration. iOS will hand URLs of the form `dev.cwchanap.vela.oauth://…` to the app via `AppDelegate.application(_:open:options:)` (already wired to `ApplicationDelegateProxy.shared`). No Swift changes.
+- Produces: an iOS custom URL scheme declaration. iOS will hand URLs of the form `dev.cwchanap.vela.oauth:/…` to the app via `AppDelegate.application(_:open:options:)` (already wired to `ApplicationDelegateProxy.shared`). No Swift changes.
 
 - [ ] **Step 1: Write the failing plist scheme-registration test**
 
@@ -642,7 +644,7 @@ git add apps/vela-mobile/src-capacitor/ios/App/App/Info.plist apps/vela-mobile/s
 git commit -m "feat(mobile): register dev.cwchanap.vela.oauth URL scheme (HPA-203)
 
 Adds CFBundleURLTypes to Info.plist so iOS hands OAuth callback URLs of
-the form dev.cwchanap.vela.oauth://... to the Vela app. AppDelegate
+the form dev.cwchanap.vela.oauth:/... to the Vela app. AppDelegate
 already forwards opens through ApplicationDelegateProxy.shared, so no
 Swift changes are needed. The scheme is rooted at cwchanap.dev (a
 project-controlled domain) rather than the bundle id (com.vela.app)
@@ -674,10 +676,10 @@ Vela Mobile authenticates against the same Cognito user pool as the web app, thr
 
 The iOS callback uses a custom URL scheme registered in `apps/vela-mobile/src-capacitor/ios/App/App/Info.plist`:
 
-| URI                                        | Purpose                                              |
-| ------------------------------------------ | ---------------------------------------------------- |
-| `dev.cwchanap.vela.oauth://oauth/callback` | Receives the authorization code after Google sign-in |
-| `dev.cwchanap.vela.oauth://oauth/logout`   | Receives the redirect after Cognito sign-out         |
+| URI                                       | Purpose                                              |
+| ----------------------------------------- | ---------------------------------------------------- |
+| `dev.cwchanap.vela.oauth:/oauth/callback` | Receives the authorization code after Google sign-in |
+| `dev.cwchanap.vela.oauth:/oauth/logout`   | Receives the redirect after Cognito sign-out         |
 
 The scheme is rooted at `cwchanap.dev` (a project-controlled domain) rather than the bundle id, because `vela.app` is not a controlled namespace and custom URL schemes are an unowned namespace on iOS.
 
@@ -686,11 +688,11 @@ The scheme is rooted at `cwchanap.dev` (a project-controlled domain) rather than
 CDK env vars (defaults shown):
 
 ```dotenv
-COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth://oauth/callback
-COGNITO_MOBILE_LOGOUT_URLS=dev.cwchanap.vela.oauth://oauth/logout
+COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth:/oauth/callback
+COGNITO_MOBILE_LOGOUT_URLS=dev.cwchanap.vela.oauth:/oauth/logout
 ```
 
-Both accept comma-separated lists for dev/QA overrides. **Override URIs must use the `dev.cwchanap.vela.oauth://` scheme** — CDK validates this at synth time and throws otherwise, because iOS only registers that one scheme. Vary the path, not the scheme. The mobile client ID is published as the `CognitoMobileUserPoolClientId` CloudFormation output.
+Both accept comma-separated lists for dev/QA overrides. **Override URIs must use the `dev.cwchanap.vela.oauth:/` scheme** (RFC 8252 §7.1 private-use form, single slash) and an allowed path — CDK validates both at synth time and throws otherwise, because iOS only registers that one scheme and the app's router only handles known paths. Vary the path within the allowlist, not the scheme or URI form. The mobile client ID is published as the `CognitoMobileUserPoolClientId` CloudFormation output.
 
 The following M2 work is required before the mobile OAuth flow can complete end-to-end (out of scope for HPA-203):
 
@@ -707,9 +709,9 @@ In the root `.env.example`, locate the existing `CORS_ALLOWED_EXTENSION_IDS` lin
 ```dotenv
 
 # CDK deploy-time only (not read by the Quasar apps; do not mirror into apps/*/.env.example)
-# Override URIs MUST use the dev.cwchanap.vela.oauth:// scheme — CDK throws at synth time otherwise.
-COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth://oauth/callback
-COGNITO_MOBILE_LOGOUT_URLS=dev.cwchanap.vela.oauth://oauth/logout
+# Override URIs MUST use the dev.cwchanap.vela.oauth:/ scheme (RFC 8252 §7.1 private-use form) — CDK throws at synth time otherwise.
+COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth:/oauth/callback
+COGNITO_MOBILE_LOGOUT_URLS=dev.cwchanap.vela.oauth:/oauth/logout
 ```
 
 (The leading blank line preserves visual separation from the CORS block above.)

--- a/docs/superpowers/plans/2026-07-19-mobile-mvp-m1-cognito-mobile-oauth-client.md
+++ b/docs/superpowers/plans/2026-07-19-mobile-mvp-m1-cognito-mobile-oauth-client.md
@@ -245,30 +245,53 @@ const DEFAULT_MOBILE_LOGOUT_URLS = [`${MOBILE_OAUTH_SCHEME}://oauth/logout`];
  * successfully and then fail silently on-device because iOS would have no
  * handler registered for the dispatch.
  *
- * Two distinct error branches so the failure message names the actual defect:
- *   1. Wrong scheme  → `${label} must use the ...:// scheme (...)`
- *   2. Right scheme, bad path (empty / whitespace-only / query-only /
- *      fragment-only) → `${label} must include a non-empty, non-whitespace
- *      path after ...:// (...)`
+ * Four checks, in order: case-sensitive scheme prefix, raw-string fragment
+ * (`#`), raw-string whitespace, then a WHATWG URL parse for structural
+ * validation (non-empty path).
  *
- * The path check uses `^\.\.\.://[^\s?#]+\S*$` rather than a naive
- * `startsWith(prefix)` so it also rejects `scheme://` (no path), `scheme:// `
- * (whitespace-only path), `scheme://?query` (query-only, no path), and
- * `scheme://#fragment` (fragment-only, no path) — all of which Cognito would
- * accept but iOS would dispatch to a no-op handler.
+ * The raw-string fragment and whitespace checks come BEFORE `new URL()`
+ * because the WHATWG parser normalises away exactly the characters Cognito
+ * rejects: a trailing `#` (empty fragment) yields `parsed.hash === ''`, and
+ * internal whitespace is percent-encoded (spaces) or silently stripped
+ * (tabs/newlines). Validating the parsed representation would let these
+ * through; the raw string is what Cognito receives, so it is what must be
+ * checked.
+ *
+ * Structural validation uses `new URL()` rather than a regex because a
+ * regex like `[^\s?#]+` cannot distinguish authority from path in a custom
+ * scheme. `dev.cwchanap.vela.oauth://oauth` (authority-only, empty
+ * pathname) would pass such a regex — `oauth` matches the path character
+ * class — but WHATWG assigns `oauth` to `host` and leaves `pathname` empty.
+ * That authority-only case is exactly the kind of fat-fingered config
+ * (missing `/callback` or `/logout`) this validator exists to catch.
  */
 function assertMobileScheme(label: string, uris: string[]): void {
   const schemePrefix = `${MOBILE_OAUTH_SCHEME}://`;
-  const mobileUriPattern = new RegExp(
-    `^${MOBILE_OAUTH_SCHEME.replace(/\./g, '\\.')}://[^\\s?#]+\\S*$`,
-  );
   for (const uri of uris) {
     if (!uri.startsWith(schemePrefix)) {
       throw new Error(
         `${label} must use the ${MOBILE_OAUTH_SCHEME}:// scheme (Info.plist only registers that scheme). Got: ${uri}`,
       );
     }
-    if (!mobileUriPattern.test(uri)) {
+    if (uri.includes('#')) {
+      throw new Error(
+        `${label} must not contain a fragment (Cognito rejects redirect URIs with a \`#\` component). Got: ${uri}`,
+      );
+    }
+    if (/\s/u.test(uri)) {
+      throw new Error(
+        `${label} must not contain whitespace (Cognito rejects redirect URIs containing whitespace characters). Got: ${uri}`,
+      );
+    }
+    let parsed: URL;
+    try {
+      parsed = new URL(uri);
+    } catch {
+      throw new Error(
+        `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device). Got: ${uri}`,
+      );
+    }
+    if (parsed.pathname === '' || parsed.pathname === '/') {
       throw new Error(
         `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device). Got: ${uri}`,
       );

--- a/docs/superpowers/plans/2026-07-19-mobile-mvp-m1-cognito-mobile-oauth-client.md
+++ b/docs/superpowers/plans/2026-07-19-mobile-mvp-m1-cognito-mobile-oauth-client.md
@@ -237,17 +237,40 @@ const DEFAULT_MOBILE_CALLBACK_URLS = [`${MOBILE_OAUTH_SCHEME}://oauth/callback`]
 const DEFAULT_MOBILE_LOGOUT_URLS = [`${MOBILE_OAUTH_SCHEME}://oauth/logout`];
 
 /**
- * Reject mobile callback/logout URIs that do not use the registered iOS scheme.
- * `parseCommaList` is permissive on its own; without this guard a typo like
- * `dev.cwchanap.vela.dev://...` would synthesise + deploy successfully and
- * then fail silently on-device because iOS would have no handler registered.
+ * Reject mobile callback/logout URIs that do not use the registered iOS scheme
+ * or that use the right scheme with an empty/invalid path. `parseCommaList` is
+ * permissive on its own; without this guard a typo like
+ * `dev.cwchanap.vela.dev://...` (wrong scheme) or
+ * `dev.cwchanap.vela.oauth://` (empty path) would synthesise + deploy
+ * successfully and then fail silently on-device because iOS would have no
+ * handler registered for the dispatch.
+ *
+ * Two distinct error branches so the failure message names the actual defect:
+ *   1. Wrong scheme  → `${label} must use the ...:// scheme (...)`
+ *   2. Right scheme, bad path (empty / whitespace-only / query-only /
+ *      fragment-only) → `${label} must include a non-empty, non-whitespace
+ *      path after ...:// (...)`
+ *
+ * The path check uses `^\.\.\.://[^\s?#]+\S*$` rather than a naive
+ * `startsWith(prefix)` so it also rejects `scheme://` (no path), `scheme:// `
+ * (whitespace-only path), `scheme://?query` (query-only, no path), and
+ * `scheme://#fragment` (fragment-only, no path) — all of which Cognito would
+ * accept but iOS would dispatch to a no-op handler.
  */
 function assertMobileScheme(label: string, uris: string[]): void {
-  const prefix = `${MOBILE_OAUTH_SCHEME}://`;
+  const schemePrefix = `${MOBILE_OAUTH_SCHEME}://`;
+  const mobileUriPattern = new RegExp(
+    `^${MOBILE_OAUTH_SCHEME.replace(/\./g, '\\.')}://[^\\s?#]+\\S*$`,
+  );
   for (const uri of uris) {
-    if (!uri.startsWith(prefix)) {
+    if (!uri.startsWith(schemePrefix)) {
       throw new Error(
         `${label} must use the ${MOBILE_OAUTH_SCHEME}:// scheme (Info.plist only registers that scheme). Got: ${uri}`,
+      );
+    }
+    if (!mobileUriPattern.test(uri)) {
+      throw new Error(
+        `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device). Got: ${uri}`,
       );
     }
   }

--- a/docs/superpowers/plans/2026-07-19-mobile-mvp-m1-cognito-mobile-oauth-client.md
+++ b/docs/superpowers/plans/2026-07-19-mobile-mvp-m1-cognito-mobile-oauth-client.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Provision a third Cognito app client (`vela-mobile-client`) configured for public PKCE OAuth, register an iOS custom URL scheme to receive the callback, and expose the new client ID through CloudFormation outputs — without changing the existing web or test client contracts.
+**Goal:** Provision a third Cognito app client (`vela-mobile-client`) configured as a public authorization-code client (PKCE-compatible — the PKCE flow itself is implemented client-side in M2), register an iOS custom URL scheme to receive the callback, and expose the new client ID through CloudFormation outputs — without changing the existing web or test client contracts.
 
 **Architecture:** Inline a third `UserPoolClient` in `packages/cdk/lib/auth-stack.ts` next to the existing web and test clients, with synth-time scheme validation that throws if the mobile callback/logout URIs do not use the registered iOS scheme (`dev.cwchanap.vela.oauth`). Surface the new client ID via a `CognitoMobileUserPoolClientId` output on `StaticWebStack`. Register the scheme in `apps/vela-mobile/src-capacitor/ios/App/App/Info.plist` via `CFBundleURLTypes` (no Swift changes — `AppDelegate` already forwards to `ApplicationDelegateProxy.shared`). Document the result in `CLAUDE.md` and `.env.example`.
 
@@ -242,8 +242,10 @@ const DEFAULT_MOBILE_LOGOUT_URLS = [`${MOBILE_OAUTH_SCHEME}://oauth/logout`];
  * permissive on its own; without this guard a typo like
  * `dev.cwchanap.vela.dev://...` (wrong scheme) or
  * `dev.cwchanap.vela.oauth://` (empty path) would synthesise + deploy
- * successfully and then fail silently on-device because iOS would have no
- * handler registered for the dispatch.
+ * successfully and then fail silently on-device: a wrong scheme means iOS
+ * would not dispatch the URL to this app at all, and an empty path means
+ * iOS would deliver the URL but the app's router would have no matching
+ * route.
  *
  * Four checks, in order: case-sensitive scheme prefix, raw-string fragment
  * (`#`), raw-string whitespace, then a WHATWG URL parse for structural
@@ -288,12 +290,12 @@ function assertMobileScheme(label: string, uris: string[]): void {
       parsed = new URL(uri);
     } catch {
       throw new Error(
-        `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device). Got: ${uri}`,
+        `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path; the app's router would have no matching route). Got: ${uri}`,
       );
     }
     if (parsed.pathname === '' || parsed.pathname === '/') {
       throw new Error(
-        `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device). Got: ${uri}`,
+        `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path; the app's router would have no matching route). Got: ${uri}`,
       );
     }
   }
@@ -525,7 +527,7 @@ In `packages/cdk/lib/static-web-stack.ts`, immediately after the existing `Cogni
 ```ts
 new CfnOutput(this, 'CognitoMobileUserPoolClientId', {
   value: auth.mobileUserPoolClient.userPoolClientId,
-  description: 'Cognito User Pool Client ID for the iOS mobile app (public, PKCE)',
+  description: 'Cognito User Pool Client ID for the iOS mobile app (public, no client secret)',
 });
 ```
 
@@ -668,7 +670,7 @@ In `CLAUDE.md`, locate the `## Authentication` section. Append a new `### Mobile
 ````md
 ### Mobile client (iOS)
 
-Vela Mobile authenticates against the same Cognito user pool as the web app, through a dedicated **public** app client (`vela-mobile-client`). The mobile OAuth flow uses authorization-code grant + PKCE; no client secret is bundled in the app binary.
+Vela Mobile authenticates against the same Cognito user pool as the web app, through a dedicated **public** app client (`vela-mobile-client`). The client is configured for authorization-code grant with no client secret bundled in the app binary. PKCE, `state`, and `nonce` validation are implemented client-side in M2 (see below) before mobile sign-in is enabled; the M1 client is PKCE-_compatible_ (public, auth-code grant) but does not yet perform the PKCE flow.
 
 The iOS callback uses a custom URL scheme registered in `apps/vela-mobile/src-capacitor/ios/App/App/Info.plist`:
 

--- a/docs/superpowers/plans/2026-07-19-mobile-mvp-m1-cognito-mobile-oauth-client.md
+++ b/docs/superpowers/plans/2026-07-19-mobile-mvp-m1-cognito-mobile-oauth-client.md
@@ -378,7 +378,7 @@ git commit -m "feat(cdk): add vela-mobile-client for iOS OAuth (HPA-203)
 **Interfaces:**
 
 - Consumes: `auth.mobileUserPoolClient.userPoolClientId` from Task 1.
-- Produces: a CloudFormation output named `CognitoMobileUserPoolClientId` whose `Value` resolves to the mobile client's logical resource (Fn::GetAtt or Ref), not the web or test client.
+- Produces: a CloudFormation output named `CognitoMobileUserPoolClientId` whose `Value` is an `Fn::ImportValue` of the AuthStack export backed by the mobile client, not the web or test client.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -430,11 +430,15 @@ describe('StaticWebStack', () => {
       storage,
       api,
     });
-    return { stack: staticWeb, template: Template.fromStack(staticWeb) };
+    return {
+      stack: staticWeb,
+      template: Template.fromStack(staticWeb),
+      authTemplate: Template.fromStack(auth),
+    };
   }
 
   test('exposes CognitoMobileUserPoolClientId wired to the mobile client resource', () => {
-    const { template } = synthesize();
+    const { template, authTemplate } = synthesize();
 
     // The output exists.
     const outputs = (template.toJSON().Outputs ?? {}) as Record<
@@ -443,21 +447,22 @@ describe('StaticWebStack', () => {
     >;
     expect(outputs.CognitoMobileUserPoolClientId).toBeDefined();
 
-    // The Value must reference the *mobile* client, not the web or test client.
-    // CDK renders userPoolClientId as { "Fn::GetAtt": ["<logicalId>", "ClientId"] }
-    // in the synthesised template.
+    // AuthStack and StaticWebStack are separate stacks, so CDK renders the
+    // cross-stack reference as an Fn::ImportValue rather than Fn::GetAtt.
     const value = outputs.CognitoMobileUserPoolClientId.Value as Record<string, unknown>;
-    expect(value).toHaveProperty('Fn::GetAtt');
-    const getAtt = value['Fn::GetAtt'] as unknown[];
-    expect(getAtt[0]).toContain('VelaMobileUserPoolClient');
-    expect(String(getAtt[0])).not.toContain('VelaTestUserPoolClient');
-    // The web client's logical id is just 'VelaUserPoolClient' — guard against
-    // a substring false-positive by checking exact-id membership via findResources.
-    const clients = template.findResources('AWS::Cognito::UserPoolClient');
+    expect(value).toHaveProperty('Fn::ImportValue');
+    const importValue = value['Fn::ImportValue'] as string;
+    expect(importValue).toContain('VelaMobileUserPoolClient');
+    expect(importValue).not.toContain('VelaTestUserPoolClient');
+
+    // Confirm the imported export name embeds the logical id of the one
+    // AuthStack client whose ClientName is vela-mobile-client.
+    const clients = authTemplate.findResources('AWS::Cognito::UserPoolClient');
     const mobileLogicalIds = Object.keys(clients).filter(
       (id) => clients[id].Properties?.ClientName === 'vela-mobile-client',
     );
-    expect(mobileLogicalIds).toContain(getAtt[0]);
+    expect(mobileLogicalIds).toHaveLength(1);
+    expect(importValue).toContain(mobileLogicalIds[0]);
   });
 });
 ```
@@ -486,7 +491,7 @@ Expected: the new test PASSES.
 - [ ] **Step 5: Verify CDK synth succeeds and emits the new output**
 
 Run: `cdk:synth` from `packages/cdk/`
-Expected: synthesis completes. The synthesised template's `Outputs` block contains a `CognitoMobileUserPoolClientId` entry whose `Value` is a `Fn::GetAtt` referencing `VelaMobileUserPoolClient`.
+Expected: synthesis completes. The `StaticWebStack` template's `Outputs` block contains a `CognitoMobileUserPoolClientId` entry whose `Value` is an `Fn::ImportValue` of the AuthStack export for `VelaMobileUserPoolClient`.
 
 - [ ] **Step 6: Commit**
 
@@ -614,7 +619,7 @@ it (src-capacitor/ is not in the include list)."
 
 In `CLAUDE.md`, locate the `## Authentication` section. Append a new `### Mobile client (iOS)` subsection at the end of that section (before the next top-level `##` heading):
 
-```md
+````md
 ### Mobile client (iOS)
 
 Vela Mobile authenticates against the same Cognito user pool as the web app, through a dedicated **public** app client (`vela-mobile-client`). The mobile OAuth flow uses authorization-code grant + PKCE; no client secret is bundled in the app binary.
@@ -632,8 +637,10 @@ The scheme is rooted at `cwchanap.dev` (a project-controlled domain) rather than
 
 CDK env vars (defaults shown):
 
-    COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth://oauth/callback
-    COGNITO_MOBILE_LOGOUT_URLS=dev.cwchanap.vela.oauth://oauth/logout
+```dotenv
+COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth://oauth/callback
+COGNITO_MOBILE_LOGOUT_URLS=dev.cwchanap.vela.oauth://oauth/logout
+```
 
 Both accept comma-separated lists for dev/QA overrides. **Override URIs must use the `dev.cwchanap.vela.oauth://` scheme** — CDK validates this at synth time and throws otherwise, because iOS only registers that one scheme. Vary the path, not the scheme. The mobile client ID is published as the `CognitoMobileUserPoolClientId` CloudFormation output.
 
@@ -643,13 +650,13 @@ The following M2 work is required before the mobile OAuth flow can complete end-
 2. Wire the mobile client ID into the Capacitor build.
 3. If API calls go through WKWebView, add `capacitor://localhost` to the API CORS allow-list.
 4. Implement PKCE + `state` + `nonce` in the client-side OAuth flow.
-```
+````
 
 - [ ] **Step 2: Add the CDK deploy-time block to `.env.example`**
 
 In the root `.env.example`, locate the existing `CORS_ALLOWED_EXTENSION_IDS` line (line 29). Immediately after it, insert:
 
-```
+```dotenv
 
 # CDK deploy-time only (not read by the Quasar apps; do not mirror into apps/*/.env.example)
 # Override URIs MUST use the dev.cwchanap.vela.oauth:// scheme — CDK throws at synth time otherwise.
@@ -687,8 +694,8 @@ After all four tasks are complete:
 
 - [ ] **Final check 1:** Run the full CDK test suite: `bun test` from `packages/cdk/`. All tests pass (existing 12 + new mobile-client tests + new StaticWebStack test).
 - [ ] **Final check 2:** Run the mobile test suite: `bun test` from `apps/vela-mobile/`. The new Info.plist test passes alongside all existing tests.
-- [ ] **Final check 3:** Run `cdk:synth` from `packages/cdk/`. Confirm the synthesised template contains:
-  - Three `AWS::Cognito::UserPoolClient` resources named `vela-web-client`, `vela-test-client`, `vela-mobile-client`.
-  - A `CognitoMobileUserPoolClientId` output whose `Value` is a `Fn::GetAtt` on `VelaMobileUserPoolClient`.
+- [ ] **Final check 3:** Run `cdk:synth` from `packages/cdk/`. Confirm the synthesised templates contain:
+  - Three `AWS::Cognito::UserPoolClient` resources named `vela-web-client`, `vela-test-client`, `vela-mobile-client` in `AuthStack`.
+  - A `CognitoMobileUserPoolClientId` output in `StaticWebStack` whose `Value` is an `Fn::ImportValue` of the AuthStack export for `VelaMobileUserPoolClient`.
 - [ ] **Final check 4:** Confirm `AGENTS.md` still symlinks to `CLAUDE.md` and shows the new "Mobile client (iOS)" subsection.
 - [ ] **Final check 5:** Confirm the bundle id is unchanged (`com.vela.app`) — only the OAuth scheme is `dev.cwchanap.vela.oauth`. Check `capacitor.config.json` was not modified.

--- a/docs/superpowers/plans/2026-07-19-mobile-mvp-m1-cognito-mobile-oauth-client.md
+++ b/docs/superpowers/plans/2026-07-19-mobile-mvp-m1-cognito-mobile-oauth-client.md
@@ -1,0 +1,694 @@
+# Mobile MVP M1: Cognito Mobile OAuth Client + iOS Deep-Link Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Provision a third Cognito app client (`vela-mobile-client`) configured for public PKCE OAuth, register an iOS custom URL scheme to receive the callback, and expose the new client ID through CloudFormation outputs — without changing the existing web or test client contracts.
+
+**Architecture:** Inline a third `UserPoolClient` in `packages/cdk/lib/auth-stack.ts` next to the existing web and test clients, with synth-time scheme validation that throws if the mobile callback/logout URIs do not use the registered iOS scheme (`dev.cwchanap.vela.oauth`). Surface the new client ID via a `CognitoMobileUserPoolClientId` output on `StaticWebStack`. Register the scheme in `apps/vela-mobile/src-capacitor/ios/App/App/Info.plist` via `CFBundleURLTypes` (no Swift changes — `AppDelegate` already forwards to `ApplicationDelegateProxy.shared`). Document the result in `CLAUDE.md` and `.env.example`.
+
+**Tech Stack:** AWS CDK v2 (`aws-cdk-lib/aws-cognito`), Bun test runner (CDK tests), Vitest (mobile app tests), Vue/Quasar iOS app via Capacitor, Cognito user pool with Google IdP.
+
+**Spec:** `docs/superpowers/specs/2026-07-19-mobile-mvp-m1-cognito-mobile-oauth-client-design.md`
+
+## Global Constraints
+
+- Custom OAuth scheme is **`dev.cwchanap.vela.oauth`** (reverse-DNS of the controlled `vela.cwchanap.dev` domain; do NOT use `com.vela.app` — that's the bundle id, separate namespace).
+- Bundle id stays `com.vela.app`; only the OAuth scheme changes.
+- Callback URI: `dev.cwchanap.vela.oauth://oauth/callback`. Logout URI: `dev.cwchanap.vela.oauth://oauth/logout`.
+- The mobile client MUST be public: `generateSecret: false` (explicit, not implicit default).
+- Web and test client behaviour must remain unchanged. Existing tests that count clients or use unpinned `hasResourceProperties` must be updated to pin `ClientName: 'vela-web-client'` where they were implicitly asserting the web client's contract.
+- Mobile callback/logout URI overrides via `COGNITO_MOBILE_CALLBACK_URLS` / `COGNITO_MOBILE_LOGOUT_URLS` MUST be validated to use the registered scheme; a typo like `dev.cwchanap.vela.dev://...` must throw at synth time, not deploy silently.
+- Documentation target is **`CLAUDE.md`** at the repo root (`AGENTS.md` is a symlink to it).
+- M2 prerequisites (API JWT verifier widening, mobile client ID injection, Capacitor OAuth integration, `state`/`nonce`) are **out of scope** — the spec documents them, this plan does not implement them.
+
+---
+
+## File Structure
+
+**Files created:**
+
+- `packages/cdk/test/static-web-stack.test.ts` — new test file for the `StaticWebStack` outputs (none exists today).
+- `apps/vela-mobile/src/ios/info-plist.test.ts` — plist scheme-registration test. **Must live under `src/`** because `vitest.config.ts:19` only includes `src/**` and `scripts/**`.
+
+**Files modified:**
+
+- `packages/cdk/lib/auth-stack.ts` — add constants, validation helper, and the `mobileUserPoolClient` block.
+- `packages/cdk/lib/static-web-stack.ts` — add the `CognitoMobileUserPoolClientId` `CfnOutput`.
+- `packages/cdk/test/auth-stack.test.ts` — add mobile-client tests, scheme-rejection test, class-field test; update the two literal-count assertions and pin the three nameless `hasResourceProperties` tests to `ClientName: 'vela-web-client'`.
+- `apps/vela-mobile/src-capacitor/ios/App/App/Info.plist` — add `CFBundleURLTypes` block registering `dev.cwchanap.vela.oauth`.
+- `CLAUDE.md` — extend the Authentication section with a "Mobile client (iOS)" subsection.
+- `.env.example` — append `COGNITO_MOBILE_CALLBACK_URLS` / `COGNITO_MOBILE_LOGOUT_URLS` after the existing `CORS_ALLOWED_*` lines, under a `# CDK deploy-time only` comment block.
+
+**Helper refactor inside the test file** (no new files): extend `synthesizeTemplate()` to expose the underlying `AuthStack`, or add a sibling `synthesizeStack()` helper, so the class-field test does not duplicate synthesis setup.
+
+---
+
+## Task 1: Add the `vela-mobile-client` to AuthStack (TDD)
+
+**Files:**
+
+- Modify: `packages/cdk/lib/auth-stack.ts`
+- Modify: `packages/cdk/test/auth-stack.test.ts`
+
+**Interfaces:**
+
+- Produces: `AuthStack.mobileUserPoolClient: UserPoolClient` (new public readonly field). Consumed by `StaticWebStack` in Task 3.
+- Produces: synth-time `Error` from `assertMobileScheme()` when `COGNITO_MOBILE_CALLBACK_URLS` / `COGNITO_MOBILE_LOGOUT_URLS` contains a URI that does not start with `dev.cwchanap.vela.oauth://`.
+
+- [ ] **Step 1: Refactor the test helper to expose the stack instance**
+
+Edit `packages/cdk/test/auth-stack.test.ts`. Replace the existing `synthesizeTemplate` function (lines 21–31) with two helpers — one returning just the `Template` (preserves call sites), one returning both the stack and template:
+
+```ts
+function synthesizeStack() {
+  const app = new App();
+  const stack = new AuthStack(app, 'TestAuthStack', {
+    env: {
+      account: '123456789012',
+      region: 'us-east-1',
+    },
+  });
+  return { stack, template: Template.fromStack(stack) };
+}
+
+function synthesizeTemplate(): Template {
+  return synthesizeStack().template;
+}
+```
+
+- [ ] **Step 2: Run the existing test suite to confirm the refactor is a no-op**
+
+Run: `bun test` from `packages/cdk/`
+Expected: all 12 existing tests still pass.
+
+- [ ] **Step 3: Add the new mobile-client test block (will fail — no mobile client exists yet)**
+
+Append the following inside the `describe('AuthStack', () => { … })` block, after the existing `'includes localhost OAuth URLs in deployed (non-placeholder) mode'` test:
+
+```ts
+test('mobile client uses the iOS custom-scheme callback and logout URIs', () => {
+  const template = synthesizeTemplate();
+
+  template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
+    ClientName: 'vela-mobile-client',
+    CallbackURLs: ['dev.cwchanap.vela.oauth://oauth/callback'],
+    LogoutURLs: ['dev.cwchanap.vela.oauth://oauth/logout'],
+  });
+});
+
+test('creates a dedicated public mobile client with PKCE-compatible OAuth', () => {
+  const template = synthesizeTemplate();
+  const clients = template.findResources('AWS::Cognito::UserPoolClient');
+  const mobile = Object.values(clients).find(
+    (c) => c.Properties.ClientName === 'vela-mobile-client',
+  );
+
+  expect(mobile).toBeDefined();
+  // Public client — CloudFormation omits GenerateSecret when false; undefined is falsy.
+  expect(mobile!.Properties.GenerateSecret).toBeFalsy();
+  expect(mobile!.Properties.AllowedOAuthFlows).toEqual(['code']);
+  expect(mobile!.Properties.AllowedOAuthFlowsUserPoolClient).toBe(true);
+  expect(mobile!.Properties.SupportedIdentityProviders).toEqual(['Google']);
+  expect(mobile!.Properties.AllowedOAuthScopes.toSorted()).toEqual(['email', 'openid', 'profile']);
+  expect(mobile!.Properties.ExplicitAuthFlows).toEqual(['ALLOW_REFRESH_TOKEN_AUTH']);
+});
+
+test('mobile callback/logout URIs are overridable via env vars (same-scheme only)', () => {
+  process.env.COGNITO_MOBILE_CALLBACK_URLS =
+    'dev.cwchanap.vela.oauth://oauth/staging-callback,dev.cwchanap.vela.oauth://oauth/callback';
+  process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://oauth/staging-logout';
+
+  const template = synthesizeTemplate();
+  const clients = template.findResources('AWS::Cognito::UserPoolClient');
+  const byName = (name: string) =>
+    Object.values(clients).find((c) => c.Properties.ClientName === name);
+
+  const mobile = byName('vela-mobile-client');
+  expect(mobile!.Properties.CallbackURLs).toEqual([
+    'dev.cwchanap.vela.oauth://oauth/staging-callback',
+    'dev.cwchanap.vela.oauth://oauth/callback',
+  ]);
+  expect(mobile!.Properties.LogoutURLs).toEqual(['dev.cwchanap.vela.oauth://oauth/staging-logout']);
+
+  const web = byName('vela-web-client');
+  expect(web!.Properties.CallbackURLs).toEqual(
+    expect.arrayContaining([
+      'https://vela.cwchanap.dev/auth/callback',
+      'http://localhost:9000/auth/callback',
+    ]),
+  );
+  expect(web!.Properties.LogoutURLs).toEqual(
+    expect.arrayContaining([
+      'https://vela.cwchanap.dev/auth/login',
+      'http://localhost:9000/auth/login',
+    ]),
+  );
+});
+
+test('mobile callback/logout URIs fall back to defaults when env vars are empty', () => {
+  process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
+  process.env.COGNITO_MOBILE_LOGOUT_URLS = '   ';
+
+  const template = synthesizeTemplate();
+
+  template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
+    ClientName: 'vela-mobile-client',
+    CallbackURLs: ['dev.cwchanap.vela.oauth://oauth/callback'],
+    LogoutURLs: ['dev.cwchanap.vela.oauth://oauth/logout'],
+  });
+});
+
+test('rejects mobile callback/logout URIs that do not use the registered scheme', () => {
+  process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.dev://oauth/callback';
+
+  expect(() => synthesizeTemplate()).toThrow(
+    /COGNITO_MOBILE_CALLBACK_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme/,
+  );
+
+  process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
+  process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.dev://oauth/logout';
+
+  expect(() => synthesizeTemplate()).toThrow(
+    /COGNITO_MOBILE_LOGOUT_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme/,
+  );
+});
+
+test('mobile client is distinct from web and test clients', () => {
+  const template = synthesizeTemplate();
+  const clients = Object.values(template.findResources('AWS::Cognito::UserPoolClient'));
+
+  const byName = (name: string) => clients.find((c) => c.Properties.ClientName === name);
+
+  expect(byName('vela-web-client')).toBeDefined();
+  expect(byName('vela-test-client')).toBeDefined();
+  expect(byName('vela-mobile-client')).toBeDefined();
+
+  const names = clients.map((c) => c.Properties.ClientName);
+  expect(new Set(names).size).toBe(3);
+});
+
+test('web client contract is unchanged by the mobile client addition', () => {
+  const template = synthesizeTemplate();
+  const clients = template.findResources('AWS::Cognito::UserPoolClient');
+  const web = Object.values(clients).find((c) => c.Properties.ClientName === 'vela-web-client');
+
+  expect(web!.Properties.SupportedIdentityProviders).toEqual(['Google']);
+  expect(web!.Properties.AllowedOAuthFlows).toEqual(['code']);
+  expect(web!.Properties.AllowedOAuthFlowsUserPoolClient).toBe(true);
+  expect(web!.Properties.AllowedOAuthScopes.toSorted()).toEqual(['email', 'openid', 'profile']);
+  expect(web!.Properties.ExplicitAuthFlows).toEqual(['ALLOW_REFRESH_TOKEN_AUTH']);
+  expect(web!.Properties.GenerateSecret).toBeFalsy();
+  expect(web!.Properties.CallbackURLs).toEqual(
+    expect.arrayContaining([
+      'https://vela.cwchanap.dev/auth/callback',
+      'http://localhost:9000/auth/callback',
+      'http://127.0.0.1:9000/auth/callback',
+    ]),
+  );
+  expect(web!.Properties.LogoutURLs).toEqual(
+    expect.arrayContaining([
+      'https://vela.cwchanap.dev/auth/login',
+      'http://localhost:9000/auth/login',
+      'http://127.0.0.1:9000/auth/login',
+    ]),
+  );
+});
+
+test('exposes the mobile client as a public field on AuthStack', () => {
+  const { stack } = synthesizeStack();
+
+  expect(stack.mobileUserPoolClient).toBeDefined();
+  expect(stack.mobileUserPoolClient.userPoolClientId).toBeDefined();
+});
+```
+
+- [ ] **Step 4: Run the new tests — confirm they fail for the right reason**
+
+Run: `bun test` from `packages/cdk/`
+Expected: 8 new tests FAIL. The mobile-client tests fail because `vela-mobile-client` does not exist in the synthesised template; the class-field test fails because `stack.mobileUserPoolClient` is `undefined`. The scheme-rejection test fails because no validation throws.
+
+- [ ] **Step 5: Add the new constants and `assertMobileScheme` helper to `auth-stack.ts`**
+
+In `packages/cdk/lib/auth-stack.ts`, immediately after the existing `LOCAL_LOGOUT_URLS` declaration (around line 28), insert:
+
+```ts
+const MOBILE_OAUTH_SCHEME = 'dev.cwchanap.vela.oauth';
+const DEFAULT_MOBILE_CALLBACK_URLS = [`${MOBILE_OAUTH_SCHEME}://oauth/callback`];
+const DEFAULT_MOBILE_LOGOUT_URLS = [`${MOBILE_OAUTH_SCHEME}://oauth/logout`];
+
+/**
+ * Reject mobile callback/logout URIs that do not use the registered iOS scheme.
+ * `parseCommaList` is permissive on its own; without this guard a typo like
+ * `dev.cwchanap.vela.dev://...` would synthesise + deploy successfully and
+ * then fail silently on-device because iOS would have no handler registered.
+ */
+function assertMobileScheme(label: string, uris: string[]): void {
+  const prefix = `${MOBILE_OAUTH_SCHEME}://`;
+  for (const uri of uris) {
+    if (!uri.startsWith(prefix)) {
+      throw new Error(
+        `${label} must use the ${MOBILE_OAUTH_SCHEME}:// scheme (Info.plist only registers that scheme). Got: ${uri}`,
+      );
+    }
+  }
+}
+```
+
+- [ ] **Step 6: Add the `mobileUserPoolClient` public field to the `AuthStack` class**
+
+In the same file, in the `public readonly` field block near line 42–46, add:
+
+```ts
+public readonly mobileUserPoolClient: UserPoolClient;
+```
+
+(Place it between `testUserPoolClient` and `userPoolDomain`, or in alphabetical/grouped order — match the existing style.)
+
+- [ ] **Step 7: Add the mobile client block — immediately after the existing `userPoolClient.node.addDependency(googleProvider);` line (around line 167)**
+
+```ts
+const mobileCallbackUrls = parseCommaList(
+  process.env.COGNITO_MOBILE_CALLBACK_URLS,
+  DEFAULT_MOBILE_CALLBACK_URLS,
+);
+const mobileLogoutUrls = parseCommaList(
+  process.env.COGNITO_MOBILE_LOGOUT_URLS,
+  DEFAULT_MOBILE_LOGOUT_URLS,
+);
+assertMobileScheme('COGNITO_MOBILE_CALLBACK_URLS', mobileCallbackUrls);
+assertMobileScheme('COGNITO_MOBILE_LOGOUT_URLS', mobileLogoutUrls);
+
+const mobileUserPoolClient = new UserPoolClient(this, 'VelaMobileUserPoolClient', {
+  userPool,
+  userPoolClientName: 'vela-mobile-client',
+  generateSecret: false,
+  authFlows: {
+    adminUserPassword: false,
+    custom: false,
+    userPassword: false,
+    userSrp: false,
+  },
+  preventUserExistenceErrors: true,
+  supportedIdentityProviders: [UserPoolClientIdentityProvider.GOOGLE],
+  oAuth: {
+    flows: {
+      authorizationCodeGrant: true,
+      implicitCodeGrant: false,
+    },
+    scopes: [OAuthScope.OPENID, OAuthScope.EMAIL, OAuthScope.PROFILE],
+    callbackUrls: mobileCallbackUrls,
+    logoutUrls: mobileLogoutUrls,
+  },
+});
+mobileUserPoolClient.node.addDependency(googleProvider);
+```
+
+- [ ] **Step 8: Assign the new public field — alongside the other `this.foo = foo` lines (around line 188–192)**
+
+```ts
+this.mobileUserPoolClient = mobileUserPoolClient;
+```
+
+- [ ] **Step 9: Run the new tests — confirm they now pass**
+
+Run: `bun test` from `packages/cdk/`
+Expected: the 8 new tests PASS. Some older tests may now FAIL because they assert `allClients.length === 2` — that's expected, fix them in Step 10.
+
+- [ ] **Step 10: Update existing count-based and nameless assertions to account for the third client**
+
+In `packages/cdk/test/auth-stack.test.ts`:
+
+**10a.** In the test `'creates a separate test client with admin auth flow enabled'` (around line 127), change:
+
+```ts
+expect(allClients.length).toBe(2);
+```
+
+to:
+
+```ts
+expect(allClients.length).toBe(3);
+```
+
+**10b.** In the test `'test client is distinct from the production web client'` (around line 143), make the same change — `toBe(2)` → `toBe(3)`.
+
+**10c.** Pin the three nameless `hasResourceProperties` calls to `ClientName: 'vela-web-client'` so they cannot multi-match against the mobile client. The affected tests are:
+
+- `'configures the user pool app client for Google-only OAuth code flow'` (around line 72): add `ClientName: 'vela-web-client',` as the first key in the `hasResourceProperties` argument object.
+- `'uses custom callback and logout URLs from env vars'` (around line 194): same — add `ClientName: 'vela-web-client',`.
+- `'falls back to default callback and logout URLs when env vars are empty'` (around line 211): same — add `ClientName: 'vela-web-client',`.
+
+For `'includes localhost OAuth URLs in deployed (non-placeholder) mode'` (around line 231): it already includes `ClientName: 'vela-web-client'` — no change needed.
+
+- [ ] **Step 11: Run the full CDK test suite — confirm everything passes**
+
+Run: `bun test` from `packages/cdk/`
+Expected: all tests PASS (existing 12 + new 8 = 20 total).
+
+- [ ] **Step 12: Verify CDK synth succeeds end-to-end**
+
+Run: `cdk:synth` from `packages/cdk/`
+Expected: synthesis completes with no errors. Search the synthesised template for `vela-mobile-client` and confirm the new client appears with the expected properties.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add packages/cdk/lib/auth-stack.ts packages/cdk/test/auth-stack.test.ts
+git commit -m "feat(cdk): add vela-mobile-client for iOS OAuth (HPA-203)
+
+- Add public mobile UserPoolClient with auth-code grant, Google IdP,
+  no client secret (generateSecret: false explicit).
+- Add synth-time scheme validation: throws if COGNITO_MOBILE_CALLBACK_URLS
+  or COGNITO_MOBILE_LOGOUT_URLS contains a URI that does not use the
+  registered dev.cwchanap.vela.oauth:// scheme.
+- Pin three existing nameless hasResourceProperties tests to
+  ClientName: 'vela-web-client' to avoid multi-match ambiguity.
+- Update two literal-count assertions (2 -> 3 clients)."
+```
+
+---
+
+## Task 2: Expose `CognitoMobileUserPoolClientId` in StaticWebStack
+
+**Files:**
+
+- Modify: `packages/cdk/lib/static-web-stack.ts`
+- Create: `packages/cdk/test/static-web-stack.test.ts`
+
+**Interfaces:**
+
+- Consumes: `auth.mobileUserPoolClient.userPoolClientId` from Task 1.
+- Produces: a CloudFormation output named `CognitoMobileUserPoolClientId` whose `Value` resolves to the mobile client's logical resource (Fn::GetAtt or Ref), not the web or test client.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cdk/test/static-web-stack.test.ts`:
+
+```ts
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { AuthStack } from '../lib/auth-stack';
+import { DatabaseStack } from '../lib/database-stack';
+import { StorageStack } from '../lib/storage-stack';
+import { ApiStack } from '../lib/api-stack';
+import { StaticWebStack } from '../lib/static-web-stack';
+
+describe('StaticWebStack', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.ALLOW_LOCAL_OAUTH_PLACEHOLDERS = 'true';
+    process.env.COGNITO_DOMAIN_PREFIX = 'vela-test-auth';
+    process.env.GOOGLE_OAUTH_CLIENT_ID = 'test-google-client-id.apps.googleusercontent.com';
+    process.env.GOOGLE_OAUTH_CLIENT_SECRET_NAME = 'vela/test-google-oauth-client-secret';
+    delete process.env.CLOUDFRONT_CERT_ARN;
+    delete process.env.ACM_CERT_ARN;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  function synthesize() {
+    const app = new App();
+    const stackEnv = { account: '123456789012', region: 'us-east-1' };
+    const auth = new AuthStack(app, 'TestStaticAuthStack', { env: stackEnv });
+    const database = new DatabaseStack(app, 'TestStaticDatabaseStack', { env: stackEnv });
+    const storage = new StorageStack(app, 'TestStaticStorageStack', { env: stackEnv });
+    const api = new ApiStack(app, 'TestStaticApiStack', {
+      env: stackEnv,
+      auth,
+      database,
+      storage,
+    });
+    const staticWeb = new StaticWebStack(app, 'TestStaticWebStack', {
+      env: stackEnv,
+      auth,
+      database,
+      storage,
+      api,
+    });
+    return { stack: staticWeb, template: Template.fromStack(staticWeb) };
+  }
+
+  test('exposes CognitoMobileUserPoolClientId wired to the mobile client resource', () => {
+    const { template } = synthesize();
+
+    // The output exists.
+    const outputs = (template.toJSON().Outputs ?? {}) as Record<
+      string,
+      { Value: unknown; Description?: string }
+    >;
+    expect(outputs.CognitoMobileUserPoolClientId).toBeDefined();
+
+    // The Value must reference the *mobile* client, not the web or test client.
+    // CDK renders userPoolClientId as { "Fn::GetAtt": ["<logicalId>", "ClientId"] }
+    // in the synthesised template.
+    const value = outputs.CognitoMobileUserPoolClientId.Value as Record<string, unknown>;
+    expect(value).toHaveProperty('Fn::GetAtt');
+    const getAtt = value['Fn::GetAtt'] as unknown[];
+    expect(getAtt[0]).toContain('VelaMobileUserPoolClient');
+    expect(String(getAtt[0])).not.toContain('VelaTestUserPoolClient');
+    // The web client's logical id is just 'VelaUserPoolClient' — guard against
+    // a substring false-positive by checking exact-id membership via findResources.
+    const clients = template.findResources('AWS::Cognito::UserPoolClient');
+    const mobileLogicalIds = Object.keys(clients).filter(
+      (id) => clients[id].Properties?.ClientName === 'vela-mobile-client',
+    );
+    expect(mobileLogicalIds).toContain(getAtt[0]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — confirm it fails**
+
+Run: `bun test` from `packages/cdk/`
+Expected: the new test FAILS — `outputs.CognitoMobileUserPoolClientId` is `undefined`.
+
+- [ ] **Step 3: Add the `CognitoMobileUserPoolClientId` output to `StaticWebStack`**
+
+In `packages/cdk/lib/static-web-stack.ts`, immediately after the existing `CognitoTestUserPoolClientId` output (around lines 192–195), insert:
+
+```ts
+new CfnOutput(this, 'CognitoMobileUserPoolClientId', {
+  value: auth.mobileUserPoolClient.userPoolClientId,
+  description: 'Cognito User Pool Client ID for the iOS mobile app (public, PKCE)',
+});
+```
+
+- [ ] **Step 4: Run the test — confirm it passes**
+
+Run: `bun test` from `packages/cdk/`
+Expected: the new test PASSES.
+
+- [ ] **Step 5: Verify CDK synth succeeds and emits the new output**
+
+Run: `cdk:synth` from `packages/cdk/`
+Expected: synthesis completes. The synthesised template's `Outputs` block contains a `CognitoMobileUserPoolClientId` entry whose `Value` is a `Fn::GetAtt` referencing `VelaMobileUserPoolClient`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cdk/lib/static-web-stack.ts packages/cdk/test/static-web-stack.test.ts
+git commit -m "feat(cdk): expose CognitoMobileUserPoolClientId output (HPA-203)
+
+Adds a CloudFormation output for the mobile client ID on StaticWebStack.
+Value is wired to auth.mobileUserPoolClient.userPoolClientId — asserted to
+reference VelaMobileUserPoolClient, not the web or test client."
+```
+
+---
+
+## Task 3: Register `dev.cwchanap.vela.oauth` custom URL scheme in iOS `Info.plist`
+
+**Files:**
+
+- Modify: `apps/vela-mobile/src-capacitor/ios/App/App/Info.plist`
+- Create: `apps/vela-mobile/src/ios/info-plist.test.ts`
+
+**Interfaces:**
+
+- Produces: an iOS custom URL scheme declaration. iOS will hand URLs of the form `dev.cwchanap.vela.oauth://…` to the app via `AppDelegate.application(_:open:options:)` (already wired to `ApplicationDelegateProxy.shared`). No Swift changes.
+
+- [ ] **Step 1: Write the failing plist scheme-registration test**
+
+Create `apps/vela-mobile/src/ios/info-plist.test.ts`:
+
+```ts
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+// Parse the plist as XML without adding a runtime dependency.
+// The Info.plist is small and stable; a regex on the raw text is enough
+// to catch "a Capacitor sync wiped the CFBundleURLTypes entry".
+const plistPath = resolve(__dirname, '../../src-capacitor/ios/App/App/Info.plist');
+const plistContent = readFileSync(plistPath, 'utf8');
+
+function extractSchemes(xml: string): string[] {
+  const schemes: string[] = [];
+  const blockMatch = xml.match(/<key>CFBundleURLSchemes<\/key>\s*<array>([\s\S]*?)<\/array>/);
+  if (!blockMatch) return schemes;
+  const stringRegex = /<string>([^<]+)<\/string>/g;
+  let match: RegExpExecArray | null;
+  while ((match = stringRegex.exec(blockMatch[1])) !== null) {
+    schemes.push(match[1]);
+  }
+  return schemes;
+}
+
+describe('iOS Info.plist', () => {
+  test('registers the dev.cwchanap.vela.oauth custom URL scheme', () => {
+    const schemes = extractSchemes(plistContent);
+    expect(schemes).toContain('dev.cwchanap.vela.oauth');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — confirm it fails**
+
+Run: `bun test` from `apps/vela-mobile/` (or `bun run test:unit` if the script differs)
+Expected: the test FAILS — the plist has no `CFBundleURLSchemes` block today, so `extractSchemes` returns `[]`.
+
+- [ ] **Step 3: Add the `CFBundleURLTypes` block to `Info.plist`**
+
+In `apps/vela-mobile/src-capacitor/ios/App/App/Info.plist`, insert the following as a new top-level `<key>`/`<array>` pair inside the root `<dict>` (anywhere among the existing keys; convention is alphabetical or grouped with related launch-config keys). Place it immediately before the closing `</dict>`:
+
+```xml
+<key>CFBundleURLTypes</key>
+<array>
+    <dict>
+        <key>CFBundleURLSchemes</key>
+        <array>
+            <string>dev.cwchanap.vela.oauth</string>
+        </array>
+        <key>CFBundleURLName</key>
+        <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+        <key>CFBundleTypeRole</key>
+        <string>Editor</string>
+    </dict>
+</array>
+```
+
+- [ ] **Step 4: Run the test — confirm it passes**
+
+Run: `bun test` from `apps/vela-mobile/`
+Expected: the test PASSES.
+
+- [ ] **Step 5: Verify the plist is still well-formed XML**
+
+Run: `plutil -lint apps/vela-mobile/src-capacitor/ios/App/App/Info.plist`
+Expected: `apps/vela-mobile/src-capacitor/ios/App/App/Info.plist: OK`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/vela-mobile/src-capacitor/ios/App/App/Info.plist apps/vela-mobile/src/ios/info-plist.test.ts
+git commit -m "feat(mobile): register dev.cwchanap.vela.oauth URL scheme (HPA-203)
+
+Adds CFBundleURLTypes to Info.plist so iOS hands OAuth callback URLs of
+the form dev.cwchanap.vela.oauth://... to the Vela app. AppDelegate
+already forwards opens through ApplicationDelegateProxy.shared, so no
+Swift changes are needed. The scheme is rooted at cwchanap.dev (a
+project-controlled domain) rather than the bundle id (com.vela.app)
+because vela.app is not a controlled namespace.
+
+Test placed under src/ so vitest.config.ts:19's include rule discovers
+it (src-capacitor/ is not in the include list)."
+```
+
+---
+
+## Task 4: Documentation — `CLAUDE.md` + `.env.example`
+
+**Files:**
+
+- Modify: `CLAUDE.md` (the file backing the `AGENTS.md` symlink)
+- Modify: `.env.example`
+
+**Interfaces:** None — this task is documentation only.
+
+- [ ] **Step 1: Extend the Authentication section in `CLAUDE.md`**
+
+In `CLAUDE.md`, locate the `## Authentication` section. Append a new `### Mobile client (iOS)` subsection at the end of that section (before the next top-level `##` heading):
+
+```md
+### Mobile client (iOS)
+
+Vela Mobile authenticates against the same Cognito user pool as the web app, through a dedicated **public** app client (`vela-mobile-client`). The mobile OAuth flow uses authorization-code grant + PKCE; no client secret is bundled in the app binary.
+
+The iOS callback uses a custom URL scheme registered in `apps/vela-mobile/src-capacitor/ios/App/App/Info.plist`:
+
+| URI                                        | Purpose                                              |
+| ------------------------------------------ | ---------------------------------------------------- |
+| `dev.cwchanap.vela.oauth://oauth/callback` | Receives the authorization code after Google sign-in |
+| `dev.cwchanap.vela.oauth://oauth/logout`   | Receives the redirect after Cognito sign-out         |
+
+The scheme is rooted at `cwchanap.dev` (a project-controlled domain) rather than the bundle id, because `vela.app` is not a controlled namespace and custom URL schemes are an unowned namespace on iOS.
+
+`AppDelegate.application(_:open:options:)` already forwards opens to Capacitor's `ApplicationDelegateProxy`. This is only relevant if the M2 client-side flow uses `@capacitor/browser` + `@capacitor/app` — if M2 uses `ASWebAuthenticationSession` instead, the callback arrives through the session's completion handler and `AppDelegate` is bypassed entirely.
+
+CDK env vars (defaults shown):
+
+    COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth://oauth/callback
+    COGNITO_MOBILE_LOGOUT_URLS=dev.cwchanap.vela.oauth://oauth/logout
+
+Both accept comma-separated lists for dev/QA overrides. **Override URIs must use the `dev.cwchanap.vela.oauth://` scheme** — CDK validates this at synth time and throws otherwise, because iOS only registers that one scheme. Vary the path, not the scheme. The mobile client ID is published as the `CognitoMobileUserPoolClientId` CloudFormation output.
+
+The following M2 work is required before the mobile OAuth flow can complete end-to-end (out of scope for HPA-203):
+
+1. Widen the API JWT verifier to accept both web and mobile client audiences (`aws-jwt-verify` `clientId: [webId, mobileId]`).
+2. Wire the mobile client ID into the Capacitor build.
+3. If API calls go through WKWebView, add `capacitor://localhost` to the API CORS allow-list.
+4. Implement PKCE + `state` + `nonce` in the client-side OAuth flow.
+```
+
+- [ ] **Step 2: Add the CDK deploy-time block to `.env.example`**
+
+In the root `.env.example`, locate the existing `CORS_ALLOWED_EXTENSION_IDS` line (line 29). Immediately after it, insert:
+
+```
+
+# CDK deploy-time only (not read by the Quasar apps; do not mirror into apps/*/.env.example)
+# Override URIs MUST use the dev.cwchanap.vela.oauth:// scheme — CDK throws at synth time otherwise.
+COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth://oauth/callback
+COGNITO_MOBILE_LOGOUT_URLS=dev.cwchanap.vela.oauth://oauth/logout
+```
+
+(The leading blank line preserves visual separation from the CORS block above.)
+
+- [ ] **Step 3: Sanity-check the symlink still resolves**
+
+Run: `readlink AGENTS.md`
+Expected: prints `CLAUDE.md` — confirms the symlink is intact and `AGENTS.md` readers will see the new section.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md .env.example
+git commit -m "docs: document mobile OAuth client and iOS URL scheme (HPA-203)
+
+- Add a Mobile client (iOS) subsection to CLAUDE.md's Authentication
+  section covering the scheme choice, callback/logout URIs, env-var
+  override constraints, and explicit M2 prerequisites (verifier
+  widening, client ID injection, CORS, PKCE/state/nonce).
+- Add COGNITO_MOBILE_CALLBACK_URLS / COGNITO_MOBILE_LOGOUT_URLS to the
+  root .env.example under a CDK deploy-time-only comment block, placed
+  after the existing CORS_ALLOWED_* deploy-time vars."
+```
+
+---
+
+## Verification
+
+After all four tasks are complete:
+
+- [ ] **Final check 1:** Run the full CDK test suite: `bun test` from `packages/cdk/`. All tests pass (existing 12 + new mobile-client tests + new StaticWebStack test).
+- [ ] **Final check 2:** Run the mobile test suite: `bun test` from `apps/vela-mobile/`. The new Info.plist test passes alongside all existing tests.
+- [ ] **Final check 3:** Run `cdk:synth` from `packages/cdk/`. Confirm the synthesised template contains:
+  - Three `AWS::Cognito::UserPoolClient` resources named `vela-web-client`, `vela-test-client`, `vela-mobile-client`.
+  - A `CognitoMobileUserPoolClientId` output whose `Value` is a `Fn::GetAtt` on `VelaMobileUserPoolClient`.
+- [ ] **Final check 4:** Confirm `AGENTS.md` still symlinks to `CLAUDE.md` and shows the new "Mobile client (iOS)" subsection.
+- [ ] **Final check 5:** Confirm the bundle id is unchanged (`com.vela.app`) — only the OAuth scheme is `dev.cwchanap.vela.oauth`. Check `capacitor.config.json` was not modified.

--- a/packages/cdk/lib/auth-stack.ts
+++ b/packages/cdk/lib/auth-stack.ts
@@ -57,13 +57,25 @@ function assertMobileScheme(label: string, uris: string[]): void {
   // URI has no path and would likewise dispatch to a no-op handler on-device.
   // `[^\s?#]+` for the leading path segment enforces that, while the trailing
   // `\S*` still permits a legitimate `?query` / `#fragment` after a real path.
+  const schemePrefix = `${MOBILE_OAUTH_SCHEME}://`;
   const mobileUriPattern = new RegExp(
     `^${MOBILE_OAUTH_SCHEME.replace(/\./g, '\\.')}://[^\\s?#]+\\S*$`,
   );
   for (const uri of uris) {
-    if (!mobileUriPattern.test(uri)) {
+    if (!uri.startsWith(schemePrefix)) {
+      // Wrong scheme entirely (e.g. `https://...`, `dev.cwchanap.vela.dev://...`).
+      // iOS only registers `dev.cwchanap.vela.oauth`, so any other scheme would
+      // dispatch to a no-op handler (or another app) on-device.
       throw new Error(
-        `${label} must use the ${MOBILE_OAUTH_SCHEME}:// scheme with a non-empty path (Info.plist only registers that scheme). Got: ${uri}`,
+        `${label} must use the ${MOBILE_OAUTH_SCHEME}:// scheme (Info.plist only registers that scheme). Got: ${uri}`,
+      );
+    }
+    if (!mobileUriPattern.test(uri)) {
+      // Right scheme but missing/invalid path: `scheme://`, `scheme:// `,
+      // `scheme://?query`, `scheme://#fragment`. Cognito would store these but
+      // iOS would dispatch to a no-op handler.
+      throw new Error(
+        `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device). Got: ${uri}`,
       );
     }
   }

--- a/packages/cdk/lib/auth-stack.ts
+++ b/packages/cdk/lib/auth-stack.ts
@@ -51,7 +51,7 @@ function assertMobileScheme(label: string, uris: string[]): void {
   // synthesise + deploy but resolve to a no-op callback on-device. `\S+`
   // (not `.+`) also rejects whitespace-only paths that would slip past a
   // naive empty-path check.
-  const re = new RegExp(`^${MOBILE_OAUTH_SCHEME.replace(/\./g, '\\.')}://\\S+`);
+  const re = new RegExp(`^${MOBILE_OAUTH_SCHEME.replace(/\./g, '\\.')}://\\S+$`);
   for (const uri of uris) {
     if (!re.test(uri)) {
       throw new Error(
@@ -222,6 +222,9 @@ export class AuthStack extends Stack {
       userPool,
       userPoolClientName: 'vela-mobile-client',
       generateSecret: false,
+      // All explicit authFlows disabled, but ALLOW_REFRESH_TOKEN_AUTH is on
+      // by default in Cognito and remains enabled — refresh-token rotation
+      // is the intended long-lived-session path for the mobile client.
       authFlows: {
         adminUserPassword: false,
         custom: false,

--- a/packages/cdk/lib/auth-stack.ts
+++ b/packages/cdk/lib/auth-stack.ts
@@ -35,7 +35,9 @@ const DEFAULT_MOBILE_LOGOUT_URLS = [`${MOBILE_OAUTH_SCHEME}://oauth/logout`];
  * Reject mobile callback/logout URIs that do not use the registered iOS scheme.
  * `parseCommaList` is permissive on its own; without this guard a typo like
  * `dev.cwchanap.vela.dev://...` would synthesise + deploy successfully and
- * then fail silently on-device because iOS would have no handler registered.
+ * then fail silently on-device because iOS would not dispatch the URL to this
+ * app — the scheme is not registered in Info.plist, so iOS sends it to a
+ * different app (or no app at all), and the OAuth callback is lost.
  *
  * The check is intentionally case-sensitive: the scheme registered in Info.plist
  * is `dev.cwchanap.vela.oauth` (all lowercase) and the override URIs in
@@ -73,21 +75,24 @@ function assertMobileScheme(label: string, uris: string[]): void {
   // character class — but WHATWG assigns `oauth` to `host` and leaves
   // `pathname` empty. That authority-only case is exactly the kind of
   // fat-fingered config (missing `/callback` or `/logout`) this validator
-  // exists to catch: Cognito would store it but iOS would dispatch to a
-  // no-op handler on-device. A path following an authority must begin with
-  // `/`, so `scheme://oauth` and `scheme://oauth/` are both rejected.
+  // exists to catch: Cognito would store it, and iOS would deliver the
+  // URL to the app, but the app's router would have no matching route —
+  // the callback is silently dropped. A path following an authority must
+  // begin with `/`, so `scheme://oauth` and `scheme://oauth/` are both
+  // rejected.
   //
   // The first character after the authority must begin a real path
   // component (not `?`): a query-only (`scheme://?foo`) URI has an empty
-  // `pathname` and would likewise dispatch to a no-op handler on-device.
-  // Fragment-only URIs (`scheme://#bar`) are already rejected by the
-  // raw-string `#` check above before parsing.
+  // `pathname` and would likewise leave the app's router with no matching
+  // route. Fragment-only URIs (`scheme://#bar`) are already rejected by
+  // the raw-string `#` check above before parsing.
   const schemePrefix = `${MOBILE_OAUTH_SCHEME}://`;
   for (const uri of uris) {
     if (!uri.startsWith(schemePrefix)) {
       // Wrong scheme entirely (e.g. `https://...`, `dev.cwchanap.vela.dev://...`).
       // iOS only registers `dev.cwchanap.vela.oauth`, so any other scheme would
-      // dispatch to a no-op handler (or another app) on-device.
+      // dispatch to a different app (or no app at all) — this app would never
+      // receive the callback.
       throw new Error(
         `${label} must use the ${MOBILE_OAUTH_SCHEME}:// scheme (Info.plist only registers that scheme). Got: ${uri}`,
       );
@@ -132,17 +137,18 @@ function assertMobileScheme(label: string, uris: string[]): void {
       // present, so a parse failure here means the rest of the URI is
       // malformed. Surface it as a path error — the scheme is fine.
       throw new Error(
-        `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device). Got: ${uri}`,
+        `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path; the app's router would have no matching route). Got: ${uri}`,
       );
     }
     if (parsed.pathname === '' || parsed.pathname === '/') {
       // Right scheme but missing path: `scheme://`, `scheme:// `,
       // `scheme://?query`, `scheme://#fragment`, `scheme://oauth`
       // (authority-only — `oauth` is the host, pathname is empty),
-      // `scheme://oauth/` (root path). Cognito would store these but
-      // iOS would dispatch to a no-op handler.
+      // `scheme://oauth/` (root path). Cognito would store these; iOS
+      // would deliver the URL to the app, but the app's router would
+      // have no matching route — the callback is silently dropped.
       throw new Error(
-        `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device). Got: ${uri}`,
+        `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path; the app's router would have no matching route). Got: ${uri}`,
       );
     }
   }

--- a/packages/cdk/lib/auth-stack.ts
+++ b/packages/cdk/lib/auth-stack.ts
@@ -27,6 +27,27 @@ const LOCAL_CALLBACK_URLS = [
 
 const LOCAL_LOGOUT_URLS = ['http://localhost:9000/auth/login', 'http://127.0.0.1:9000/auth/login'];
 
+const MOBILE_OAUTH_SCHEME = 'dev.cwchanap.vela.oauth';
+const DEFAULT_MOBILE_CALLBACK_URLS = [`${MOBILE_OAUTH_SCHEME}://oauth/callback`];
+const DEFAULT_MOBILE_LOGOUT_URLS = [`${MOBILE_OAUTH_SCHEME}://oauth/logout`];
+
+/**
+ * Reject mobile callback/logout URIs that do not use the registered iOS scheme.
+ * `parseCommaList` is permissive on its own; without this guard a typo like
+ * `dev.cwchanap.vela.dev://...` would synthesise + deploy successfully and
+ * then fail silently on-device because iOS would have no handler registered.
+ */
+function assertMobileScheme(label: string, uris: string[]): void {
+  const prefix = `${MOBILE_OAUTH_SCHEME}://`;
+  for (const uri of uris) {
+    if (!uri.startsWith(prefix)) {
+      throw new Error(
+        `${label} must use the ${MOBILE_OAUTH_SCHEME}:// scheme (Info.plist only registers that scheme). Got: ${uri}`,
+      );
+    }
+  }
+}
+
 function parseCommaList(value: string | undefined, defaults: string[]): string[] {
   if (!value || value.trim().length === 0) {
     return defaults;
@@ -42,6 +63,7 @@ export class AuthStack extends Stack {
   public readonly userPool: UserPool;
   public readonly userPoolClient: UserPoolClient;
   public readonly testUserPoolClient: UserPoolClient;
+  public readonly mobileUserPoolClient: UserPoolClient;
   public readonly userPoolDomain: UserPoolDomain;
   public readonly oauthDomain: string;
 
@@ -166,6 +188,41 @@ export class AuthStack extends Stack {
     });
     userPoolClient.node.addDependency(googleProvider);
 
+    const mobileCallbackUrls = parseCommaList(
+      process.env.COGNITO_MOBILE_CALLBACK_URLS,
+      DEFAULT_MOBILE_CALLBACK_URLS,
+    );
+    const mobileLogoutUrls = parseCommaList(
+      process.env.COGNITO_MOBILE_LOGOUT_URLS,
+      DEFAULT_MOBILE_LOGOUT_URLS,
+    );
+    assertMobileScheme('COGNITO_MOBILE_CALLBACK_URLS', mobileCallbackUrls);
+    assertMobileScheme('COGNITO_MOBILE_LOGOUT_URLS', mobileLogoutUrls);
+
+    const mobileUserPoolClient = new UserPoolClient(this, 'VelaMobileUserPoolClient', {
+      userPool,
+      userPoolClientName: 'vela-mobile-client',
+      generateSecret: false,
+      authFlows: {
+        adminUserPassword: false,
+        custom: false,
+        userPassword: false,
+        userSrp: false,
+      },
+      preventUserExistenceErrors: true,
+      supportedIdentityProviders: [UserPoolClientIdentityProvider.GOOGLE],
+      oAuth: {
+        flows: {
+          authorizationCodeGrant: true,
+          implicitCodeGrant: false,
+        },
+        scopes: [OAuthScope.OPENID, OAuthScope.EMAIL, OAuthScope.PROFILE],
+        callbackUrls: mobileCallbackUrls,
+        logoutUrls: mobileLogoutUrls,
+      },
+    });
+    mobileUserPoolClient.node.addDependency(googleProvider);
+
     // Separate client for e2e tests: enables ADMIN_USER_PASSWORD_AUTH so Playwright
     // fixtures can obtain tokens via AdminInitiateAuth without going through
     // the Google Hosted UI. Only deployed alongside the production stack —
@@ -189,6 +246,7 @@ export class AuthStack extends Stack {
     this.userPoolClient = userPoolClient;
     this.userPoolDomain = userPoolDomain;
     this.testUserPoolClient = testPoolClient;
+    this.mobileUserPoolClient = mobileUserPoolClient;
     this.oauthDomain = `${domainPrefix}.auth.${Stack.of(this).region}.amazoncognito.com`;
   }
 }

--- a/packages/cdk/lib/auth-stack.ts
+++ b/packages/cdk/lib/auth-stack.ts
@@ -36,6 +36,13 @@ const DEFAULT_MOBILE_LOGOUT_URLS = [`${MOBILE_OAUTH_SCHEME}://oauth/logout`];
  * `parseCommaList` is permissive on its own; without this guard a typo like
  * `dev.cwchanap.vela.dev://...` would synthesise + deploy successfully and
  * then fail silently on-device because iOS would have no handler registered.
+ *
+ * The check is intentionally case-sensitive: the scheme registered in Info.plist
+ * is `dev.cwchanap.vela.oauth` (all lowercase) and the override URIs in
+ * COGNITO_MOBILE_*_URLS are project-controlled values, not free user input.
+ * iOS itself lowercases custom URL schemes before dispatch, so a mixed-case
+ * override would still work on-device — but accepting it here would mask a
+ * config drift between CDK and Info.plist. Fail strict, fix the config.
  */
 function assertMobileScheme(label: string, uris: string[]): void {
   const prefix = `${MOBILE_OAUTH_SCHEME}://`;
@@ -175,6 +182,7 @@ export class AuthStack extends Stack {
         userSrp: false,
       },
       preventUserExistenceErrors: true,
+      enableTokenRevocation: true,
       supportedIdentityProviders: [UserPoolClientIdentityProvider.GOOGLE],
       oAuth: {
         flows: {
@@ -210,6 +218,7 @@ export class AuthStack extends Stack {
         userSrp: false,
       },
       preventUserExistenceErrors: true,
+      enableTokenRevocation: true,
       supportedIdentityProviders: [UserPoolClientIdentityProvider.GOOGLE],
       oAuth: {
         flows: {
@@ -238,6 +247,7 @@ export class AuthStack extends Stack {
         userSrp: false,
       },
       preventUserExistenceErrors: true,
+      enableTokenRevocation: true,
       supportedIdentityProviders: [UserPoolClientIdentityProvider.COGNITO],
       disableOAuth: true,
     });

--- a/packages/cdk/lib/auth-stack.ts
+++ b/packages/cdk/lib/auth-stack.ts
@@ -45,28 +45,41 @@ const DEFAULT_MOBILE_LOGOUT_URLS = [`${MOBILE_OAUTH_SCHEME}://oauth/logout`];
  * config drift between CDK and Info.plist. Fail strict, fix the config.
  */
 function assertMobileScheme(label: string, uris: string[]): void {
-  // Scheme prefix plus a non-empty, non-whitespace path. Rejecting `scheme://`
-  // (empty path) catches fat-fingered config like
-  // `COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth://` which would
-  // synthesise + deploy but resolve to a no-op callback on-device. `\S+`
-  // (not `.+`) also rejects whitespace-only paths that would slip past a
-  // naive empty-path check.
+  // Two checks: a case-sensitive scheme prefix check, then a WHATWG URL
+  // parse for structural validation.
   //
-  // The first character after `://` must be a real path character (not `?`
-  // or `#`): a query-only (`scheme://?foo`) or fragment-only (`scheme://#bar`)
-  // URI has no path and would likewise dispatch to a no-op handler on-device.
-  // `[^\s?#]+` for the leading path segment enforces that, while the trailing
-  // `\S*` still permits a legitimate `?query` / `#fragment` after a real
-  // path. Fragments are then rejected by the explicit `#` check below —
-  // Cognito's CreateUserPoolClient docs require that a redirect URI "Not
-  // include a fragment component", so a URI like `scheme://oauth/callback#frag`
-  // would synth + deploy-fail at the AWS::Cognito::UserPoolClient resource.
-  // Reject it at synth time with a fragment-specific error message instead
-  // of the generic "missing path" message.
+  // The scheme check is intentionally case-sensitive: the scheme registered
+  // in Info.plist is `dev.cwchanap.vela.oauth` (all lowercase) and the
+  // override URIs in COGNITO_MOBILE_*_URLS are project-controlled values,
+  // not free user input. iOS itself lowercases custom URL schemes before
+  // dispatch, so a mixed-case override would still work on-device — but
+  // accepting it here would mask a config drift between CDK and Info.plist.
+  // Fail strict, fix the config. `new URL()` lowercases the scheme, so it
+  // cannot enforce this on its own; the `startsWith` check must come first.
+  //
+  // Structural validation uses `new URL()` rather than a regex because a
+  // regex like `[^\s?#]+` cannot distinguish authority from path in a
+  // custom scheme. `dev.cwchanap.vela.oauth://oauth` (authority-only,
+  // empty pathname) would pass such a regex — `oauth` matches the path
+  // character class — but WHATWG assigns `oauth` to `host` and leaves
+  // `pathname` empty. That authority-only case is exactly the kind of
+  // fat-fingered config (missing `/callback` or `/logout`) this validator
+  // exists to catch: Cognito would store it but iOS would dispatch to a
+  // no-op handler on-device. A path following an authority must begin with
+  // `/`, so `scheme://oauth` and `scheme://oauth/` are both rejected.
+  //
+  // The first character after the authority must begin a real path
+  // component (not `?` or `#`): a query-only (`scheme://?foo`) or
+  // fragment-only (`scheme://#bar`) URI has an empty `pathname` and would
+  // likewise dispatch to a no-op handler on-device. Fragments on a URI
+  // that *does* have a path are then rejected by the explicit `hash`
+  // check — Cognito's CreateUserPoolClient docs require that a redirect
+  // URI "Not include a fragment component", so a URI like
+  // `scheme://oauth/callback#frag` would synth + deploy-fail at the
+  // AWS::Cognito::UserPoolClient resource. Reject it at synth time with a
+  // fragment-specific error message instead of the generic "missing path"
+  // message.
   const schemePrefix = `${MOBILE_OAUTH_SCHEME}://`;
-  const mobileUriPattern = new RegExp(
-    `^${MOBILE_OAUTH_SCHEME.replace(/\./g, '\\.')}://[^\\s?#]+\\S*$`,
-  );
   for (const uri of uris) {
     if (!uri.startsWith(schemePrefix)) {
       // Wrong scheme entirely (e.g. `https://...`, `dev.cwchanap.vela.dev://...`).
@@ -76,15 +89,28 @@ function assertMobileScheme(label: string, uris: string[]): void {
         `${label} must use the ${MOBILE_OAUTH_SCHEME}:// scheme (Info.plist only registers that scheme). Got: ${uri}`,
       );
     }
-    if (!mobileUriPattern.test(uri)) {
-      // Right scheme but missing/invalid path: `scheme://`, `scheme:// `,
-      // `scheme://?query`, `scheme://#fragment`. Cognito would store these but
+    let parsed: URL;
+    try {
+      parsed = new URL(uri);
+    } catch {
+      // `startsWith(schemePrefix)` already guaranteed the scheme prefix is
+      // present, so a parse failure here means the rest of the URI is
+      // malformed. Surface it as a path error — the scheme is fine.
+      throw new Error(
+        `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device). Got: ${uri}`,
+      );
+    }
+    if (parsed.pathname === '' || parsed.pathname === '/') {
+      // Right scheme but missing path: `scheme://`, `scheme:// `,
+      // `scheme://?query`, `scheme://#fragment`, `scheme://oauth`
+      // (authority-only — `oauth` is the host, pathname is empty),
+      // `scheme://oauth/` (root path). Cognito would store these but
       // iOS would dispatch to a no-op handler.
       throw new Error(
         `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device). Got: ${uri}`,
       );
     }
-    if (uri.includes('#')) {
+    if (parsed.hash !== '') {
       // Path is well-formed but a `#fragment` is present. Cognito rejects
       // redirect URIs containing a fragment component at deploy time
       // (CreateUserPoolClient / UpdateUserPoolClient validation), so synth
@@ -223,11 +249,23 @@ export class AuthStack extends Stack {
         userSrp: false,
       },
       preventUserExistenceErrors: true,
-      // enableTokenRevocation adds origin_jti/origin_iat claims to issued
-      // access tokens (a token-shape change, not a runtime no-op) and enables
-      // the RevokeToken endpoint for this client. Applied to every client as
+      // enableTokenRevocation adds origin_jti/jti claims to issued access and
+      // ID tokens (a token-shape change, not a runtime no-op) and enables the
+      // RevokeToken endpoint for this client. Applied to every client as
       // defense-in-depth: a future revoke flow then works uniformly without a
       // per-client CDK change. Pinned by the `pins enableTokenRevocation` test.
+      //
+      // Security scope: RevokeToken invalidates the refresh token and prevents
+      // issuance of *new* access/ID tokens, but it does NOT immediately
+      // invalidate already-issued bearer tokens. The Vela API verifies ID
+      // tokens locally with aws-jwt-verify's CognitoJwtVerifier, which only
+      // checks token cryptography and standard claims — it does not perform a
+      // revocation lookup against Cognito. AWS confirms that revoked tokens
+      // remain valid when evaluated by such a JWT library until their natural
+      // `exp`. Immediate logout / bearer-token invalidation would require a
+      // server-side session or token-version denylist in the API; that is
+      // out of scope for this hardening pass, which only ensures the
+      // RevokeToken endpoint and token-shape prerequisites are in place.
       enableTokenRevocation: true,
       supportedIdentityProviders: [UserPoolClientIdentityProvider.GOOGLE],
       oAuth: {

--- a/packages/cdk/lib/auth-stack.ts
+++ b/packages/cdk/lib/auth-stack.ts
@@ -155,6 +155,33 @@ function assertMobileRedirect(label: string, uris: string[], allowedPaths: strin
         `${label} path must be one of [${allowedPaths.join(', ')}] (the app's router has no matching route for other paths). Got: ${uri}`,
       );
     }
+    // Reject query strings. RFC 6749 §3.1.2 requires that a query
+    // component on the registered redirect URI be retained when the
+    // authorization server appends OAuth response parameters. Cognito
+    // appends `code`, `state`, etc. at redirect time, so a static query
+    // like `?code=abc` would produce an ambiguous callback with
+    // duplicate parameter values (e.g. `?code=abc&code=<actual>`),
+    // and different URL parsers select different values. There is no
+    // current need for static query parameters on mobile redirect URIs.
+    if (parsed.search !== '') {
+      throw new Error(
+        `${label} must not include a query string (Cognito appends OAuth response parameters to the redirect URI at redirect time; a static query would collide with them and produce ambiguous duplicate parameters). Got: ${uri}`,
+      );
+    }
+    // Require the raw URI to exactly match the normalized form
+    // `scheme:<allowedPath>`. WHATWG URL parsing normalizes dot segments,
+    // so a raw value like `dev.cwchanap.vela.oauth:/oauth/temporary/../callback`
+    // parses to pathname `/oauth/callback` and would pass the allowlist
+    // above — but the raw string registered with Cognito is not the
+    // allowlisted URI. The env vars are deployment-controlled, so this is
+    // low-risk, but rejecting it preserves the exact-match guarantee the
+    // allowlist is meant to provide.
+    const expected = `${MOBILE_OAUTH_SCHEME}:${parsed.pathname}`;
+    if (uri !== expected) {
+      throw new Error(
+        `${label} must exactly match an allowed mobile redirect URI (dot-segment normalization and other parser transforms are rejected; the raw string registered with Cognito must be the allowlisted URI). Got: ${uri}`,
+      );
+    }
   }
 }
 

--- a/packages/cdk/lib/auth-stack.ts
+++ b/packages/cdk/lib/auth-stack.ts
@@ -45,8 +45,9 @@ const DEFAULT_MOBILE_LOGOUT_URLS = [`${MOBILE_OAUTH_SCHEME}://oauth/logout`];
  * config drift between CDK and Info.plist. Fail strict, fix the config.
  */
 function assertMobileScheme(label: string, uris: string[]): void {
-  // Two checks: a case-sensitive scheme prefix check, then a WHATWG URL
-  // parse for structural validation.
+  // Four checks, in order: case-sensitive scheme prefix, raw-string fragment
+  // (`#`), raw-string whitespace, then a WHATWG URL parse for structural
+  // validation (non-empty path).
   //
   // The scheme check is intentionally case-sensitive: the scheme registered
   // in Info.plist is `dev.cwchanap.vela.oauth` (all lowercase) and the
@@ -56,6 +57,14 @@ function assertMobileScheme(label: string, uris: string[]): void {
   // accepting it here would mask a config drift between CDK and Info.plist.
   // Fail strict, fix the config. `new URL()` lowercases the scheme, so it
   // cannot enforce this on its own; the `startsWith` check must come first.
+  //
+  // The raw-string fragment and whitespace checks come BEFORE `new URL()`
+  // because the WHATWG parser normalises away exactly the characters
+  // Cognito rejects: a trailing `#` (empty fragment) yields
+  // `parsed.hash === ''`, and internal whitespace is percent-encoded
+  // (spaces) or silently stripped (tabs/newlines). Validating the parsed
+  // representation would let these through; the raw string is what Cognito
+  // receives, so it is what must be checked.
   //
   // Structural validation uses `new URL()` rather than a regex because a
   // regex like `[^\s?#]+` cannot distinguish authority from path in a
@@ -69,16 +78,10 @@ function assertMobileScheme(label: string, uris: string[]): void {
   // `/`, so `scheme://oauth` and `scheme://oauth/` are both rejected.
   //
   // The first character after the authority must begin a real path
-  // component (not `?` or `#`): a query-only (`scheme://?foo`) or
-  // fragment-only (`scheme://#bar`) URI has an empty `pathname` and would
-  // likewise dispatch to a no-op handler on-device. Fragments on a URI
-  // that *does* have a path are then rejected by the explicit `hash`
-  // check — Cognito's CreateUserPoolClient docs require that a redirect
-  // URI "Not include a fragment component", so a URI like
-  // `scheme://oauth/callback#frag` would synth + deploy-fail at the
-  // AWS::Cognito::UserPoolClient resource. Reject it at synth time with a
-  // fragment-specific error message instead of the generic "missing path"
-  // message.
+  // component (not `?`): a query-only (`scheme://?foo`) URI has an empty
+  // `pathname` and would likewise dispatch to a no-op handler on-device.
+  // Fragment-only URIs (`scheme://#bar`) are already rejected by the
+  // raw-string `#` check above before parsing.
   const schemePrefix = `${MOBILE_OAUTH_SCHEME}://`;
   for (const uri of uris) {
     if (!uri.startsWith(schemePrefix)) {
@@ -87,6 +90,38 @@ function assertMobileScheme(label: string, uris: string[]): void {
       // dispatch to a no-op handler (or another app) on-device.
       throw new Error(
         `${label} must use the ${MOBILE_OAUTH_SCHEME}:// scheme (Info.plist only registers that scheme). Got: ${uri}`,
+      );
+    }
+    // Raw-string checks BEFORE `new URL()` parsing. The WHATWG URL parser
+    // normalises away exactly the characters Cognito rejects, so validating
+    // the parsed representation would let invalid raw strings through:
+    //
+    //   - Trailing `#` (empty fragment): `parsed.hash === ''` but the raw
+    //     string still contains `#`. Cognito rejects any redirect URI
+    //     containing a fragment component, including a bare trailing `#`.
+    //   - Internal whitespace: `new URL()` percent-encodes spaces and
+    //     silently strips tabs/newlines, so `parsed.pathname` looks valid
+    //     while the raw string passed to Cognito contains whitespace that
+    //     Cognito's redirect URI pattern excludes.
+    //
+    // Checking the raw string catches both cases the parser masks.
+    if (uri.includes('#')) {
+      // Cognito's CreateUserPoolClient / UpdateUserPoolClient docs require
+      // that a redirect URI "Not include a fragment component". A bare
+      // trailing `#` (empty fragment) is still a fragment component —
+      // `new URL('...#').hash` is `''`, so the parsed-hash check below
+      // would miss it. Reject any `#` in the raw string.
+      throw new Error(
+        `${label} must not contain a fragment (Cognito rejects redirect URIs with a \`#\` component). Got: ${uri}`,
+      );
+    }
+    if (/\s/u.test(uri)) {
+      // Cognito's redirect URI pattern excludes whitespace. `new URL()`
+      // percent-encodes spaces and strips tabs/newlines, so the parsed
+      // representation would look valid while the raw string passed to
+      // Cognito contains whitespace that deploy-time validation rejects.
+      throw new Error(
+        `${label} must not contain whitespace (Cognito rejects redirect URIs containing whitespace characters). Got: ${uri}`,
       );
     }
     let parsed: URL;
@@ -108,15 +143,6 @@ function assertMobileScheme(label: string, uris: string[]): void {
       // iOS would dispatch to a no-op handler.
       throw new Error(
         `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device). Got: ${uri}`,
-      );
-    }
-    if (parsed.hash !== '') {
-      // Path is well-formed but a `#fragment` is present. Cognito rejects
-      // redirect URIs containing a fragment component at deploy time
-      // (CreateUserPoolClient / UpdateUserPoolClient validation), so synth
-      // would succeed and deploy would fail. Fail fast at synth instead.
-      throw new Error(
-        `${label} must not contain a fragment (Cognito rejects redirect URIs with a \`#\` component). Got: ${uri}`,
       );
     }
   }
@@ -296,7 +322,7 @@ export class AuthStack extends Stack {
       userPoolClientName: 'vela-mobile-client',
       generateSecret: false,
       // All explicit authFlows disabled, but ALLOW_REFRESH_TOKEN_AUTH is on
-      // by default in Cognito and remains enabled — refresh-token rotation
+      // by default in Cognito and remains enabled — refresh-token renewal
       // is the intended long-lived-session path for the mobile client.
       authFlows: {
         adminUserPassword: false,

--- a/packages/cdk/lib/auth-stack.ts
+++ b/packages/cdk/lib/auth-stack.ts
@@ -56,7 +56,13 @@ function assertMobileScheme(label: string, uris: string[]): void {
   // or `#`): a query-only (`scheme://?foo`) or fragment-only (`scheme://#bar`)
   // URI has no path and would likewise dispatch to a no-op handler on-device.
   // `[^\s?#]+` for the leading path segment enforces that, while the trailing
-  // `\S*` still permits a legitimate `?query` / `#fragment` after a real path.
+  // `\S*` still permits a legitimate `?query` / `#fragment` after a real
+  // path. Fragments are then rejected by the explicit `#` check below —
+  // Cognito's CreateUserPoolClient docs require that a redirect URI "Not
+  // include a fragment component", so a URI like `scheme://oauth/callback#frag`
+  // would synth + deploy-fail at the AWS::Cognito::UserPoolClient resource.
+  // Reject it at synth time with a fragment-specific error message instead
+  // of the generic "missing path" message.
   const schemePrefix = `${MOBILE_OAUTH_SCHEME}://`;
   const mobileUriPattern = new RegExp(
     `^${MOBILE_OAUTH_SCHEME.replace(/\./g, '\\.')}://[^\\s?#]+\\S*$`,
@@ -76,6 +82,15 @@ function assertMobileScheme(label: string, uris: string[]): void {
       // iOS would dispatch to a no-op handler.
       throw new Error(
         `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device). Got: ${uri}`,
+      );
+    }
+    if (uri.includes('#')) {
+      // Path is well-formed but a `#fragment` is present. Cognito rejects
+      // redirect URIs containing a fragment component at deploy time
+      // (CreateUserPoolClient / UpdateUserPoolClient validation), so synth
+      // would succeed and deploy would fail. Fail fast at synth instead.
+      throw new Error(
+        `${label} must not contain a fragment (Cognito rejects redirect URIs with a \`#\` component). Got: ${uri}`,
       );
     }
   }

--- a/packages/cdk/lib/auth-stack.ts
+++ b/packages/cdk/lib/auth-stack.ts
@@ -182,6 +182,10 @@ export class AuthStack extends Stack {
         userSrp: false,
       },
       preventUserExistenceErrors: true,
+      // enableTokenRevocation is a runtime no-op until RevokeToken is called,
+      // but is applied to every client as defense-in-depth: it costs nothing
+      // at rest and means a future revoke flow works uniformly without a
+      // per-client CDK change. Pinned by the `pins enableTokenRevocation` test.
       enableTokenRevocation: true,
       supportedIdentityProviders: [UserPoolClientIdentityProvider.GOOGLE],
       oAuth: {

--- a/packages/cdk/lib/auth-stack.ts
+++ b/packages/cdk/lib/auth-stack.ts
@@ -51,9 +51,17 @@ function assertMobileScheme(label: string, uris: string[]): void {
   // synthesise + deploy but resolve to a no-op callback on-device. `\S+`
   // (not `.+`) also rejects whitespace-only paths that would slip past a
   // naive empty-path check.
-  const re = new RegExp(`^${MOBILE_OAUTH_SCHEME.replace(/\./g, '\\.')}://\\S+$`);
+  //
+  // The first character after `://` must be a real path character (not `?`
+  // or `#`): a query-only (`scheme://?foo`) or fragment-only (`scheme://#bar`)
+  // URI has no path and would likewise dispatch to a no-op handler on-device.
+  // `[^\s?#]+` for the leading path segment enforces that, while the trailing
+  // `\S*` still permits a legitimate `?query` / `#fragment` after a real path.
+  const mobileUriPattern = new RegExp(
+    `^${MOBILE_OAUTH_SCHEME.replace(/\./g, '\\.')}://[^\\s?#]+\\S*$`,
+  );
   for (const uri of uris) {
-    if (!re.test(uri)) {
+    if (!mobileUriPattern.test(uri)) {
       throw new Error(
         `${label} must use the ${MOBILE_OAUTH_SCHEME}:// scheme with a non-empty path (Info.plist only registers that scheme). Got: ${uri}`,
       );

--- a/packages/cdk/lib/auth-stack.ts
+++ b/packages/cdk/lib/auth-stack.ts
@@ -28,28 +28,44 @@ const LOCAL_CALLBACK_URLS = [
 const LOCAL_LOGOUT_URLS = ['http://localhost:9000/auth/login', 'http://127.0.0.1:9000/auth/login'];
 
 const MOBILE_OAUTH_SCHEME = 'dev.cwchanap.vela.oauth';
-const DEFAULT_MOBILE_CALLBACK_URLS = [`${MOBILE_OAUTH_SCHEME}://oauth/callback`];
-const DEFAULT_MOBILE_LOGOUT_URLS = [`${MOBILE_OAUTH_SCHEME}://oauth/logout`];
+const DEFAULT_MOBILE_CALLBACK_URLS = [`${MOBILE_OAUTH_SCHEME}:/oauth/callback`];
+const DEFAULT_MOBILE_LOGOUT_URLS = [`${MOBILE_OAUTH_SCHEME}:/oauth/logout`];
+
+// Allowed paths for mobile callback/logout URIs. Adding a new path (e.g. a
+// new staging environment) is a deliberate code change, not an env-var
+// change — the env var only controls which of these paths are active.
+const MOBILE_CALLBACK_PATHS = ['/oauth/callback', '/oauth/staging-callback'];
+const MOBILE_LOGOUT_PATHS = ['/oauth/logout', '/oauth/staging-logout'];
 
 /**
- * Reject mobile callback/logout URIs that do not use the registered iOS scheme.
+ * Reject mobile callback/logout URIs that do not use the registered iOS
+ * scheme, the RFC 8252 §7.1 private-use URI form, or an allowed route path.
+ *
  * `parseCommaList` is permissive on its own; without this guard a typo like
- * `dev.cwchanap.vela.dev://...` would synthesise + deploy successfully and
+ * `dev.cwchanap.vela.dev:/...` would synthesise + deploy successfully and
  * then fail silently on-device because iOS would not dispatch the URL to this
  * app — the scheme is not registered in Info.plist, so iOS sends it to a
  * different app (or no app at all), and the OAuth callback is lost.
  *
- * The check is intentionally case-sensitive: the scheme registered in Info.plist
- * is `dev.cwchanap.vela.oauth` (all lowercase) and the override URIs in
- * COGNITO_MOBILE_*_URLS are project-controlled values, not free user input.
- * iOS itself lowercases custom URL schemes before dispatch, so a mixed-case
- * override would still work on-device — but accepting it here would mask a
- * config drift between CDK and Info.plist. Fail strict, fix the config.
+ * The scheme check is intentionally case-sensitive: the scheme registered in
+ * Info.plist is `dev.cwchanap.vela.oauth` (all lowercase) and the override
+ * URIs in COGNITO_MOBILE_*_URLS are project-controlled values, not free user
+ * input. iOS itself lowercases custom URL schemes before dispatch, so a
+ * mixed-case override would still work on-device — but accepting it here
+ * would mask a config drift between CDK and Info.plist. Fail strict, fix
+ * the config.
+ *
+ * URI form: RFC 8252 §7.1 requires the single-slash form
+ * (`scheme:/path`) for private-use URI schemes because there is no naming
+ * authority. The `scheme://host/path` (authority) form is rejected — it
+ * introduces a spurious `host` component and would mask config drift from
+ * the BCP. `new URL()` distinguishes the two: `scheme:/path` has
+ * `host === ''`; `scheme://host/path` sets `host`.
  */
-function assertMobileScheme(label: string, uris: string[]): void {
-  // Four checks, in order: case-sensitive scheme prefix, raw-string fragment
+function assertMobileRedirect(label: string, uris: string[], allowedPaths: string[]): void {
+  // Checks, in order: case-sensitive scheme prefix, raw-string fragment
   // (`#`), raw-string whitespace, then a WHATWG URL parse for structural
-  // validation (non-empty path).
+  // validation (no authority + path in allowlist).
   //
   // The scheme check is intentionally case-sensitive: the scheme registered
   // in Info.plist is `dev.cwchanap.vela.oauth` (all lowercase) and the
@@ -67,34 +83,15 @@ function assertMobileScheme(label: string, uris: string[]): void {
   // (spaces) or silently stripped (tabs/newlines). Validating the parsed
   // representation would let these through; the raw string is what Cognito
   // receives, so it is what must be checked.
-  //
-  // Structural validation uses `new URL()` rather than a regex because a
-  // regex like `[^\s?#]+` cannot distinguish authority from path in a
-  // custom scheme. `dev.cwchanap.vela.oauth://oauth` (authority-only,
-  // empty pathname) would pass such a regex — `oauth` matches the path
-  // character class — but WHATWG assigns `oauth` to `host` and leaves
-  // `pathname` empty. That authority-only case is exactly the kind of
-  // fat-fingered config (missing `/callback` or `/logout`) this validator
-  // exists to catch: Cognito would store it, and iOS would deliver the
-  // URL to the app, but the app's router would have no matching route —
-  // the callback is silently dropped. A path following an authority must
-  // begin with `/`, so `scheme://oauth` and `scheme://oauth/` are both
-  // rejected.
-  //
-  // The first character after the authority must begin a real path
-  // component (not `?`): a query-only (`scheme://?foo`) URI has an empty
-  // `pathname` and would likewise leave the app's router with no matching
-  // route. Fragment-only URIs (`scheme://#bar`) are already rejected by
-  // the raw-string `#` check above before parsing.
-  const schemePrefix = `${MOBILE_OAUTH_SCHEME}://`;
+  const schemePrefix = `${MOBILE_OAUTH_SCHEME}:/`;
   for (const uri of uris) {
     if (!uri.startsWith(schemePrefix)) {
-      // Wrong scheme entirely (e.g. `https://...`, `dev.cwchanap.vela.dev://...`).
+      // Wrong scheme entirely (e.g. `https://...`, `dev.cwchanap.vela.dev:/...`).
       // iOS only registers `dev.cwchanap.vela.oauth`, so any other scheme would
       // dispatch to a different app (or no app at all) — this app would never
       // receive the callback.
       throw new Error(
-        `${label} must use the ${MOBILE_OAUTH_SCHEME}:// scheme (Info.plist only registers that scheme). Got: ${uri}`,
+        `${label} must use the ${MOBILE_OAUTH_SCHEME}:/ scheme (Info.plist only registers that scheme). Got: ${uri}`,
       );
     }
     // Raw-string checks BEFORE `new URL()` parsing. The WHATWG URL parser
@@ -137,18 +134,25 @@ function assertMobileScheme(label: string, uris: string[]): void {
       // present, so a parse failure here means the rest of the URI is
       // malformed. Surface it as a path error — the scheme is fine.
       throw new Error(
-        `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path; the app's router would have no matching route). Got: ${uri}`,
+        `${label} must include a valid path after ${MOBILE_OAUTH_SCHEME}:/ (the app's router has no matching route for other paths). Got: ${uri}`,
       );
     }
-    if (parsed.pathname === '' || parsed.pathname === '/') {
-      // Right scheme but missing path: `scheme://`, `scheme:// `,
-      // `scheme://?query`, `scheme://#fragment`, `scheme://oauth`
-      // (authority-only — `oauth` is the host, pathname is empty),
-      // `scheme://oauth/` (root path). Cognito would store these; iOS
-      // would deliver the URL to the app, but the app's router would
-      // have no matching route — the callback is silently dropped.
+    // Reject the authority form (`scheme://host/path`). RFC 8252 §7.1
+    // requires the single-slash form (`scheme:/path`) for private-use URI
+    // schemes because there is no naming authority. `startsWith` alone
+    // cannot distinguish `:/` from `://` (the latter contains the former);
+    // `parsed.host !== ''` catches the authority form after parsing.
+    if (parsed.host !== '') {
       throw new Error(
-        `${label} must include a non-empty, non-whitespace path after ${MOBILE_OAUTH_SCHEME}:// (query-only and fragment-only URIs have no path; the app's router would have no matching route). Got: ${uri}`,
+        `${label} must use the ${MOBILE_OAUTH_SCHEME}:/ form (no authority component), not ${MOBILE_OAUTH_SCHEME}://. RFC 8252 §7.1 requires a single slash for private-use URI schemes. Got: ${uri}`,
+      );
+    }
+    // Validate the path against an explicit allowlist. The app's router
+    // only handles known callback/logout routes; a typo like `/oauth/typo`
+    // would deploy silently and the callback would be dropped on-device.
+    if (!allowedPaths.includes(parsed.pathname)) {
+      throw new Error(
+        `${label} path must be one of [${allowedPaths.join(', ')}] (the app's router has no matching route for other paths). Got: ${uri}`,
       );
     }
   }
@@ -320,8 +324,8 @@ export class AuthStack extends Stack {
       process.env.COGNITO_MOBILE_LOGOUT_URLS,
       DEFAULT_MOBILE_LOGOUT_URLS,
     );
-    assertMobileScheme('COGNITO_MOBILE_CALLBACK_URLS', mobileCallbackUrls);
-    assertMobileScheme('COGNITO_MOBILE_LOGOUT_URLS', mobileLogoutUrls);
+    assertMobileRedirect('COGNITO_MOBILE_CALLBACK_URLS', mobileCallbackUrls, MOBILE_CALLBACK_PATHS);
+    assertMobileRedirect('COGNITO_MOBILE_LOGOUT_URLS', mobileLogoutUrls, MOBILE_LOGOUT_PATHS);
 
     const mobileUserPoolClient = new UserPoolClient(this, 'VelaMobileUserPoolClient', {
       userPool,

--- a/packages/cdk/lib/auth-stack.ts
+++ b/packages/cdk/lib/auth-stack.ts
@@ -45,11 +45,14 @@ const DEFAULT_MOBILE_LOGOUT_URLS = [`${MOBILE_OAUTH_SCHEME}://oauth/logout`];
  * config drift between CDK and Info.plist. Fail strict, fix the config.
  */
 function assertMobileScheme(label: string, uris: string[]): void {
-  const prefix = `${MOBILE_OAUTH_SCHEME}://`;
+  // Scheme prefix plus a non-empty path. Rejecting `scheme://` (empty path)
+  // catches fat-fingered config like `COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth://`
+  // which would synthesise + deploy but resolve to a no-op callback on-device.
+  const re = new RegExp(`^${MOBILE_OAUTH_SCHEME.replace(/\./g, '\\.')}://.+`);
   for (const uri of uris) {
-    if (!uri.startsWith(prefix)) {
+    if (!re.test(uri)) {
       throw new Error(
-        `${label} must use the ${MOBILE_OAUTH_SCHEME}:// scheme (Info.plist only registers that scheme). Got: ${uri}`,
+        `${label} must use the ${MOBILE_OAUTH_SCHEME}:// scheme with a non-empty path (Info.plist only registers that scheme). Got: ${uri}`,
       );
     }
   }
@@ -182,9 +185,10 @@ export class AuthStack extends Stack {
         userSrp: false,
       },
       preventUserExistenceErrors: true,
-      // enableTokenRevocation is a runtime no-op until RevokeToken is called,
-      // but is applied to every client as defense-in-depth: it costs nothing
-      // at rest and means a future revoke flow works uniformly without a
+      // enableTokenRevocation adds origin_jti/origin_iat claims to issued
+      // access tokens (a token-shape change, not a runtime no-op) and enables
+      // the RevokeToken endpoint for this client. Applied to every client as
+      // defense-in-depth: a future revoke flow then works uniformly without a
       // per-client CDK change. Pinned by the `pins enableTokenRevocation` test.
       enableTokenRevocation: true,
       supportedIdentityProviders: [UserPoolClientIdentityProvider.GOOGLE],

--- a/packages/cdk/lib/auth-stack.ts
+++ b/packages/cdk/lib/auth-stack.ts
@@ -45,10 +45,13 @@ const DEFAULT_MOBILE_LOGOUT_URLS = [`${MOBILE_OAUTH_SCHEME}://oauth/logout`];
  * config drift between CDK and Info.plist. Fail strict, fix the config.
  */
 function assertMobileScheme(label: string, uris: string[]): void {
-  // Scheme prefix plus a non-empty path. Rejecting `scheme://` (empty path)
-  // catches fat-fingered config like `COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth://`
-  // which would synthesise + deploy but resolve to a no-op callback on-device.
-  const re = new RegExp(`^${MOBILE_OAUTH_SCHEME.replace(/\./g, '\\.')}://.+`);
+  // Scheme prefix plus a non-empty, non-whitespace path. Rejecting `scheme://`
+  // (empty path) catches fat-fingered config like
+  // `COGNITO_MOBILE_CALLBACK_URLS=dev.cwchanap.vela.oauth://` which would
+  // synthesise + deploy but resolve to a no-op callback on-device. `\S+`
+  // (not `.+`) also rejects whitespace-only paths that would slip past a
+  // naive empty-path check.
+  const re = new RegExp(`^${MOBILE_OAUTH_SCHEME.replace(/\./g, '\\.')}://\\S+`);
   for (const uri of uris) {
     if (!re.test(uri)) {
       throw new Error(

--- a/packages/cdk/lib/static-web-stack.ts
+++ b/packages/cdk/lib/static-web-stack.ts
@@ -194,6 +194,11 @@ function handler(event) {
       description: 'Cognito User Pool Client ID for e2e tests (admin auth flow enabled)',
     });
 
+    new CfnOutput(this, 'CognitoMobileUserPoolClientId', {
+      value: auth.mobileUserPoolClient.userPoolClientId,
+      description: 'Cognito User Pool Client ID for the iOS mobile app (public, PKCE)',
+    });
+
     new CfnOutput(this, 'CognitoRegion', {
       value: Stack.of(this).region,
       description: 'AWS Region for Cognito',

--- a/packages/cdk/lib/static-web-stack.ts
+++ b/packages/cdk/lib/static-web-stack.ts
@@ -203,7 +203,7 @@ function handler(event) {
 
     new CfnOutput(this, 'CognitoMobileUserPoolClientId', {
       value: auth.mobileUserPoolClient.userPoolClientId,
-      description: 'Cognito User Pool Client ID for the iOS mobile app (public, PKCE)',
+      description: 'Cognito User Pool Client ID for the iOS mobile app (public, no client secret)',
     });
 
     new CfnOutput(this, 'CognitoRegion', {

--- a/packages/cdk/lib/static-web-stack.ts
+++ b/packages/cdk/lib/static-web-stack.ts
@@ -117,8 +117,15 @@ function handler(event) {
       allowedMethods: AllowedMethods.ALLOW_ALL,
     });
 
+    // Allow the SPA dist path to be overridden for test synth. `Source.asset`
+    // stats the directory at construct time, so a fresh checkout without a
+    // built SPA (`bun run build` in apps/vela) fails before any test runs.
+    // Tests set CDK_SPA_DIST_PATH to a temp directory to break that dependency.
+    const spaDistPath =
+      process.env.CDK_SPA_DIST_PATH || path.join(__dirname, '../../../apps/vela/dist/spa');
+
     new BucketDeployment(this, 'VelaWebsiteDeployment', {
-      sources: [Source.asset(path.join(__dirname, '../../../apps/vela/dist/spa'))],
+      sources: [Source.asset(spaDistPath)],
       destinationBucket: websiteBucket,
       distribution,
       distributionPaths: ['/*'],

--- a/packages/cdk/test/auth-stack.test.ts
+++ b/packages/cdk/test/auth-stack.test.ts
@@ -392,6 +392,25 @@ describe('AuthStack', () => {
     );
   });
 
+  test('rejects mobile URIs that contain a fragment after a real path', () => {
+    // Cognito rejects callback/logout URLs containing a fragment component
+    // (see CreateUserPoolClient docs: "Not include a fragment component").
+    // Without this guard, synth succeeds and deploy fails at the
+    // AWS::Cognito::UserPoolClient resource.
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth://oauth/callback#fragment';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_CALLBACK_URLS must not contain a fragment \(Cognito rejects redirect URIs with a `#` component\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth\/callback#fragment/,
+    );
+
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://oauth/logout#fragment';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_LOGOUT_URLS must not contain a fragment \(Cognito rejects redirect URIs with a `#` component\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth\/logout#fragment/,
+    );
+  });
+
   test('mobile client is distinct from web and test clients', () => {
     const template = synthesizeTemplate();
     const clients = Object.values(template.findResources('AWS::Cognito::UserPoolClient'));

--- a/packages/cdk/test/auth-stack.test.ts
+++ b/packages/cdk/test/auth-stack.test.ts
@@ -365,12 +365,16 @@ describe('AuthStack', () => {
   });
 
   test('rejects mobile URIs with a whitespace-only path', () => {
-    // `.+` would accept `scheme:// ` (space-only path); `\S+` rejects it.
-    // Cognito would store the URI but iOS would dispatch to a no-op handler.
+    // `parseCommaList` trims each entry before `assertMobileScheme` sees
+    // it, so `dev.cwchanap.vela.oauth:// ` arrives as
+    // `dev.cwchanap.vela.oauth://` — the trailing space is already gone.
+    // The path-empty check then rejects it. (Internal whitespace within
+    // a path is NOT trimmed by `parseCommaList` and is caught by the
+    // raw-string whitespace check — see the internal-whitespace test.)
     process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth:// ';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_CALLBACK_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\//,
+      /COGNITO_MOBILE_CALLBACK_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/$/,
     );
   });
 
@@ -414,20 +418,23 @@ describe('AuthStack', () => {
   });
 
   test('rejects mobile URIs with a query-only or fragment-only suffix', () => {
-    // A URI like `scheme://?foo` or `scheme://#bar` has no path component;
-    // `\S+` alone would accept it because `?` and `#` are non-whitespace.
-    // iOS would have no handler registered for the empty path → no-op callback.
+    // A URI like `scheme://?foo` has no path component; `\S+` alone would
+    // accept it because `?` is non-whitespace. iOS would have no handler
+    // registered for the empty path → no-op callback.
     process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth://?code=abc';
 
     expect(() => synthesizeTemplate()).toThrow(
       /COGNITO_MOBILE_CALLBACK_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\//,
     );
 
+    // `scheme://#bar` is rejected by the raw-string `#` check (before
+    // parsing) with a fragment-specific error — Cognito rejects any
+    // redirect URI containing a fragment component, regardless of path.
     process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
     process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://#fragment';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_LOGOUT_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\//,
+      /COGNITO_MOBILE_LOGOUT_URLS must not contain a fragment \(Cognito rejects redirect URIs with a `#` component\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/#fragment/,
     );
   });
 
@@ -448,6 +455,62 @@ describe('AuthStack', () => {
     expect(() => synthesizeTemplate()).toThrow(
       /COGNITO_MOBILE_LOGOUT_URLS must not contain a fragment \(Cognito rejects redirect URIs with a `#` component\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth\/logout#fragment/,
     );
+  });
+
+  test('rejects mobile URIs with a bare trailing `#` (empty fragment)', () => {
+    // Regression: `new URL('...#').hash === ''`, so the old `parsed.hash`
+    // check did not reject a trailing `#`. But the raw string still
+    // contains `#`, and Cognito rejects any redirect URI with a fragment
+    // component — including a bare trailing `#` with empty fragment.
+    // The raw-string `uri.includes('#')` check catches this before parsing.
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth://oauth/callback#';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_CALLBACK_URLS must not contain a fragment \(Cognito rejects redirect URIs with a `#` component\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth\/callback#$/,
+    );
+
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://oauth/logout#';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_LOGOUT_URLS must not contain a fragment \(Cognito rejects redirect URIs with a `#` component\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth\/logout#$/,
+    );
+  });
+
+  test('rejects mobile URIs with internal whitespace in an otherwise valid path', () => {
+    // Regression: `new URL()` percent-encodes spaces and silently strips
+    // tabs/newlines, so `parsed.pathname` looks valid while the raw string
+    // passed to Cognito contains whitespace that Cognito's redirect URI
+    // pattern excludes. The raw-string `/\s/u` check catches these before
+    // parsing.
+    const cases = [
+      'dev.cwchanap.vela.oauth://oauth/callback trailing',
+      'dev.cwchanap.vela.oauth://oauth/callback\tsuffix',
+      'dev.cwchanap.vela.oauth://oauth/callback\nsuffix',
+    ];
+
+    for (const uri of cases) {
+      process.env.COGNITO_MOBILE_CALLBACK_URLS = uri;
+      expect(() => synthesizeTemplate()).toThrow(
+        /COGNITO_MOBILE_CALLBACK_URLS must not contain whitespace \(Cognito rejects redirect URIs containing whitespace characters\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth\/callback[\s\S]*$/,
+      );
+      process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
+    }
+
+    // Logout URLs: same bypass, same fix.
+    const logoutCases = [
+      'dev.cwchanap.vela.oauth://oauth/logout trailing',
+      'dev.cwchanap.vela.oauth://oauth/logout\tsuffix',
+      'dev.cwchanap.vela.oauth://oauth/logout\nsuffix',
+    ];
+
+    for (const uri of logoutCases) {
+      process.env.COGNITO_MOBILE_LOGOUT_URLS = uri;
+      expect(() => synthesizeTemplate()).toThrow(
+        /COGNITO_MOBILE_LOGOUT_URLS must not contain whitespace \(Cognito rejects redirect URIs containing whitespace characters\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth\/logout[\s\S]*$/,
+      );
+      process.env.COGNITO_MOBILE_LOGOUT_URLS = '';
+    }
   });
 
   test('mobile client is distinct from web and test clients', () => {

--- a/packages/cdk/test/auth-stack.test.ts
+++ b/packages/cdk/test/auth-stack.test.ts
@@ -386,7 +386,7 @@ describe('AuthStack', () => {
     expect(new Set(names).size).toBe(3);
   });
 
-  test('web client OAuth contract is unchanged by the mobile client addition', () => {
+  test('web client OAuth flow, scopes, and redirect URIs are preserved after the mobile client addition', () => {
     const template = synthesizeTemplate();
     const clients = template.findResources('AWS::Cognito::UserPoolClient');
     const web = Object.values(clients).find((c) => c.Properties.ClientName === 'vela-web-client');

--- a/packages/cdk/test/auth-stack.test.ts
+++ b/packages/cdk/test/auth-stack.test.ts
@@ -374,6 +374,45 @@ describe('AuthStack', () => {
     );
   });
 
+  test('rejects mobile URIs with an authority-only path (no pathname)', () => {
+    // `dev.cwchanap.vela.oauth://oauth` has `oauth` as the host and an empty
+    // pathname per WHATWG URL parsing. A regex like `[^\s?#]+` would accept it
+    // (treating `oauth` as the path), but iOS would dispatch to a no-op
+    // handler because the path that distinguishes callback vs logout is
+    // missing. `new URL()` correctly assigns `oauth` to `host` and leaves
+    // `pathname` empty, which the validator rejects.
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth://oauth';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_CALLBACK_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth$/,
+    );
+
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://oauth';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_LOGOUT_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth$/,
+    );
+  });
+
+  test('rejects mobile URIs with a root-only path (slash after authority)', () => {
+    // `dev.cwchanap.vela.oauth://oauth/` has pathname `/` — the authority is
+    // present but the path is just the root slash, which does not distinguish
+    // callback from logout. iOS would dispatch to a no-op handler.
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth://oauth/';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_CALLBACK_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/.*Got: dev\.cwchanap\.vela\.oauth:\/\/oauth\/$/,
+    );
+
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://oauth/';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_LOGOUT_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/.*Got: dev\.cwchanap\.vela\.oauth:\/\/oauth\/$/,
+    );
+  });
+
   test('rejects mobile URIs with a query-only or fragment-only suffix', () => {
     // A URI like `scheme://?foo` or `scheme://#bar` has no path component;
     // `\S+` alone would accept it because `?` and `#` are non-whitespace.
@@ -460,10 +499,12 @@ describe('AuthStack', () => {
   });
 
   // Pins the intentional enableTokenRevocation: true hardening applied to
-  // every client. It adds origin_jti/origin_iat claims to access tokens and
+  // every client. It adds origin_jti/jti claims to access and ID tokens and
   // enables the RevokeToken endpoint; pinning the synthesized template
   // prevents a future refactor from silently dropping it. See auth-stack.ts
-  // for the rationale.
+  // for the rationale and the security-scope caveat (revocation does not
+  // immediately invalidate already-issued bearer tokens verified locally by
+  // the Vela API).
   test('pins enableTokenRevocation=true on all three clients', () => {
     const template = synthesizeTemplate();
     const clients = Object.values(template.findResources('AWS::Cognito::UserPoolClient'));

--- a/packages/cdk/test/auth-stack.test.ts
+++ b/packages/cdk/test/auth-stack.test.ts
@@ -18,7 +18,7 @@ describe('AuthStack', () => {
     process.env = originalEnv;
   });
 
-  function synthesizeTemplate(): Template {
+  function synthesizeStack() {
     const app = new App();
     const stack = new AuthStack(app, 'TestAuthStack', {
       env: {
@@ -26,8 +26,11 @@ describe('AuthStack', () => {
         region: 'us-east-1',
       },
     });
+    return { stack, template: Template.fromStack(stack) };
+  }
 
-    return Template.fromStack(stack);
+  function synthesizeTemplate(): Template {
+    return synthesizeStack().template;
   }
 
   test('configures Google as the hosted UI identity provider', () => {
@@ -73,6 +76,7 @@ describe('AuthStack', () => {
     const template = synthesizeTemplate();
 
     template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
+      ClientName: 'vela-web-client',
       SupportedIdentityProviders: ['Google'],
       AllowedOAuthFlows: ['code'],
       AllowedOAuthFlowsUserPoolClient: true,
@@ -129,7 +133,7 @@ describe('AuthStack', () => {
     const clients = template.findResources('AWS::Cognito::UserPoolClient');
 
     const allClients = Object.values(clients);
-    expect(allClients.length).toBe(2);
+    expect(allClients.length).toBe(3);
 
     const testClient = allClients.find((c) => c.Properties.ClientName === 'vela-test-client');
     expect(testClient).toBeDefined();
@@ -145,7 +149,7 @@ describe('AuthStack', () => {
     const clients = template.findResources('AWS::Cognito::UserPoolClient');
 
     const allClients = Object.values(clients);
-    expect(allClients.length).toBe(2);
+    expect(allClients.length).toBe(3);
 
     const webClient = allClients.find((c) => c.Properties.ClientName === 'vela-web-client');
     const testClient = allClients.find((c) => c.Properties.ClientName === 'vela-test-client');
@@ -200,6 +204,7 @@ describe('AuthStack', () => {
     const template = synthesizeTemplate();
 
     template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
+      ClientName: 'vela-web-client',
       CallbackURLs: [
         'https://staging.example.com/auth/callback',
         'http://localhost:9000/auth/callback',
@@ -215,6 +220,7 @@ describe('AuthStack', () => {
     const template = synthesizeTemplate();
 
     template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
+      ClientName: 'vela-web-client',
       CallbackURLs: Match.arrayWith([
         'https://vela.cwchanap.dev/auth/callback',
         'http://localhost:9000/auth/callback',
@@ -247,5 +253,145 @@ describe('AuthStack', () => {
         'http://127.0.0.1:9000/auth/login',
       ]),
     });
+  });
+
+  test('mobile client uses the iOS custom-scheme callback and logout URIs', () => {
+    const template = synthesizeTemplate();
+
+    template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
+      ClientName: 'vela-mobile-client',
+      CallbackURLs: ['dev.cwchanap.vela.oauth://oauth/callback'],
+      LogoutURLs: ['dev.cwchanap.vela.oauth://oauth/logout'],
+    });
+  });
+
+  test('creates a dedicated public mobile client with PKCE-compatible OAuth', () => {
+    const template = synthesizeTemplate();
+    const clients = template.findResources('AWS::Cognito::UserPoolClient');
+    const mobile = Object.values(clients).find(
+      (c) => c.Properties.ClientName === 'vela-mobile-client',
+    );
+
+    expect(mobile).toBeDefined();
+    expect(mobile!.Properties.GenerateSecret).toBeFalsy();
+    expect(mobile!.Properties.AllowedOAuthFlows).toEqual(['code']);
+    expect(mobile!.Properties.AllowedOAuthFlowsUserPoolClient).toBe(true);
+    expect(mobile!.Properties.SupportedIdentityProviders).toEqual(['Google']);
+    expect(mobile!.Properties.AllowedOAuthScopes.toSorted()).toEqual([
+      'email',
+      'openid',
+      'profile',
+    ]);
+    expect(mobile!.Properties.ExplicitAuthFlows).toEqual(['ALLOW_REFRESH_TOKEN_AUTH']);
+  });
+
+  test('mobile callback/logout URIs are overridable via env vars (same-scheme only)', () => {
+    process.env.COGNITO_MOBILE_CALLBACK_URLS =
+      'dev.cwchanap.vela.oauth://oauth/staging-callback,dev.cwchanap.vela.oauth://oauth/callback';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://oauth/staging-logout';
+
+    const template = synthesizeTemplate();
+    const clients = template.findResources('AWS::Cognito::UserPoolClient');
+    const byName = (name: string) =>
+      Object.values(clients).find((c) => c.Properties.ClientName === name);
+
+    const mobile = byName('vela-mobile-client');
+    expect(mobile!.Properties.CallbackURLs).toEqual([
+      'dev.cwchanap.vela.oauth://oauth/staging-callback',
+      'dev.cwchanap.vela.oauth://oauth/callback',
+    ]);
+    expect(mobile!.Properties.LogoutURLs).toEqual([
+      'dev.cwchanap.vela.oauth://oauth/staging-logout',
+    ]);
+
+    const web = byName('vela-web-client');
+    expect(web!.Properties.CallbackURLs).toEqual(
+      expect.arrayContaining([
+        'https://vela.cwchanap.dev/auth/callback',
+        'http://localhost:9000/auth/callback',
+      ]),
+    );
+    expect(web!.Properties.LogoutURLs).toEqual(
+      expect.arrayContaining([
+        'https://vela.cwchanap.dev/auth/login',
+        'http://localhost:9000/auth/login',
+      ]),
+    );
+  });
+
+  test('mobile callback/logout URIs fall back to defaults when env vars are empty', () => {
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = '   ';
+
+    const template = synthesizeTemplate();
+
+    template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
+      ClientName: 'vela-mobile-client',
+      CallbackURLs: ['dev.cwchanap.vela.oauth://oauth/callback'],
+      LogoutURLs: ['dev.cwchanap.vela.oauth://oauth/logout'],
+    });
+  });
+
+  test('rejects mobile callback/logout URIs that do not use the registered scheme', () => {
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.dev://oauth/callback';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_CALLBACK_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme/,
+    );
+
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.dev://oauth/logout';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_LOGOUT_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme/,
+    );
+  });
+
+  test('mobile client is distinct from web and test clients', () => {
+    const template = synthesizeTemplate();
+    const clients = Object.values(template.findResources('AWS::Cognito::UserPoolClient'));
+
+    const byName = (name: string) => clients.find((c) => c.Properties.ClientName === name);
+
+    expect(byName('vela-web-client')).toBeDefined();
+    expect(byName('vela-test-client')).toBeDefined();
+    expect(byName('vela-mobile-client')).toBeDefined();
+
+    const names = clients.map((c) => c.Properties.ClientName);
+    expect(new Set(names).size).toBe(3);
+  });
+
+  test('web client contract is unchanged by the mobile client addition', () => {
+    const template = synthesizeTemplate();
+    const clients = template.findResources('AWS::Cognito::UserPoolClient');
+    const web = Object.values(clients).find((c) => c.Properties.ClientName === 'vela-web-client');
+
+    expect(web!.Properties.SupportedIdentityProviders).toEqual(['Google']);
+    expect(web!.Properties.AllowedOAuthFlows).toEqual(['code']);
+    expect(web!.Properties.AllowedOAuthFlowsUserPoolClient).toBe(true);
+    expect(web!.Properties.AllowedOAuthScopes.toSorted()).toEqual(['email', 'openid', 'profile']);
+    expect(web!.Properties.ExplicitAuthFlows).toEqual(['ALLOW_REFRESH_TOKEN_AUTH']);
+    expect(web!.Properties.GenerateSecret).toBeFalsy();
+    expect(web!.Properties.CallbackURLs).toEqual(
+      expect.arrayContaining([
+        'https://vela.cwchanap.dev/auth/callback',
+        'http://localhost:9000/auth/callback',
+        'http://127.0.0.1:9000/auth/callback',
+      ]),
+    );
+    expect(web!.Properties.LogoutURLs).toEqual(
+      expect.arrayContaining([
+        'https://vela.cwchanap.dev/auth/login',
+        'http://localhost:9000/auth/login',
+        'http://127.0.0.1:9000/auth/login',
+      ]),
+    );
+  });
+
+  test('exposes the mobile client as a public field on AuthStack', () => {
+    const { stack } = synthesizeStack();
+
+    expect(stack.mobileUserPoolClient).toBeDefined();
+    expect(stack.mobileUserPoolClient.userPoolClientId).toBeDefined();
   });
 });

--- a/packages/cdk/test/auth-stack.test.ts
+++ b/packages/cdk/test/auth-stack.test.ts
@@ -455,20 +455,58 @@ describe('AuthStack', () => {
     );
   });
 
-  test('accepts mobile URIs with a query string on an allowed path', () => {
-    // A query string is valid — Cognito appends `?code=...` to the callback
-    // URI. The allowlist check uses `parsed.pathname`, which excludes the
-    // query, so `/oauth/callback?code=abc` matches `/oauth/callback`.
+  test('rejects mobile URIs with a query string on an allowed path', () => {
+    // RFC 6749 §3.1.2 requires that a query component on the registered
+    // redirect URI be retained when the authorization server appends
+    // response parameters. Cognito appends `code`, `state`, etc. at
+    // redirect time, so a static query like `?code=abc` would produce an
+    // ambiguous callback with duplicate parameter values
+    // (e.g. `?code=abc&code=<actual>`). Reject any query string — there
+    // is no current need for static query parameters on mobile redirect
+    // URIs.
     process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth:/oauth/callback?code=abc';
 
-    const template = synthesizeTemplate();
-    const clients = template.findResources('AWS::Cognito::UserPoolClient');
-    const mobile = Object.values(clients).find(
-      (c) => c.Properties.ClientName === 'vela-mobile-client',
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_CALLBACK_URLS must not include a query string \(Cognito appends OAuth response parameters to the redirect URI at redirect time; a static query would collide with them and produce ambiguous duplicate parameters\)\. Got: dev\.cwchanap\.vela\.oauth:\/oauth\/callback\?code=abc/,
     );
-    expect(mobile!.Properties.CallbackURLs).toEqual([
-      'dev.cwchanap.vela.oauth:/oauth/callback?code=abc',
-    ]);
+
+    // A non-reserved query parameter is also rejected — the simpler
+    // "no query" rule is safer than maintaining a reserved-parameter
+    // blocklist, and no current override needs static query params.
+    process.env.COGNITO_MOBILE_CALLBACK_URLS =
+      'dev.cwchanap.vela.oauth:/oauth/callback?environment=staging';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_CALLBACK_URLS must not include a query string/,
+    );
+
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth:/oauth/logout?foo=bar';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_LOGOUT_URLS must not include a query string/,
+    );
+  });
+
+  test('rejects mobile URIs that rely on dot-segment normalization', () => {
+    // WHATWG URL parsing normalizes dot segments, so
+    // `dev.cwchanap.vela.oauth:/oauth/temporary/../callback` parses to
+    // pathname `/oauth/callback` and would pass the path allowlist. But
+    // the raw string registered with Cognito is not the allowlisted URI.
+    // Require the raw URI to exactly match `scheme:<allowedPath>`.
+    process.env.COGNITO_MOBILE_CALLBACK_URLS =
+      'dev.cwchanap.vela.oauth:/oauth/temporary/../callback';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_CALLBACK_URLS must exactly match an allowed mobile redirect URI \(dot-segment normalization and other parser transforms are rejected; the raw string registered with Cognito must be the allowlisted URI\)\. Got: dev\.cwchanap\.vela\.oauth:\/oauth\/temporary\/\.\.\/callback/,
+    );
+
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth:/oauth/temporary/../logout';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_LOGOUT_URLS must exactly match an allowed mobile redirect URI/,
+    );
   });
 
   test('rejects mobile URIs with a fragment-only suffix', () => {

--- a/packages/cdk/test/auth-stack.test.ts
+++ b/packages/cdk/test/auth-stack.test.ts
@@ -335,30 +335,32 @@ describe('AuthStack', () => {
   test('rejects mobile callback/logout URIs that do not use the registered scheme', () => {
     process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.dev://oauth/callback';
 
+    // Wrong-scheme branch: message names the scheme, not the path.
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_CALLBACK_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme/,
+      /COGNITO_MOBILE_CALLBACK_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme \(Info\.plist only registers that scheme\)\. Got: dev\.cwchanap\.vela\.dev:\/\/oauth\/callback/,
     );
 
     process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
     process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.dev://oauth/logout';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_LOGOUT_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme/,
+      /COGNITO_MOBILE_LOGOUT_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme \(Info\.plist only registers that scheme\)\. Got: dev\.cwchanap\.vela\.dev:\/\/oauth\/logout/,
     );
   });
 
   test('rejects mobile URIs with the right scheme but an empty path', () => {
     process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth://';
 
+    // Right-scheme / bad-path branch: message names the path, not the scheme.
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_CALLBACK_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme with a non-empty path/,
+      /COGNITO_MOBILE_CALLBACK_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/$/,
     );
 
     process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
     process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_LOGOUT_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme with a non-empty path/,
+      /COGNITO_MOBILE_LOGOUT_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/$/,
     );
   });
 
@@ -368,7 +370,7 @@ describe('AuthStack', () => {
     process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth:// ';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_CALLBACK_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme with a non-empty path/,
+      /COGNITO_MOBILE_CALLBACK_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\//,
     );
   });
 
@@ -379,14 +381,14 @@ describe('AuthStack', () => {
     process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth://?code=abc';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_CALLBACK_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme with a non-empty path/,
+      /COGNITO_MOBILE_CALLBACK_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\//,
     );
 
     process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
     process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://#fragment';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_LOGOUT_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme with a non-empty path/,
+      /COGNITO_MOBILE_LOGOUT_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\//,
     );
   });
 

--- a/packages/cdk/test/auth-stack.test.ts
+++ b/packages/cdk/test/auth-stack.test.ts
@@ -262,8 +262,8 @@ describe('AuthStack', () => {
 
     template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
       ClientName: 'vela-mobile-client',
-      CallbackURLs: ['dev.cwchanap.vela.oauth://oauth/callback'],
-      LogoutURLs: ['dev.cwchanap.vela.oauth://oauth/logout'],
+      CallbackURLs: ['dev.cwchanap.vela.oauth:/oauth/callback'],
+      LogoutURLs: ['dev.cwchanap.vela.oauth:/oauth/logout'],
     });
   });
 
@@ -289,8 +289,8 @@ describe('AuthStack', () => {
 
   test('mobile callback/logout URIs are overridable via env vars (same-scheme only)', () => {
     process.env.COGNITO_MOBILE_CALLBACK_URLS =
-      'dev.cwchanap.vela.oauth://oauth/staging-callback,dev.cwchanap.vela.oauth://oauth/callback';
-    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://oauth/staging-logout';
+      'dev.cwchanap.vela.oauth:/oauth/staging-callback,dev.cwchanap.vela.oauth:/oauth/callback';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth:/oauth/staging-logout';
 
     const template = synthesizeTemplate();
     const clients = template.findResources('AWS::Cognito::UserPoolClient');
@@ -299,11 +299,11 @@ describe('AuthStack', () => {
 
     const mobile = byName('vela-mobile-client');
     expect(mobile!.Properties.CallbackURLs).toEqual([
-      'dev.cwchanap.vela.oauth://oauth/staging-callback',
-      'dev.cwchanap.vela.oauth://oauth/callback',
+      'dev.cwchanap.vela.oauth:/oauth/staging-callback',
+      'dev.cwchanap.vela.oauth:/oauth/callback',
     ]);
     expect(mobile!.Properties.LogoutURLs).toEqual([
-      'dev.cwchanap.vela.oauth://oauth/staging-logout',
+      'dev.cwchanap.vela.oauth:/oauth/staging-logout',
     ]);
 
     const web = byName('vela-web-client');
@@ -329,114 +329,156 @@ describe('AuthStack', () => {
 
     template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
       ClientName: 'vela-mobile-client',
-      CallbackURLs: ['dev.cwchanap.vela.oauth://oauth/callback'],
-      LogoutURLs: ['dev.cwchanap.vela.oauth://oauth/logout'],
+      CallbackURLs: ['dev.cwchanap.vela.oauth:/oauth/callback'],
+      LogoutURLs: ['dev.cwchanap.vela.oauth:/oauth/logout'],
     });
   });
 
   test('rejects mobile callback/logout URIs that do not use the registered scheme', () => {
-    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.dev://oauth/callback';
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.dev:/oauth/callback';
 
     // Wrong-scheme branch: message names the scheme, not the path.
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_CALLBACK_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme \(Info\.plist only registers that scheme\)\. Got: dev\.cwchanap\.vela\.dev:\/\/oauth\/callback/,
+      /COGNITO_MOBILE_CALLBACK_URLS must use the dev\.cwchanap\.vela\.oauth:\/ scheme \(Info\.plist only registers that scheme\)\. Got: dev\.cwchanap\.vela\.dev:\/oauth\/callback/,
     );
 
     process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
-    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.dev://oauth/logout';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.dev:/oauth/logout';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_LOGOUT_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme \(Info\.plist only registers that scheme\)\. Got: dev\.cwchanap\.vela\.dev:\/\/oauth\/logout/,
+      /COGNITO_MOBILE_LOGOUT_URLS must use the dev\.cwchanap\.vela\.oauth:\/ scheme \(Info\.plist only registers that scheme\)\. Got: dev\.cwchanap\.vela\.dev:\/oauth\/logout/,
     );
   });
 
-  test('rejects mobile URIs with the right scheme but an empty path', () => {
-    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth://';
+  test('rejects the RFC 8252 authority form (scheme://host/path) for private-use URIs', () => {
+    // RFC 8252 §7.1 requires the single-slash form (`scheme:/path`) for
+    // private-use URI schemes because there is no naming authority. The
+    // `://` form introduces a spurious host component. `startsWith` alone
+    // cannot distinguish `:/` from `://` (the latter contains the former);
+    // `parsed.host !== ''` catches the authority form after parsing.
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth://oauth/callback';
 
-    // Right-scheme / bad-path branch: message names the path, not the scheme.
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_CALLBACK_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path; the app's router would have no matching route\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/$/,
+      /COGNITO_MOBILE_CALLBACK_URLS must use the dev\.cwchanap\.vela\.oauth:\/ form \(no authority component\), not dev\.cwchanap\.vela\.oauth:\/\/\. RFC 8252 §7\.1 requires a single slash for private-use URI schemes\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth\/callback/,
     );
 
     process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
-    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://oauth/logout';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_LOGOUT_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path; the app's router would have no matching route\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/$/,
+      /COGNITO_MOBILE_LOGOUT_URLS must use the dev\.cwchanap\.vela\.oauth:\/ form \(no authority component\), not dev\.cwchanap\.vela\.oauth:\/\/\. RFC 8252 §7\.1 requires a single slash for private-use URI schemes\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth\/logout/,
+    );
+  });
+
+  test('rejects mobile URIs with the right scheme but a path not in the allowlist', () => {
+    // The validator enforces an explicit path allowlist — a typo like
+    // `/oauth/typo` would deploy silently and the callback would be
+    // dropped on-device because the app's router has no matching route.
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth:/oauth/typo';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_CALLBACK_URLS path must be one of \[\/oauth\/callback, \/oauth\/staging-callback\] \(the app's router has no matching route for other paths\)\. Got: dev\.cwchanap\.vela\.oauth:\/oauth\/typo/,
+    );
+
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth:/oauth/typo';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_LOGOUT_URLS path must be one of \[\/oauth\/logout, \/oauth\/staging-logout\] \(the app's router has no matching route for other paths\)\. Got: dev\.cwchanap\.vela\.oauth:\/oauth\/typo/,
+    );
+  });
+
+  test('rejects mobile URIs with an empty path (root only)', () => {
+    // `dev.cwchanap.vela.oauth:/` has pathname `/` — not in the allowlist.
+    // `dev.cwchanap.vela.oauth:/oauth` has pathname `/oauth` — also not in
+    // the allowlist. Both would leave the app's router with no matching route.
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth:/';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_CALLBACK_URLS path must be one of \[\/oauth\/callback, \/oauth\/staging-callback\]/,
+    );
+
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth:/oauth';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_CALLBACK_URLS path must be one of \[\/oauth\/callback, \/oauth\/staging-callback\]/,
+    );
+
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth:/';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_LOGOUT_URLS path must be one of \[\/oauth\/logout, \/oauth\/staging-logout\]/,
     );
   });
 
   test('rejects mobile URIs with a whitespace-only path', () => {
-    // `parseCommaList` trims each entry before `assertMobileScheme` sees
-    // it, so `dev.cwchanap.vela.oauth:// ` arrives as
-    // `dev.cwchanap.vela.oauth://` — the trailing space is already gone.
-    // The path-empty check then rejects it. (Internal whitespace within
-    // a path is NOT trimmed by `parseCommaList` and is caught by the
-    // raw-string whitespace check — see the internal-whitespace test.)
-    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth:// ';
+    // `parseCommaList` trims each entry before `assertMobileRedirect` sees
+    // it, so `dev.cwchanap.vela.oauth:/ ` arrives as
+    // `dev.cwchanap.vela.oauth:/` — the trailing space is already gone.
+    // The path-not-in-allowlist check then rejects it (`/` is not allowed).
+    // (Internal whitespace within a path is NOT trimmed by `parseCommaList`
+    // and is caught by the raw-string whitespace check — see the
+    // internal-whitespace test.)
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth:/ ';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_CALLBACK_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path; the app's router would have no matching route\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/$/,
+      /COGNITO_MOBILE_CALLBACK_URLS path must be one of \[\/oauth\/callback, \/oauth\/staging-callback\]/,
     );
   });
 
-  test('rejects mobile URIs with an authority-only path (no pathname)', () => {
-    // `dev.cwchanap.vela.oauth://oauth` has `oauth` as the host and an empty
-    // pathname per WHATWG URL parsing. A regex like `[^\s?#]+` would accept it
-    // (treating `oauth` as the path), but the app's router would have no
-    // matching route because the path that distinguishes callback vs logout
-    // is missing. `new URL()` correctly assigns `oauth` to `host` and leaves
-    // `pathname` empty, which the validator rejects.
-    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth://oauth';
+  test('rejects mobile URIs with a trailing slash on an allowed path', () => {
+    // `dev.cwchanap.vela.oauth:/oauth/callback/` has pathname
+    // `/oauth/callback/` — not in the allowlist (trailing slash changes the
+    // route). The app's router would have no matching route.
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth:/oauth/callback/';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_CALLBACK_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path; the app's router would have no matching route\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth$/,
+      /COGNITO_MOBILE_CALLBACK_URLS path must be one of \[\/oauth\/callback, \/oauth\/staging-callback\]/,
     );
 
     process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
-    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://oauth';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth:/oauth/logout/';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_LOGOUT_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path; the app's router would have no matching route\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth$/,
+      /COGNITO_MOBILE_LOGOUT_URLS path must be one of \[\/oauth\/logout, \/oauth\/staging-logout\]/,
     );
   });
 
-  test('rejects mobile URIs with a root-only path (slash after authority)', () => {
-    // `dev.cwchanap.vela.oauth://oauth/` has pathname `/` — the authority is
-    // present but the path is just the root slash, which does not distinguish
-    // callback from logout. The app's router would have no matching route.
-    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth://oauth/';
+  test('rejects mobile URIs with a query-only suffix (no path)', () => {
+    // `dev.cwchanap.vela.oauth:/?code=abc` has pathname `/` — not in the
+    // allowlist. The app's router would have no matching route.
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth:/?code=abc';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_CALLBACK_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/.*Got: dev\.cwchanap\.vela\.oauth:\/\/oauth\/$/,
-    );
-
-    process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
-    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://oauth/';
-
-    expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_LOGOUT_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/.*Got: dev\.cwchanap\.vela\.oauth:\/\/oauth\/$/,
+      /COGNITO_MOBILE_CALLBACK_URLS path must be one of \[\/oauth\/callback, \/oauth\/staging-callback\]/,
     );
   });
 
-  test('rejects mobile URIs with a query-only or fragment-only suffix', () => {
-    // A URI like `scheme://?foo` has no path component; `\S+` alone would
-    // accept it because `?` is non-whitespace. The app's router would have
-    // no matching route for the empty path → callback silently dropped.
-    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth://?code=abc';
+  test('accepts mobile URIs with a query string on an allowed path', () => {
+    // A query string is valid — Cognito appends `?code=...` to the callback
+    // URI. The allowlist check uses `parsed.pathname`, which excludes the
+    // query, so `/oauth/callback?code=abc` matches `/oauth/callback`.
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth:/oauth/callback?code=abc';
 
-    expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_CALLBACK_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\//,
+    const template = synthesizeTemplate();
+    const clients = template.findResources('AWS::Cognito::UserPoolClient');
+    const mobile = Object.values(clients).find(
+      (c) => c.Properties.ClientName === 'vela-mobile-client',
     );
+    expect(mobile!.Properties.CallbackURLs).toEqual([
+      'dev.cwchanap.vela.oauth:/oauth/callback?code=abc',
+    ]);
+  });
 
-    // `scheme://#bar` is rejected by the raw-string `#` check (before
+  test('rejects mobile URIs with a fragment-only suffix', () => {
+    // `scheme:/#bar` is rejected by the raw-string `#` check (before
     // parsing) with a fragment-specific error — Cognito rejects any
     // redirect URI containing a fragment component, regardless of path.
-    process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
-    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://#fragment';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth:/#fragment';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_LOGOUT_URLS must not contain a fragment \(Cognito rejects redirect URIs with a `#` component\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/#fragment/,
+      /COGNITO_MOBILE_LOGOUT_URLS must not contain a fragment \(Cognito rejects redirect URIs with a `#` component\)\. Got: dev\.cwchanap\.vela\.oauth:\/#fragment/,
     );
   });
 
@@ -445,17 +487,17 @@ describe('AuthStack', () => {
     // (see CreateUserPoolClient docs: "Not include a fragment component").
     // Without this guard, synth succeeds and deploy fails at the
     // AWS::Cognito::UserPoolClient resource.
-    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth://oauth/callback#fragment';
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth:/oauth/callback#fragment';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_CALLBACK_URLS must not contain a fragment \(Cognito rejects redirect URIs with a `#` component\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth\/callback#fragment/,
+      /COGNITO_MOBILE_CALLBACK_URLS must not contain a fragment \(Cognito rejects redirect URIs with a `#` component\)\. Got: dev\.cwchanap\.vela\.oauth:\/oauth\/callback#fragment/,
     );
 
     process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
-    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://oauth/logout#fragment';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth:/oauth/logout#fragment';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_LOGOUT_URLS must not contain a fragment \(Cognito rejects redirect URIs with a `#` component\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth\/logout#fragment/,
+      /COGNITO_MOBILE_LOGOUT_URLS must not contain a fragment \(Cognito rejects redirect URIs with a `#` component\)\. Got: dev\.cwchanap\.vela\.oauth:\/oauth\/logout#fragment/,
     );
   });
 
@@ -465,17 +507,17 @@ describe('AuthStack', () => {
     // contains `#`, and Cognito rejects any redirect URI with a fragment
     // component — including a bare trailing `#` with empty fragment.
     // The raw-string `uri.includes('#')` check catches this before parsing.
-    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth://oauth/callback#';
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth:/oauth/callback#';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_CALLBACK_URLS must not contain a fragment \(Cognito rejects redirect URIs with a `#` component\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth\/callback#$/,
+      /COGNITO_MOBILE_CALLBACK_URLS must not contain a fragment \(Cognito rejects redirect URIs with a `#` component\)\. Got: dev\.cwchanap\.vela\.oauth:\/oauth\/callback#$/,
     );
 
     process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
-    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://oauth/logout#';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth:/oauth/logout#';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_LOGOUT_URLS must not contain a fragment \(Cognito rejects redirect URIs with a `#` component\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth\/logout#$/,
+      /COGNITO_MOBILE_LOGOUT_URLS must not contain a fragment \(Cognito rejects redirect URIs with a `#` component\)\. Got: dev\.cwchanap\.vela\.oauth:\/oauth\/logout#$/,
     );
   });
 
@@ -486,30 +528,30 @@ describe('AuthStack', () => {
     // pattern excludes. The raw-string `/\s/u` check catches these before
     // parsing.
     const cases = [
-      'dev.cwchanap.vela.oauth://oauth/callback trailing',
-      'dev.cwchanap.vela.oauth://oauth/callback\tsuffix',
-      'dev.cwchanap.vela.oauth://oauth/callback\nsuffix',
+      'dev.cwchanap.vela.oauth:/oauth/callback trailing',
+      'dev.cwchanap.vela.oauth:/oauth/callback\tsuffix',
+      'dev.cwchanap.vela.oauth:/oauth/callback\nsuffix',
     ];
 
     for (const uri of cases) {
       process.env.COGNITO_MOBILE_CALLBACK_URLS = uri;
       expect(() => synthesizeTemplate()).toThrow(
-        /COGNITO_MOBILE_CALLBACK_URLS must not contain whitespace \(Cognito rejects redirect URIs containing whitespace characters\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth\/callback[\s\S]*$/,
+        /COGNITO_MOBILE_CALLBACK_URLS must not contain whitespace \(Cognito rejects redirect URIs containing whitespace characters\)\. Got: dev\.cwchanap\.vela\.oauth:\/oauth\/callback[\s\S]*$/,
       );
       process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
     }
 
     // Logout URLs: same bypass, same fix.
     const logoutCases = [
-      'dev.cwchanap.vela.oauth://oauth/logout trailing',
-      'dev.cwchanap.vela.oauth://oauth/logout\tsuffix',
-      'dev.cwchanap.vela.oauth://oauth/logout\nsuffix',
+      'dev.cwchanap.vela.oauth:/oauth/logout trailing',
+      'dev.cwchanap.vela.oauth:/oauth/logout\tsuffix',
+      'dev.cwchanap.vela.oauth:/oauth/logout\nsuffix',
     ];
 
     for (const uri of logoutCases) {
       process.env.COGNITO_MOBILE_LOGOUT_URLS = uri;
       expect(() => synthesizeTemplate()).toThrow(
-        /COGNITO_MOBILE_LOGOUT_URLS must not contain whitespace \(Cognito rejects redirect URIs containing whitespace characters\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth\/logout[\s\S]*$/,
+        /COGNITO_MOBILE_LOGOUT_URLS must not contain whitespace \(Cognito rejects redirect URIs containing whitespace characters\)\. Got: dev\.cwchanap\.vela\.oauth:\/oauth\/logout[\s\S]*$/,
       );
       process.env.COGNITO_MOBILE_LOGOUT_URLS = '';
     }
@@ -604,7 +646,11 @@ describe('AuthStack', () => {
     );
     expect(mobile).toBeDefined();
     const cdkCallbackUrl = mobile!.Properties.CallbackURLs[0] as string;
-    const cdkScheme = cdkCallbackUrl.split('://')[0];
+    // Extract the scheme via WHATWG URL parsing. The mobile callback URI
+    // uses the RFC 8252 §7.1 private-use form (`scheme:/path`, no
+    // authority), so `split('://')` would not split — `new URL().protocol`
+    // reliably yields `scheme:` regardless of `:/` vs `://` form.
+    const cdkScheme = new URL(cdkCallbackUrl).protocol.replace(/:$/, '');
 
     // Extract the scheme from Info.plist. The plist is XML text; a regex
     // on the CFBundleURLSchemes array is sufficient (the mobile test suite

--- a/packages/cdk/test/auth-stack.test.ts
+++ b/packages/cdk/test/auth-stack.test.ts
@@ -372,6 +372,24 @@ describe('AuthStack', () => {
     );
   });
 
+  test('rejects mobile URIs with a query-only or fragment-only suffix', () => {
+    // A URI like `scheme://?foo` or `scheme://#bar` has no path component;
+    // `\S+` alone would accept it because `?` and `#` are non-whitespace.
+    // iOS would have no handler registered for the empty path → no-op callback.
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth://?code=abc';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_CALLBACK_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme with a non-empty path/,
+    );
+
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://#fragment';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_LOGOUT_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme with a non-empty path/,
+    );
+  });
+
   test('mobile client is distinct from web and test clients', () => {
     const template = synthesizeTemplate();
     const clients = Object.values(template.findResources('AWS::Cognito::UserPoolClient'));

--- a/packages/cdk/test/auth-stack.test.ts
+++ b/packages/cdk/test/auth-stack.test.ts
@@ -394,4 +394,19 @@ describe('AuthStack', () => {
     expect(stack.mobileUserPoolClient).toBeDefined();
     expect(stack.mobileUserPoolClient.userPoolClientId).toBeDefined();
   });
+
+  // Pins the intentional enableTokenRevocation: true hardening applied to
+  // every client. It is a runtime no-op until RevokeToken is called, but
+  // pinning the synthesized template prevents a future refactor from silently
+  // dropping it. See auth-stack.ts for the rationale.
+  test('pins enableTokenRevocation=true on all three clients', () => {
+    const template = synthesizeTemplate();
+    const clients = Object.values(template.findResources('AWS::Cognito::UserPoolClient'));
+
+    expect(clients.length).toBe(3);
+    for (const client of clients) {
+      expect(client.Properties.ClientName).toMatch(/^vela-(web|mobile|test)-client$/);
+      expect(client.Properties.EnableTokenRevocation).toBe(true);
+    }
+  });
 });

--- a/packages/cdk/test/auth-stack.test.ts
+++ b/packages/cdk/test/auth-stack.test.ts
@@ -1,6 +1,8 @@
 import { App } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { AuthStack } from '../lib/auth-stack';
 
 describe('AuthStack', () => {
@@ -353,14 +355,14 @@ describe('AuthStack', () => {
 
     // Right-scheme / bad-path branch: message names the path, not the scheme.
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_CALLBACK_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/$/,
+      /COGNITO_MOBILE_CALLBACK_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path; the app's router would have no matching route\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/$/,
     );
 
     process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
     process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_LOGOUT_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/$/,
+      /COGNITO_MOBILE_LOGOUT_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path; the app's router would have no matching route\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/$/,
     );
   });
 
@@ -374,35 +376,35 @@ describe('AuthStack', () => {
     process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth:// ';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_CALLBACK_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/$/,
+      /COGNITO_MOBILE_CALLBACK_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path; the app's router would have no matching route\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/$/,
     );
   });
 
   test('rejects mobile URIs with an authority-only path (no pathname)', () => {
     // `dev.cwchanap.vela.oauth://oauth` has `oauth` as the host and an empty
     // pathname per WHATWG URL parsing. A regex like `[^\s?#]+` would accept it
-    // (treating `oauth` as the path), but iOS would dispatch to a no-op
-    // handler because the path that distinguishes callback vs logout is
-    // missing. `new URL()` correctly assigns `oauth` to `host` and leaves
+    // (treating `oauth` as the path), but the app's router would have no
+    // matching route because the path that distinguishes callback vs logout
+    // is missing. `new URL()` correctly assigns `oauth` to `host` and leaves
     // `pathname` empty, which the validator rejects.
     process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth://oauth';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_CALLBACK_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth$/,
+      /COGNITO_MOBILE_CALLBACK_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path; the app's router would have no matching route\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth$/,
     );
 
     process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
     process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://oauth';
 
     expect(() => synthesizeTemplate()).toThrow(
-      /COGNITO_MOBILE_LOGOUT_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path and dispatch to a no-op handler on-device\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth$/,
+      /COGNITO_MOBILE_LOGOUT_URLS must include a non-empty, non-whitespace path after dev\.cwchanap\.vela\.oauth:\/\/ \(query-only and fragment-only URIs have no path; the app's router would have no matching route\)\. Got: dev\.cwchanap\.vela\.oauth:\/\/oauth$/,
     );
   });
 
   test('rejects mobile URIs with a root-only path (slash after authority)', () => {
     // `dev.cwchanap.vela.oauth://oauth/` has pathname `/` — the authority is
     // present but the path is just the root slash, which does not distinguish
-    // callback from logout. iOS would dispatch to a no-op handler.
+    // callback from logout. The app's router would have no matching route.
     process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth://oauth/';
 
     expect(() => synthesizeTemplate()).toThrow(
@@ -419,8 +421,8 @@ describe('AuthStack', () => {
 
   test('rejects mobile URIs with a query-only or fragment-only suffix', () => {
     // A URI like `scheme://?foo` has no path component; `\S+` alone would
-    // accept it because `?` is non-whitespace. iOS would have no handler
-    // registered for the empty path → no-op callback.
+    // accept it because `?` is non-whitespace. The app's router would have
+    // no matching route for the empty path → callback silently dropped.
     process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth://?code=abc';
 
     expect(() => synthesizeTemplate()).toThrow(
@@ -577,5 +579,63 @@ describe('AuthStack', () => {
       expect(client.Properties.ClientName).toMatch(/^vela-(web|mobile|test)-client$/);
       expect(client.Properties.EnableTokenRevocation).toBe(true);
     }
+  });
+
+  // Cross-layer contract test: the iOS custom URL scheme registered in
+  // Info.plist must match the scheme used in the CDK mobile client's
+  // callback/logout URIs. The scheme is hardcoded independently in CDK
+  // source (MOBILE_OAUTH_SCHEME) and in Info.plist (CFBundleURLSchemes).
+  // Without this test, a change to one without the other would leave all
+  // existing tests green while OAuth callbacks fail on-device: iOS would
+  // not dispatch the CDK-configured callback URL to the app (or vice
+  // versa, the app would register a scheme Cognito never sends).
+  //
+  // This test reads the Info.plist directly (cross-package file read, no
+  // runtime dependency) and compares the scheme against the mobile
+  // client's synthesized CallbackURLs. The mobile info-plist.test.ts
+  // suite independently asserts the plist structure; this test only
+  // bridges the two packages' scheme constants.
+  test('CDK mobile callback scheme matches the iOS Info.plist CFBundleURLSchemes entry', () => {
+    // Extract the scheme from the synthesized CDK template.
+    const template = synthesizeTemplate();
+    const clients = template.findResources('AWS::Cognito::UserPoolClient');
+    const mobile = Object.values(clients).find(
+      (c) => c.Properties.ClientName === 'vela-mobile-client',
+    );
+    expect(mobile).toBeDefined();
+    const cdkCallbackUrl = mobile!.Properties.CallbackURLs[0] as string;
+    const cdkScheme = cdkCallbackUrl.split('://')[0];
+
+    // Extract the scheme from Info.plist. The plist is XML text; a regex
+    // on the CFBundleURLSchemes array is sufficient (the mobile test suite
+    // already validates the plist structure more thoroughly).
+    const plistPath = resolve(
+      __dirname,
+      '../../../apps/vela-mobile/src-capacitor/ios/App/App/Info.plist',
+    );
+    const plistContent = readFileSync(plistPath, 'utf8');
+
+    // Guard against binary plists — would produce a misleading failure.
+    expect(
+      !plistContent.startsWith('bplist'),
+      `${plistPath} is a binary plist. Convert it: plutil -convert xml1 "${plistPath}".`,
+    ).toBe(true);
+
+    const schemesBlock = plistContent.match(
+      /<key>CFBundleURLSchemes<\/key>\s*<array>([\s\S]*?)<\/array>/,
+    );
+    expect(schemesBlock, 'CFBundleURLSchemes entry not found in Info.plist').not.toBeNull();
+    const plistSchemes: string[] = [];
+    const stringRegex = /<string>([^<]+)<\/string>/g;
+    let match: RegExpExecArray | null;
+    while ((match = stringRegex.exec(schemesBlock![1])) !== null) {
+      if (match[1] !== undefined) plistSchemes.push(match[1]);
+    }
+    expect(plistSchemes, 'Info.plist CFBundleURLSchemes array is empty').not.toHaveLength(0);
+
+    // The CDK scheme must be registered in Info.plist. If this fails, either
+    // update Info.plist's CFBundleURLSchemes or the CDK MOBILE_OAUTH_SCHEME
+    // constant — they must stay in sync.
+    expect(plistSchemes).toContain(cdkScheme);
   });
 });

--- a/packages/cdk/test/auth-stack.test.ts
+++ b/packages/cdk/test/auth-stack.test.ts
@@ -362,6 +362,16 @@ describe('AuthStack', () => {
     );
   });
 
+  test('rejects mobile URIs with a whitespace-only path', () => {
+    // `.+` would accept `scheme:// ` (space-only path); `\S+` rejects it.
+    // Cognito would store the URI but iOS would dispatch to a no-op handler.
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth:// ';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_CALLBACK_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme with a non-empty path/,
+    );
+  });
+
   test('mobile client is distinct from web and test clients', () => {
     const template = synthesizeTemplate();
     const clients = Object.values(template.findResources('AWS::Cognito::UserPoolClient'));

--- a/packages/cdk/test/auth-stack.test.ts
+++ b/packages/cdk/test/auth-stack.test.ts
@@ -347,6 +347,21 @@ describe('AuthStack', () => {
     );
   });
 
+  test('rejects mobile URIs with the right scheme but an empty path', () => {
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = 'dev.cwchanap.vela.oauth://';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_CALLBACK_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme with a non-empty path/,
+    );
+
+    process.env.COGNITO_MOBILE_CALLBACK_URLS = '';
+    process.env.COGNITO_MOBILE_LOGOUT_URLS = 'dev.cwchanap.vela.oauth://';
+
+    expect(() => synthesizeTemplate()).toThrow(
+      /COGNITO_MOBILE_LOGOUT_URLS must use the dev\.cwchanap\.vela\.oauth:\/\/ scheme with a non-empty path/,
+    );
+  });
+
   test('mobile client is distinct from web and test clients', () => {
     const template = synthesizeTemplate();
     const clients = Object.values(template.findResources('AWS::Cognito::UserPoolClient'));
@@ -361,7 +376,7 @@ describe('AuthStack', () => {
     expect(new Set(names).size).toBe(3);
   });
 
-  test('web client contract is unchanged by the mobile client addition', () => {
+  test('web client OAuth contract is unchanged by the mobile client addition', () => {
     const template = synthesizeTemplate();
     const clients = template.findResources('AWS::Cognito::UserPoolClient');
     const web = Object.values(clients).find((c) => c.Properties.ClientName === 'vela-web-client');
@@ -396,9 +411,10 @@ describe('AuthStack', () => {
   });
 
   // Pins the intentional enableTokenRevocation: true hardening applied to
-  // every client. It is a runtime no-op until RevokeToken is called, but
-  // pinning the synthesized template prevents a future refactor from silently
-  // dropping it. See auth-stack.ts for the rationale.
+  // every client. It adds origin_jti/origin_iat claims to access tokens and
+  // enables the RevokeToken endpoint; pinning the synthesized template
+  // prevents a future refactor from silently dropping it. See auth-stack.ts
+  // for the rationale.
   test('pins enableTokenRevocation=true on all three clients', () => {
     const template = synthesizeTemplate();
     const clients = Object.values(template.findResources('AWS::Cognito::UserPoolClient'));

--- a/packages/cdk/test/static-web-stack.test.ts
+++ b/packages/cdk/test/static-web-stack.test.ts
@@ -75,11 +75,12 @@ describe('StaticWebStack', () => {
       { Value: unknown; Description?: string }
     >;
     expect(outputs.CognitoMobileUserPoolClientId).toBeDefined();
-    // Pin the description so a future edit (e.g. dropping "public, PKCE" or
-    // swapping it for the web client's description) is caught. The description
-    // documents the security-relevant "public client, no secret" property.
+    // Pin the description so a future edit (e.g. dropping "public, no client
+    // secret" or swapping it for the web client's description) is caught. The
+    // description documents the security-relevant "public client, no secret"
+    // property. PKCE is not yet implemented (M2 work); do not advertise it here.
     expect(outputs.CognitoMobileUserPoolClientId.Description).toBe(
-      'Cognito User Pool Client ID for the iOS mobile app (public, PKCE)',
+      'Cognito User Pool Client ID for the iOS mobile app (public, no client secret)',
     );
 
     // The Value must reference the *mobile* client, not the web or test client.

--- a/packages/cdk/test/static-web-stack.test.ts
+++ b/packages/cdk/test/static-web-stack.test.ts
@@ -1,6 +1,9 @@
 import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { AuthStack } from '../lib/auth-stack';
 import { DatabaseStack } from '../lib/database-stack';
 import { StorageStack } from '../lib/storage-stack';
@@ -9,6 +12,7 @@ import { StaticWebStack } from '../lib/static-web-stack';
 
 describe('StaticWebStack', () => {
   const originalEnv = { ...process.env };
+  let spaDistDir: string | undefined;
 
   beforeEach(() => {
     process.env = { ...originalEnv };
@@ -18,10 +22,22 @@ describe('StaticWebStack', () => {
     process.env.GOOGLE_OAUTH_CLIENT_SECRET_NAME = 'vela/test-google-oauth-client-secret';
     delete process.env.CLOUDFRONT_CERT_ARN;
     delete process.env.ACM_CERT_ARN;
+
+    // Source.asset stats the directory at construct time. Point CDK_SPA_DIST_PATH
+    // at a temp dir with a dummy index.html so tests don't require a built SPA
+    // (`bun run build` in apps/vela). Without this, a fresh checkout fails
+    // synth with "Cannot find asset at .../apps/vela/dist/spa".
+    spaDistDir = mkdtempSync(join(tmpdir(), 'vela-cdk-spa-'));
+    writeFileSync(join(spaDistDir, 'index.html'), '<!doctype html><title>test</title>');
+    process.env.CDK_SPA_DIST_PATH = spaDistDir;
   });
 
   afterEach(() => {
     process.env = originalEnv;
+    if (spaDistDir) {
+      rmSync(spaDistDir, { recursive: true, force: true });
+      spaDistDir = undefined;
+    }
   });
 
   function synthesize() {

--- a/packages/cdk/test/static-web-stack.test.ts
+++ b/packages/cdk/test/static-web-stack.test.ts
@@ -1,0 +1,84 @@
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { AuthStack } from '../lib/auth-stack';
+import { DatabaseStack } from '../lib/database-stack';
+import { StorageStack } from '../lib/storage-stack';
+import { ApiStack } from '../lib/api-stack';
+import { StaticWebStack } from '../lib/static-web-stack';
+
+describe('StaticWebStack', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.ALLOW_LOCAL_OAUTH_PLACEHOLDERS = 'true';
+    process.env.COGNITO_DOMAIN_PREFIX = 'vela-test-auth';
+    process.env.GOOGLE_OAUTH_CLIENT_ID = 'test-google-client-id.apps.googleusercontent.com';
+    process.env.GOOGLE_OAUTH_CLIENT_SECRET_NAME = 'vela/test-google-oauth-client-secret';
+    delete process.env.CLOUDFRONT_CERT_ARN;
+    delete process.env.ACM_CERT_ARN;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  function synthesize() {
+    const app = new App();
+    const stackEnv = { account: '123456789012', region: 'us-east-1' };
+    const auth = new AuthStack(app, 'TestStaticAuthStack', { env: stackEnv });
+    const database = new DatabaseStack(app, 'TestStaticDatabaseStack', { env: stackEnv });
+    const storage = new StorageStack(app, 'TestStaticStorageStack', { env: stackEnv });
+    const api = new ApiStack(app, 'TestStaticApiStack', {
+      env: stackEnv,
+      auth,
+      database,
+      storage,
+    });
+    const staticWeb = new StaticWebStack(app, 'TestStaticWebStack', {
+      env: stackEnv,
+      auth,
+      database,
+      storage,
+      api,
+    });
+    return {
+      stack: staticWeb,
+      template: Template.fromStack(staticWeb),
+      authTemplate: Template.fromStack(auth),
+    };
+  }
+
+  test('exposes CognitoMobileUserPoolClientId wired to the mobile client resource', () => {
+    const { template, authTemplate } = synthesize();
+
+    // The output exists.
+    const outputs = (template.toJSON().Outputs ?? {}) as Record<
+      string,
+      { Value: unknown; Description?: string }
+    >;
+    expect(outputs.CognitoMobileUserPoolClientId).toBeDefined();
+
+    // The Value must reference the *mobile* client, not the web or test client.
+    // AuthStack and StaticWebStack are separate stacks, so CDK renders the
+    // cross-stack reference as { "Fn::ImportValue": "<stack>:ExportsOutputRef<LogicalId><hash>" }
+    // (a same-stack reference would be Fn::GetAtt instead). Both forms embed
+    // the source resource's logical id in the rendered value string.
+    const value = outputs.CognitoMobileUserPoolClientId.Value as Record<string, unknown>;
+    expect(value).toHaveProperty('Fn::ImportValue');
+    const importValue = value['Fn::ImportValue'] as string;
+    expect(importValue).toContain('VelaMobileUserPoolClient');
+    expect(importValue).not.toContain('VelaTestUserPoolClient');
+    // The web client's logical id is just 'VelaUserPoolClient' — guard against
+    // a substring false-positive by checking exact-id membership via findResources.
+    // The UserPoolClient resources live in AuthStack, so the lookup must go there
+    // (the StaticWebStack template only contains CfnOutputs, no client resources).
+    const clients = authTemplate.findResources('AWS::Cognito::UserPoolClient');
+    const mobileLogicalIds = Object.keys(clients).filter(
+      (id) => clients[id].Properties?.ClientName === 'vela-mobile-client',
+    );
+    expect(mobileLogicalIds).toHaveLength(1);
+    expect(importValue).toContain(mobileLogicalIds[0]);
+  });
+});

--- a/packages/cdk/test/static-web-stack.test.ts
+++ b/packages/cdk/test/static-web-stack.test.ts
@@ -103,4 +103,39 @@ describe('StaticWebStack', () => {
     expect(mobileLogicalIds).toHaveLength(1);
     expect(importValue).toContain(mobileLogicalIds[0]);
   });
+
+  // Belt-and-suspenders: the pre-existing CognitoUserPoolClientId output must
+  // still be wired to the *web* client after the mobile client addition. The
+  // web client's resource contract (scopes, flows, redirect URIs) is pinned in
+  // auth-stack.test.ts; this test pins the StaticWebStack output pass-through
+  // so a future edit that accidentally swaps the output's source client is
+  // caught here, not by a downstream consumer getting the wrong client ID.
+  test('exposes CognitoUserPoolClientId wired to the web client resource', () => {
+    const { template, authTemplate } = synthesize();
+
+    const outputs = (template.toJSON().Outputs ?? {}) as Record<
+      string,
+      { Value: unknown; Description?: string }
+    >;
+    expect(outputs.CognitoUserPoolClientId).toBeDefined();
+    expect(outputs.CognitoUserPoolClientId.Description).toBe('Cognito User Pool Client ID');
+
+    const value = outputs.CognitoUserPoolClientId.Value as Record<string, unknown>;
+    expect(value).toHaveProperty('Fn::ImportValue');
+    const importValue = value['Fn::ImportValue'] as string;
+    // The web client's logical id is 'VelaUserPoolClient' (no prefix). Guard
+    // against a substring false-positive (e.g. 'VelaMobileUserPoolClient'
+    // contains 'VelaUserPoolClient' as a substring) by looking up the actual
+    // web-client logical id via findResources and asserting exact membership.
+    expect(importValue).toContain('VelaUserPoolClient');
+    expect(importValue).not.toContain('VelaMobileUserPoolClient');
+    expect(importValue).not.toContain('VelaTestUserPoolClient');
+
+    const clients = authTemplate.findResources('AWS::Cognito::UserPoolClient');
+    const webLogicalIds = Object.keys(clients).filter(
+      (id) => clients[id].Properties?.ClientName === 'vela-web-client',
+    );
+    expect(webLogicalIds).toHaveLength(1);
+    expect(importValue).toContain(webLogicalIds[0]);
+  });
 });

--- a/packages/cdk/test/static-web-stack.test.ts
+++ b/packages/cdk/test/static-web-stack.test.ts
@@ -75,6 +75,12 @@ describe('StaticWebStack', () => {
       { Value: unknown; Description?: string }
     >;
     expect(outputs.CognitoMobileUserPoolClientId).toBeDefined();
+    // Pin the description so a future edit (e.g. dropping "public, PKCE" or
+    // swapping it for the web client's description) is caught. The description
+    // documents the security-relevant "public client, no secret" property.
+    expect(outputs.CognitoMobileUserPoolClientId.Description).toBe(
+      'Cognito User Pool Client ID for the iOS mobile app (public, PKCE)',
+    );
 
     // The Value must reference the *mobile* client, not the web or test client.
     // AuthStack and StaticWebStack are separate stacks, so CDK renders the


### PR DESCRIPTION
## Summary
- Add a public `vela-mobile-client` Cognito user pool client configured for authorization-code grant OAuth (no client secret). The client is PKCE-*compatible* (public, auth-code grant); the PKCE flow itself — verifier generation, `code_challenge` derivation, and `code_verifier` at token exchange — is implemented client-side in M2.
- Validate mobile callback/logout URIs at CDK synth time so only the registered `dev.cwchanap.vela.oauth:/` scheme (RFC 8252 §7.1 private-use form, single slash — the `://` authority form is rejected) is accepted, with an exact path allowlist (`/oauth/callback`, `/oauth/staging-callback`, `/oauth/logout`, `/oauth/staging-logout`), no query string, no fragment, no whitespace, no authority component, and no WHATWG parser normalization (raw URI must exactly match an allowlisted value).
- Expose `CognitoMobileUserPoolClientId` as a `StaticWebStack` CloudFormation output for the iOS app to consume.
- Register `dev.cwchanap.vela.oauth` as an iOS custom URL scheme in `apps/vela-mobile/src-capacitor/ios/App/App/Info.plist`, with a Vitest regression test.
- Document the mobile OAuth flow, env-var overrides, and M2 prerequisites in `CLAUDE.md` and `.env.example`.
- Add the implementation plan under `docs/superpowers/plans`.

### Intentional deviation from plan: `enableTokenRevocation: true` on all clients
Not in the M1 plan but added as defense-in-depth: `EnableTokenRevocation` is now `true` on the web, mobile, and test user-pool clients. This is a real CloudFormation update to the existing production web + test clients, not just the new mobile client:
- New access tokens issued after deploy will carry `origin_jti` / `jti` claims (token-shape change).
- The `RevokeToken` endpoint becomes available for these clients.
- Pre-deploy tokens remain valid until they expire or the user re-auths; they are not revocable until re-issuance.
- Pinned by `pins enableTokenRevocation=true on all three clients` in `auth-stack.test.ts` so a future refactor can't silently drop it.

#### Test plan
- [x] `bun run test` passes across the monorepo (unit tests)
- [x] `bun test` in `packages/cdk` passes (no longer requires a built SPA — `CDK_SPA_DIST_PATH` env var + temp dir in test)
- [x] `bun test` in `apps/vela-mobile` passes (55 tests)

Generated with [Devin](https://devin.ai)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated Cognito OAuth support for the iOS mobile app using PKCE-compatible authorization code flow.
  * Added iOS deep-link handling through the `dev.cwchanap.vela.oauth` URL scheme.
  * Published the mobile Cognito client ID for app configuration.
  * Added configurable and validated mobile callback and logout URLs.

* **Documentation**
  * Added setup and integration guidance for mobile OAuth, iOS callbacks, and deployment configuration.

* **Tests & Chores**
  * Expanded coverage for mobile OAuth, redirect validation, iOS configuration, and CloudFormation outputs.
  * Added automated mobile and CDK test jobs with read-only workflow permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->