### PR TITLE
feat(mobile): add secure Cognito session persistence

### DIFF
--- a/apps/vela-mobile/quasar.config.ts
+++ b/apps/vela-mobile/quasar.config.ts
@@ -24,6 +24,10 @@ export default defineConfig((ctx) => {
           __dirname,
           'src-capacitor/node_modules/@capacitor/preferences',
         ),
+        '@aparajita/capacitor-secure-storage': resolve(
+          __dirname,
+          'src-capacitor/node_modules/@aparajita/capacitor-secure-storage',
+        ),
       },
 
       target: {

--- a/apps/vela-mobile/src-capacitor/bun.lock
+++ b/apps/vela-mobile/src-capacitor/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@vela/mobile",
       "dependencies": {
+        "@aparajita/capacitor-secure-storage": "7.1.6",
         "@capacitor/app": "^7.0.0",
         "@capacitor/browser": "^7.0.0",
         "@capacitor/core": "^7.0.0",
@@ -18,6 +19,10 @@
     },
   },
   "packages": {
+    "@aparajita/capacitor-secure-storage": ["@aparajita/capacitor-secure-storage@7.1.6", "", { "dependencies": { "@capacitor/android": "^7.4.4", "@capacitor/app": "^7.1.0", "@capacitor/core": "^7.4.4", "@capacitor/ios": "^7.4.4" } }, "sha512-KIfLOm/oSciUiWsOMtMv2nzlnwW3LERid0DvZ3djt7UORBQvFqpvSefiLG5kkc8D34pGkb2ZqAz0ZprrI9LiTQ=="],
+
+    "@capacitor/android": ["@capacitor/android@7.6.8", "", { "peerDependencies": { "@capacitor/core": "^7.6.0" } }, "sha512-N5LXe1ls+TA0mq+RhtyDdP1JISzAAI+OuLGL3G7OWQxfQQOZYkiEjEJMYqMV6JR421IqpRsYj08JOfC0PFC3NA=="],
+
     "@capacitor/app": ["@capacitor/app@7.1.2", "", { "peerDependencies": { "@capacitor/core": ">=7.0.0" } }, "sha512-d4I/oF/PRu4megL7/IGKYfe5j7yzSON1FRFgq6kH+m5kH6g7V+wyjHRLauCzGNjdRx4S+nWOumINds0qcRBtKg=="],
 
     "@capacitor/browser": ["@capacitor/browser@7.0.5", "", { "peerDependencies": { "@capacitor/core": ">=7.0.0" } }, "sha512-YF/kC1m1e6c81X/agtAnYItVlqiQ/nXLG+Q3QXNDuiMoRynqa3Guu8ZaV9kWvqQcHoE2w18xz7WGpPOuh+R1fA=="],

--- a/apps/vela-mobile/src-capacitor/ios/App/Podfile
+++ b/apps/vela-mobile/src-capacitor/ios/App/Podfile
@@ -11,6 +11,7 @@ install! 'cocoapods', :disable_input_output_paths => true
 def capacitor_pods
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
+  pod 'AparajitaCapacitorSecureStorage', :path => '../../node_modules/@aparajita/capacitor-secure-storage'
   pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
   pod 'CapacitorBrowser', :path => '../../node_modules/@capacitor/browser'
   pod 'CapacitorKeyboard', :path => '../../node_modules/@capacitor/keyboard'

--- a/apps/vela-mobile/src-capacitor/ios/App/Podfile.lock
+++ b/apps/vela-mobile/src-capacitor/ios/App/Podfile.lock
@@ -1,4 +1,7 @@
 PODS:
+  - AparajitaCapacitorSecureStorage (7.1.6):
+    - Capacitor
+    - KeychainSwift (~> 21.0)
   - Capacitor (7.6.8):
     - CapacitorCordova
   - CapacitorApp (7.1.2):
@@ -10,8 +13,10 @@ PODS:
     - Capacitor
   - CapacitorPreferences (7.0.4):
     - Capacitor
+  - KeychainSwift (21.0.0)
 
 DEPENDENCIES:
+  - "AparajitaCapacitorSecureStorage (from `../../node_modules/@aparajita/capacitor-secure-storage`)"
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
   - "CapacitorApp (from `../../node_modules/@capacitor/app`)"
   - "CapacitorBrowser (from `../../node_modules/@capacitor/browser`)"
@@ -19,7 +24,13 @@ DEPENDENCIES:
   - "CapacitorKeyboard (from `../../node_modules/@capacitor/keyboard`)"
   - "CapacitorPreferences (from `../../node_modules/@capacitor/preferences`)"
 
+SPEC REPOS:
+  trunk:
+    - KeychainSwift
+
 EXTERNAL SOURCES:
+  AparajitaCapacitorSecureStorage:
+    :path: "../../node_modules/@aparajita/capacitor-secure-storage"
   Capacitor:
     :path: "../../node_modules/@capacitor/ios"
   CapacitorApp:
@@ -34,13 +45,15 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/preferences"
 
 SPEC CHECKSUMS:
+  AparajitaCapacitorSecureStorage: 502bff73187cf9d0164459458ccf47ec65d5895a
   Capacitor: ff6bf01336ac353098378828aff465095a89e459
   CapacitorApp: f01a913211780e0718dae9750442c3e23f96e106
   CapacitorBrowser: 6d09f59655e89aede71654ef08b98de55cf032b6
   CapacitorCordova: e61ee8c40101b8cd011d0224261606a290c082cf
   CapacitorKeyboard: a2e0869edd229490ce36aed2549c0d6b95e27ee8
   CapacitorPreferences: 69d9991307507aeab8ef8019c10b9babfda0e9ca
+  KeychainSwift: 4a71a45c802fd9e73906457c2dcbdbdc06c9419d
 
-PODFILE CHECKSUM: 9c279e6562c03943313fd35de97984be533a612f
+PODFILE CHECKSUM: fa479eafbf685418473159d66b3cbe8aa3fa0fc0
 
 COCOAPODS: 1.17.0

--- a/apps/vela-mobile/src-capacitor/package.json
+++ b/apps/vela-mobile/src-capacitor/package.json
@@ -5,6 +5,7 @@
   "author": "cwchanap <cwchanap@connect.ust.hk>",
   "private": true,
   "dependencies": {
+    "@aparajita/capacitor-secure-storage": "7.1.6",
     "@capacitor/app": "^7.0.0",
     "@capacitor/browser": "^7.0.0",
     "@capacitor/core": "^7.0.0",

--- a/apps/vela-mobile/src/App.test.ts
+++ b/apps/vela-mobile/src/App.test.ts
@@ -30,7 +30,11 @@ describe('App', () => {
     const Review = routedComponent('review');
     const state = reactive<MobileAuthState>({
       phase: 'signedOut',
+      operation: 'idle',
+      sessionUsable: false,
       errorCode: null,
+      retryAction: null,
+      notice: null,
       user: null,
     });
     const coordinator: MobileAuthCoordinator = {
@@ -70,6 +74,7 @@ describe('App', () => {
     expect(wrapper.find('[data-testid$="-route"]').exists()).toBe(false);
 
     state.phase = 'authenticated';
+    state.sessionUsable = true;
     state.user = { userId: 'user-1', email: null };
     await nextTick();
 

--- a/apps/vela-mobile/src/App.test.ts
+++ b/apps/vela-mobile/src/App.test.ts
@@ -90,5 +90,19 @@ describe('App', () => {
     expect(mountedRoutes).toEqual(['home']);
     expect(wrapper.find('[data-testid="review-route"]').exists()).toBe(false);
     expect(wrapper.get('[data-testid="home-route"]').text()).toBe('home');
+
+    Object.assign(state, {
+      phase: 'signedOut',
+      operation: 'signingOut',
+      sessionUsable: false,
+      errorCode: null,
+      retryAction: null,
+      notice: null,
+      user: null,
+    });
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="home-route"]').exists()).toBe(false);
+    expect(wrapper.get('[role="status"]').text()).toContain('Signing out…');
   });
 });

--- a/apps/vela-mobile/src/App.test.ts
+++ b/apps/vela-mobile/src/App.test.ts
@@ -92,13 +92,13 @@ describe('App', () => {
     expect(wrapper.get('[data-testid="home-route"]').text()).toBe('home');
 
     Object.assign(state, {
-      phase: 'signedOut',
+      phase: 'authenticated',
       operation: 'signingOut',
       sessionUsable: false,
       errorCode: null,
       retryAction: null,
       notice: null,
-      user: null,
+      user: { userId: 'user-1', email: null },
     });
     await nextTick();
 

--- a/apps/vela-mobile/src/App.test.ts
+++ b/apps/vela-mobile/src/App.test.ts
@@ -42,7 +42,7 @@ describe('App', () => {
       initialize: vi.fn().mockResolvedValue(undefined),
       startSignIn: vi.fn().mockResolvedValue(undefined),
       completeCallback: vi.fn().mockResolvedValue(undefined),
-      retrySessionVerification: vi.fn().mockResolvedValue(undefined),
+      retryCurrentOperation: vi.fn().mockResolvedValue(undefined),
       dispose: vi.fn().mockResolvedValue(undefined),
     };
     const landing = deferred();

--- a/apps/vela-mobile/src/App.test.ts
+++ b/apps/vela-mobile/src/App.test.ts
@@ -43,6 +43,7 @@ describe('App', () => {
       startSignIn: vi.fn().mockResolvedValue(undefined),
       completeCallback: vi.fn().mockResolvedValue(undefined),
       retryCurrentOperation: vi.fn().mockResolvedValue(undefined),
+      signOut: vi.fn().mockResolvedValue(undefined),
       dispose: vi.fn().mockResolvedValue(undefined),
     };
     const landing = deferred();

--- a/apps/vela-mobile/src/auth/mobile-auth-contract.ts
+++ b/apps/vela-mobile/src/auth/mobile-auth-contract.ts
@@ -146,6 +146,10 @@ export function assertMobileAuthState(
       state.user !== null);
   const restoreFailurePhaseIsInvalid =
     state.errorCode === 'session_restore_failed' && state.phase !== 'initializing';
+  const refreshFailurePhaseIsInvalid =
+    state.errorCode === 'session_refresh_failed' &&
+    state.phase !== 'authenticated' &&
+    state.phase !== 'error';
   const signOutOperationIsInvalid =
     state.operation === 'signingOut' &&
     ((state.phase !== 'initializing' && state.phase !== 'authenticated') ||
@@ -174,6 +178,7 @@ export function assertMobileAuthState(
     terminalNoticeIsInvalid ||
     cleanupNoticeIsInvalid ||
     restoreFailurePhaseIsInvalid ||
+    refreshFailurePhaseIsInvalid ||
     signOutOperationIsInvalid ||
     cleanupOperationIsInvalid
   ) {

--- a/apps/vela-mobile/src/auth/mobile-auth-contract.ts
+++ b/apps/vela-mobile/src/auth/mobile-auth-contract.ts
@@ -118,71 +118,90 @@ export function assertMobileAuthState(
   state: MobileAuthState,
   context: MobileAuthStateAssertionContext,
 ): void {
-  const usableSessionIsInvalid =
-    state.sessionUsable &&
-    (state.phase !== 'authenticated' ||
-      state.user === null ||
-      state.notice !== null ||
-      context.activeBundle === null ||
-      context.activeBundle.expiresAt <= context.now);
-  const errorPhaseIsInvalid = state.phase === 'error' && state.errorCode === null;
-  const retryIsInvalid =
-    state.retryAction !== null && (state.operation !== 'idle' || state.errorCode === null);
-  const terminalNoticeIsInvalid =
-    state.notice === 'session_unusable' &&
-    (state.phase !== 'signedOut' ||
-      state.operation !== 'idle' ||
-      state.sessionUsable ||
-      state.errorCode !== null ||
-      state.retryAction !== null ||
-      state.user !== null);
-  const cleanupNoticeIsInvalid =
-    state.notice === 'cleanup_incomplete' &&
-    (state.phase !== 'signedOut' ||
-      state.operation !== 'idle' ||
-      state.sessionUsable ||
-      state.errorCode !== 'session_cleanup_failed' ||
-      state.retryAction !== 'cleanup' ||
-      state.user !== null);
-  const restoreFailurePhaseIsInvalid =
-    state.errorCode === 'session_restore_failed' && state.phase !== 'initializing';
-  const refreshFailurePhaseIsInvalid =
-    state.errorCode === 'session_refresh_failed' &&
-    state.phase !== 'authenticated' &&
-    state.phase !== 'error';
-  const signOutOperationIsInvalid =
-    state.operation === 'signingOut' &&
-    ((state.phase !== 'initializing' && state.phase !== 'authenticated') ||
-      (state.phase === 'initializing' && state.user !== null) ||
-      (state.phase === 'authenticated' && state.user === null) ||
-      state.sessionUsable ||
-      state.errorCode !== null ||
-      state.retryAction !== null ||
-      state.notice !== null);
-  const cleanupOperationIsInvalid =
-    state.operation === 'cleaningUp' &&
-    ((state.phase !== 'initializing' &&
-      state.phase !== 'authenticated' &&
-      state.phase !== 'signedOut') ||
-      (state.phase === 'authenticated' && state.user === null) ||
-      (state.phase !== 'authenticated' && state.user !== null) ||
-      state.sessionUsable ||
-      state.errorCode !== null ||
-      state.retryAction !== null ||
-      state.notice !== null);
+  const invariants: { name: string; violated: boolean }[] = [
+    {
+      name: 'usable_session_requires_authenticated_phase_user_no_notice_live_bundle',
+      violated:
+        state.sessionUsable &&
+        (state.phase !== 'authenticated' ||
+          state.user === null ||
+          state.notice !== null ||
+          context.activeBundle === null ||
+          context.activeBundle.expiresAt <= context.now),
+    },
+    {
+      name: 'error_phase_requires_error_code',
+      violated: state.phase === 'error' && state.errorCode === null,
+    },
+    {
+      name: 'retry_action_requires_idle_operation_and_error_code',
+      violated:
+        state.retryAction !== null && (state.operation !== 'idle' || state.errorCode === null),
+    },
+    {
+      name: 'session_unusable_notice_confined_to_signed_out_idle_clean_state',
+      violated:
+        state.notice === 'session_unusable' &&
+        (state.phase !== 'signedOut' ||
+          state.operation !== 'idle' ||
+          state.sessionUsable ||
+          state.errorCode !== null ||
+          state.retryAction !== null ||
+          state.user !== null),
+    },
+    {
+      name: 'cleanup_incomplete_notice_confined_to_signed_out_cleanup_failure_state',
+      violated:
+        state.notice === 'cleanup_incomplete' &&
+        (state.phase !== 'signedOut' ||
+          state.operation !== 'idle' ||
+          state.sessionUsable ||
+          state.errorCode !== 'session_cleanup_failed' ||
+          state.retryAction !== 'cleanup' ||
+          state.user !== null),
+    },
+    {
+      name: 'session_restore_failed_confined_to_initializing_phase',
+      violated: state.errorCode === 'session_restore_failed' && state.phase !== 'initializing',
+    },
+    {
+      name: 'session_refresh_failed_confined_to_authenticated_or_error_phase',
+      violated:
+        state.errorCode === 'session_refresh_failed' &&
+        state.phase !== 'authenticated' &&
+        state.phase !== 'error',
+    },
+    {
+      name: 'signing_out_operation_shape',
+      violated:
+        state.operation === 'signingOut' &&
+        ((state.phase !== 'initializing' && state.phase !== 'authenticated') ||
+          (state.phase === 'initializing' && state.user !== null) ||
+          (state.phase === 'authenticated' && state.user === null) ||
+          state.sessionUsable ||
+          state.errorCode !== null ||
+          state.retryAction !== null ||
+          state.notice !== null),
+    },
+    {
+      name: 'cleaning_up_operation_shape',
+      violated:
+        state.operation === 'cleaningUp' &&
+        ((state.phase !== 'initializing' &&
+          state.phase !== 'authenticated' &&
+          state.phase !== 'signedOut') ||
+          (state.phase === 'authenticated' && state.user === null) ||
+          (state.phase !== 'authenticated' && state.user !== null) ||
+          state.sessionUsable ||
+          state.errorCode !== null ||
+          state.retryAction !== null ||
+          state.notice !== null),
+    },
+  ];
 
-  if (
-    usableSessionIsInvalid ||
-    errorPhaseIsInvalid ||
-    retryIsInvalid ||
-    terminalNoticeIsInvalid ||
-    cleanupNoticeIsInvalid ||
-    restoreFailurePhaseIsInvalid ||
-    refreshFailurePhaseIsInvalid ||
-    signOutOperationIsInvalid ||
-    cleanupOperationIsInvalid
-  ) {
-    throw new Error('invalid_mobile_auth_state');
+  const failed = invariants.find((invariant) => invariant.violated);
+  if (failed) {
+    throw new Error(`invalid_mobile_auth_state:${failed.name}`);
   }
 }
 

--- a/apps/vela-mobile/src/auth/mobile-auth-contract.ts
+++ b/apps/vela-mobile/src/auth/mobile-auth-contract.ts
@@ -19,11 +19,18 @@ export type OAuthTransaction = {
   createdAt: number;
 };
 
-export type OAuthTokenBundle = {
+export type OAuthTokenBundleBase = {
   accessToken: string;
   idToken: string;
-  refreshToken?: string;
   expiresAt: number;
+};
+
+export type AuthorizationCodeTokenBundle = OAuthTokenBundleBase & {
+  refreshToken: string;
+};
+
+export type RefreshedTokenBundle = OAuthTokenBundleBase & {
+  refreshToken?: string;
 };
 
 export type ParsedOAuthCallback =

--- a/apps/vela-mobile/src/auth/mobile-auth-contract.ts
+++ b/apps/vela-mobile/src/auth/mobile-auth-contract.ts
@@ -144,13 +144,38 @@ export function assertMobileAuthState(
       state.errorCode !== 'session_cleanup_failed' ||
       state.retryAction !== 'cleanup' ||
       state.user !== null);
+  const restoreFailurePhaseIsInvalid =
+    state.errorCode === 'session_restore_failed' && state.phase !== 'initializing';
+  const signOutOperationIsInvalid =
+    state.operation === 'signingOut' &&
+    ((state.phase !== 'initializing' && state.phase !== 'authenticated') ||
+      (state.phase === 'initializing' && state.user !== null) ||
+      (state.phase === 'authenticated' && state.user === null) ||
+      state.sessionUsable ||
+      state.errorCode !== null ||
+      state.retryAction !== null ||
+      state.notice !== null);
+  const cleanupOperationIsInvalid =
+    state.operation === 'cleaningUp' &&
+    ((state.phase !== 'initializing' &&
+      state.phase !== 'authenticated' &&
+      state.phase !== 'signedOut') ||
+      (state.phase === 'authenticated' && state.user === null) ||
+      (state.phase !== 'authenticated' && state.user !== null) ||
+      state.sessionUsable ||
+      state.errorCode !== null ||
+      state.retryAction !== null ||
+      state.notice !== null);
 
   if (
     usableSessionIsInvalid ||
     errorPhaseIsInvalid ||
     retryIsInvalid ||
     terminalNoticeIsInvalid ||
-    cleanupNoticeIsInvalid
+    cleanupNoticeIsInvalid ||
+    restoreFailurePhaseIsInvalid ||
+    signOutOperationIsInvalid ||
+    cleanupOperationIsInvalid
   ) {
     throw new Error('invalid_mobile_auth_state');
   }

--- a/apps/vela-mobile/src/auth/mobile-auth-contract.ts
+++ b/apps/vela-mobile/src/auth/mobile-auth-contract.ts
@@ -74,7 +74,25 @@ export type MobileAuthErrorCode =
   | 'code_exchange_failed'
   | 'token_validation_failed'
   | 'session_unauthorized'
-  | 'session_verification_failed';
+  | 'session_verification_failed'
+  | 'session_restore_failed'
+  | 'session_refresh_failed'
+  | 'session_persistence_failed'
+  | 'session_cleanup_failed'
+  | 'unsupported_platform';
+
+export type MobileAuthRetryAction = 'restore' | 'refresh' | 'persist' | 'verify' | 'cleanup';
+
+export type MobileAuthOperation =
+  | 'idle'
+  | 'restoring'
+  | 'refreshing'
+  | 'persisting'
+  | 'verifying'
+  | 'signingOut'
+  | 'cleaningUp';
+
+export type MobileAuthNotice = 'session_unusable' | 'cleanup_incomplete' | null;
 
 export type MobileAuthUser = {
   userId: string;
@@ -83,14 +101,69 @@ export type MobileAuthUser = {
 
 export type MobileAuthState = {
   phase: MobileAuthPhase;
+  operation: MobileAuthOperation;
+  sessionUsable: boolean;
   errorCode: MobileAuthErrorCode | null;
+  retryAction: MobileAuthRetryAction | null;
+  notice: MobileAuthNotice;
   user: MobileAuthUser | null;
 };
+
+export type MobileAuthStateAssertionContext = {
+  activeBundle: OAuthTokenBundleBase | null;
+  now: number;
+};
+
+export function assertMobileAuthState(
+  state: MobileAuthState,
+  context: MobileAuthStateAssertionContext,
+): void {
+  const usableSessionIsInvalid =
+    state.sessionUsable &&
+    (state.phase !== 'authenticated' ||
+      state.user === null ||
+      state.notice !== null ||
+      context.activeBundle === null ||
+      context.activeBundle.expiresAt <= context.now);
+  const errorPhaseIsInvalid = state.phase === 'error' && state.errorCode === null;
+  const retryIsInvalid =
+    state.retryAction !== null && (state.operation !== 'idle' || state.errorCode === null);
+  const terminalNoticeIsInvalid =
+    state.notice === 'session_unusable' &&
+    (state.phase !== 'signedOut' ||
+      state.operation !== 'idle' ||
+      state.sessionUsable ||
+      state.errorCode !== null ||
+      state.retryAction !== null ||
+      state.user !== null);
+  const cleanupNoticeIsInvalid =
+    state.notice === 'cleanup_incomplete' &&
+    (state.phase !== 'signedOut' ||
+      state.operation !== 'idle' ||
+      state.sessionUsable ||
+      state.errorCode !== 'session_cleanup_failed' ||
+      state.retryAction !== 'cleanup' ||
+      state.user !== null);
+
+  if (
+    usableSessionIsInvalid ||
+    errorPhaseIsInvalid ||
+    retryIsInvalid ||
+    terminalNoticeIsInvalid ||
+    cleanupNoticeIsInvalid
+  ) {
+    throw new Error('invalid_mobile_auth_state');
+  }
+}
 
 export type MobileAppAdapter = {
   addListener(
     eventName: 'appUrlOpen',
     listener: (event: { url: string }) => void,
+  ): Promise<{ remove(): Promise<void> }>;
+  addListener(
+    eventName: 'appStateChange',
+    listener: (event: { isActive: boolean }) => void,
   ): Promise<{ remove(): Promise<void> }>;
   getLaunchUrl(): Promise<{ url: string } | undefined>;
 };

--- a/apps/vela-mobile/src/auth/mobile-auth-contract.ts
+++ b/apps/vela-mobile/src/auth/mobile-auth-contract.ts
@@ -186,6 +186,6 @@ export type MobileAuthCoordinator = {
   initialize(): Promise<void>;
   startSignIn(): Promise<void>;
   completeCallback(url: string): Promise<void>;
-  retrySessionVerification(): Promise<void>;
+  retryCurrentOperation(): Promise<void>;
   dispose(): Promise<void>;
 };

--- a/apps/vela-mobile/src/auth/mobile-auth-contract.ts
+++ b/apps/vela-mobile/src/auth/mobile-auth-contract.ts
@@ -187,5 +187,6 @@ export type MobileAuthCoordinator = {
   startSignIn(): Promise<void>;
   completeCallback(url: string): Promise<void>;
   retryCurrentOperation(): Promise<void>;
+  signOut(): Promise<void>;
   dispose(): Promise<void>;
 };

--- a/apps/vela-mobile/src/auth/mobile-installation-store.test.ts
+++ b/apps/vela-mobile/src/auth/mobile-installation-store.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createMobileInstallationKey,
+  createMobileInstallationStore,
+} from './mobile-installation-store';
+
+const config = {
+  userPoolId: 'ca-central-1_pool',
+  mobileClientId: 'mobile-client',
+};
+
+describe('mobile installation store', () => {
+  it('uses an environment-scoped non-secret marker', async () => {
+    const preferences = {
+      get: vi.fn().mockResolvedValue({ value: null }),
+      set: vi.fn().mockResolvedValue(undefined),
+    };
+    const store = createMobileInstallationStore(preferences, config);
+    const key = 'vela:mobile:cognito:ca-central-1_pool:mobile-client:installation:v1';
+
+    await expect(store.isCurrentInstallationMarked()).resolves.toBe(false);
+    await store.markCurrentInstallation();
+
+    expect(createMobileInstallationKey(config)).toBe(key);
+    expect(preferences.get).toHaveBeenCalledWith({ key });
+    expect(preferences.set).toHaveBeenCalledWith({ key, value: '1' });
+  });
+
+  it('reports marked when the current installation marker is present', async () => {
+    const store = createMobileInstallationStore(
+      {
+        get: vi.fn().mockResolvedValue({ value: '1' }),
+        set: vi.fn(),
+      },
+      config,
+    );
+
+    await expect(store.isCurrentInstallationMarked()).resolves.toBe(true);
+  });
+
+  it.each([null, '', '0', 'unexpected'])('treats %p as unmarked', async (value) => {
+    const store = createMobileInstallationStore(
+      {
+        get: vi.fn().mockResolvedValue({ value }),
+        set: vi.fn(),
+      },
+      config,
+    );
+
+    await expect(store.isCurrentInstallationMarked()).resolves.toBe(false);
+  });
+
+  it('propagates an exact Preferences read rejection', async () => {
+    const failure = new Error('read failed');
+    const store = createMobileInstallationStore(
+      {
+        get: vi.fn().mockRejectedValue(failure),
+        set: vi.fn(),
+      },
+      config,
+    );
+
+    await expect(store.isCurrentInstallationMarked()).rejects.toBe(failure);
+  });
+
+  it('propagates an exact Preferences write rejection', async () => {
+    const failure = new Error('write failed');
+    const store = createMobileInstallationStore(
+      {
+        get: vi.fn(),
+        set: vi.fn().mockRejectedValue(failure),
+      },
+      config,
+    );
+
+    await expect(store.markCurrentInstallation()).rejects.toBe(failure);
+  });
+});

--- a/apps/vela-mobile/src/auth/mobile-installation-store.ts
+++ b/apps/vela-mobile/src/auth/mobile-installation-store.ts
@@ -1,0 +1,29 @@
+import type { MobileOAuthConfig } from './mobile-auth-contract';
+import type { OAuthTransactionPreferences } from './oauth-transaction-store';
+
+export type MobileInstallationStore = {
+  isCurrentInstallationMarked(): Promise<boolean>;
+  markCurrentInstallation(): Promise<void>;
+};
+
+export function createMobileInstallationKey(
+  config: Pick<MobileOAuthConfig, 'userPoolId' | 'mobileClientId'>,
+): string {
+  return `vela:mobile:cognito:${config.userPoolId}:${config.mobileClientId}:installation:v1`;
+}
+
+export function createMobileInstallationStore(
+  preferences: Pick<OAuthTransactionPreferences, 'get' | 'set'>,
+  config: Pick<MobileOAuthConfig, 'userPoolId' | 'mobileClientId'>,
+): MobileInstallationStore {
+  const key = createMobileInstallationKey(config);
+
+  return {
+    async isCurrentInstallationMarked() {
+      return (await preferences.get({ key })).value === '1';
+    },
+    async markCurrentInstallation() {
+      await preferences.set({ key, value: '1' });
+    },
+  };
+}

--- a/apps/vela-mobile/src/auth/mobile-oauth.test.ts
+++ b/apps/vela-mobile/src/auth/mobile-oauth.test.ts
@@ -351,6 +351,12 @@ describe('OAuth token parsing and ID-token claim validation', () => {
       expires_in: 3_600,
       refresh_token: '',
     },
+    {
+      access_token: 'access-token',
+      id_token: 'id-token',
+      expires_in: 3_600,
+      refresh_token: ' \t\n',
+    },
   ])('rejects malformed token response %#', (value) => {
     expect(() => parseAuthorizationCodeTokenResponse(value, 1_000)).toThrow(
       'Invalid token response',

--- a/apps/vela-mobile/src/auth/mobile-oauth.test.ts
+++ b/apps/vela-mobile/src/auth/mobile-oauth.test.ts
@@ -364,13 +364,13 @@ describe('OAuth token parsing and ID-token claim validation', () => {
   });
 
   it('accepts exact valid mobile ID-token claims without local signature verification', () => {
-    expect(() =>
+    expect(
       validateAuthorizationCodeIdTokenClaims(makeIdToken(validClaims), {
         config,
         transaction,
         now: 2_000_000 - 59_999,
       }),
-    ).not.toThrow();
+    ).toBe('user-123');
   });
 
   it('validates a refreshed ID token without nonce and returns its subject', () => {
@@ -434,7 +434,10 @@ describe('OAuth token parsing and ID-token claim validation', () => {
   });
 
   it('rejects a non-finite expiry decoded from a JSON numeric overflow', () => {
-    const rawClaims = JSON.stringify(validClaims).replace('"exp":2000', '"exp":1e400');
+    const serialized = JSON.stringify(validClaims);
+    const rawClaims = serialized.replace('"exp":2000', '"exp":1e400');
+    expect(rawClaims).not.toEqual(serialized);
+    expect(rawClaims).toContain('1e400');
     const idToken = `${base64UrlJson({ alg: 'none' })}.${base64UrlText(rawClaims)}.unsigned`;
 
     expect(() =>

--- a/apps/vela-mobile/src/auth/mobile-oauth.test.ts
+++ b/apps/vela-mobile/src/auth/mobile-oauth.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildAuthorizationUrl,
-  buildTokenRequest,
+  buildAuthorizationCodeTokenRequest,
+  buildRefreshTokenRequest,
   createOAuthTransaction,
   createPkceChallenge,
   hasOAuthCryptoCapabilities,
   parseOAuthCallback,
-  parseTokenResponse,
-  validateIdTokenClaims,
+  parseAuthorizationCodeTokenResponse,
+  parseRefreshTokenResponse,
+  validateAuthorizationCodeIdTokenClaims,
+  validateRefreshedIdTokenClaims,
 } from './mobile-oauth';
 import {
   MOBILE_OAUTH_CALLBACK_URI,
@@ -58,7 +61,7 @@ function base64UrlText(value: string): string {
   return btoa(value).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '');
 }
 
-function unsignedJwt(payload: unknown): string {
+function makeIdToken(payload: unknown): string {
   return `${base64UrlJson({ alg: 'none', typ: 'JWT' })}.${base64UrlJson(payload)}.unsigned`;
 }
 
@@ -66,6 +69,7 @@ const validClaims = {
   token_use: 'id',
   aud: config.mobileClientId,
   iss: `https://cognito-idp.${config.region}.amazonaws.com/${config.userPoolId}`,
+  sub: 'user-123',
   nonce: transaction.nonce,
   exp: 2_000,
 };
@@ -147,7 +151,7 @@ describe('OAuth request builders', () => {
   });
 
   it('builds the exact public-client native token request without a client secret', () => {
-    const request = buildTokenRequest(config, transaction, 'authorization-code');
+    const request = buildAuthorizationCodeTokenRequest(config, transaction, 'authorization-code');
     const body = new URLSearchParams(request.data);
 
     expect(request.url).toBe('https://vela.auth.us-east-1.amazoncognito.com/oauth2/token');
@@ -166,6 +170,24 @@ describe('OAuth request builders', () => {
       code_verifier: transaction.codeVerifier,
     });
     expect(body.has('client_secret')).toBe(false);
+  });
+
+  it('builds the exact refresh-token public-client request', () => {
+    const request = buildRefreshTokenRequest(config, 'refresh-token', {
+      timeoutMs: 15_000,
+    });
+    expect(request).toEqual({
+      url: `https://${config.oauthDomain}/oauth2/token`,
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      data: new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: config.mobileClientId,
+        refresh_token: 'refresh-token',
+      }).toString(),
+      timeoutMs: 15_000,
+    });
+    expect(request.data).not.toContain('client_secret');
   });
 });
 
@@ -253,12 +275,13 @@ describe('OAuth callback parser', () => {
 });
 
 describe('OAuth token parsing and ID-token claim validation', () => {
-  it('parses required token fields and derives the expiry timestamp', () => {
+  it('parses required authorization-code token fields and derives the expiry timestamp', () => {
     expect(
-      parseTokenResponse(
+      parseAuthorizationCodeTokenResponse(
         {
           access_token: 'access-token',
           id_token: 'id-token',
+          refresh_token: 'refresh-token',
           token_type: 'Bearer',
           expires_in: 3_600,
         },
@@ -267,13 +290,14 @@ describe('OAuth token parsing and ID-token claim validation', () => {
     ).toEqual({
       accessToken: 'access-token',
       idToken: 'id-token',
+      refreshToken: 'refresh-token',
       expiresAt: 3_601_000,
     });
   });
 
-  it('retains an optional non-empty refresh token in memory', () => {
+  it('retains a rotated refresh token from refresh success', () => {
     expect(
-      parseTokenResponse(
+      parseRefreshTokenResponse(
         {
           access_token: 'access-token',
           id_token: 'id-token',
@@ -286,6 +310,28 @@ describe('OAuth token parsing and ID-token claim validation', () => {
       accessToken: 'access-token',
       idToken: 'id-token',
       refreshToken: 'refresh-token',
+      expiresAt: 3_601_000,
+    });
+  });
+
+  it('requires a refresh token from authorization-code success', () => {
+    expect(() =>
+      parseAuthorizationCodeTokenResponse(
+        { access_token: 'access', id_token: 'id', expires_in: 3600 },
+        1_000,
+      ),
+    ).toThrow('Invalid token response');
+  });
+
+  it('permits refresh-token omission from refresh success', () => {
+    expect(
+      parseRefreshTokenResponse(
+        { access_token: 'access', id_token: 'id', expires_in: 3600 },
+        1_000,
+      ),
+    ).toEqual({
+      accessToken: 'access',
+      idToken: 'id',
       expiresAt: 3_601_000,
     });
   });
@@ -306,12 +352,14 @@ describe('OAuth token parsing and ID-token claim validation', () => {
       refresh_token: '',
     },
   ])('rejects malformed token response %#', (value) => {
-    expect(() => parseTokenResponse(value, 1_000)).toThrow('invalid_token_response');
+    expect(() => parseAuthorizationCodeTokenResponse(value, 1_000)).toThrow(
+      'Invalid token response',
+    );
   });
 
   it('accepts exact valid mobile ID-token claims without local signature verification', () => {
     expect(() =>
-      validateIdTokenClaims(unsignedJwt(validClaims), {
+      validateAuthorizationCodeIdTokenClaims(makeIdToken(validClaims), {
         config,
         transaction,
         now: 2_000_000 - 59_999,
@@ -319,8 +367,48 @@ describe('OAuth token parsing and ID-token claim validation', () => {
     ).not.toThrow();
   });
 
+  it('validates a refreshed ID token without nonce and returns its subject', () => {
+    const idToken = makeIdToken({
+      token_use: 'id',
+      aud: config.mobileClientId,
+      iss: `https://cognito-idp.${config.region}.amazonaws.com/${config.userPoolId}`,
+      sub: 'user-1',
+      exp: 3_600,
+    });
+    expect(
+      validateRefreshedIdTokenClaims(idToken, {
+        config,
+        now: 1_000,
+        expectedSubject: 'user-1',
+      }),
+    ).toBe('user-1');
+  });
+
+  it.each([
+    ['missing subject', undefined, undefined],
+    ['empty subject', '', undefined],
+    ['subject mismatch', 'user-2', 'user-1'],
+  ] as const)('rejects %s', (_label, subject, expectedSubject) => {
+    const idToken = makeIdToken({
+      token_use: 'id',
+      aud: config.mobileClientId,
+      iss: `https://cognito-idp.${config.region}.amazonaws.com/${config.userPoolId}`,
+      sub: subject,
+      exp: 3_600,
+    });
+    expect(() =>
+      validateRefreshedIdTokenClaims(idToken, {
+        config,
+        now: 1_000,
+        ...(expectedSubject ? { expectedSubject } : {}),
+      }),
+    ).toThrow('Invalid ID token');
+  });
+
   it.each([
     ['wrong token use', { ...validClaims, token_use: 'access' }],
+    ['missing subject', { ...validClaims, sub: undefined }],
+    ['empty subject', { ...validClaims, sub: '' }],
     ['missing audience', { ...validClaims, aud: undefined }],
     ['non-string audience', { ...validClaims, aud: 123 }],
     ['array audience', { ...validClaims, aud: [config.mobileClientId] }],
@@ -331,12 +419,12 @@ describe('OAuth token parsing and ID-token claim validation', () => {
     ['non-numeric expiry', { ...validClaims, exp: '2000' }],
   ])('rejects %s', (_name, claims) => {
     expect(() =>
-      validateIdTokenClaims(unsignedJwt(claims), {
+      validateAuthorizationCodeIdTokenClaims(makeIdToken(claims), {
         config,
         transaction,
         now: 1_000,
       }),
-    ).toThrow('invalid_id_token');
+    ).toThrow('Invalid ID token');
   });
 
   it('rejects a non-finite expiry decoded from a JSON numeric overflow', () => {
@@ -344,26 +432,26 @@ describe('OAuth token parsing and ID-token claim validation', () => {
     const idToken = `${base64UrlJson({ alg: 'none' })}.${base64UrlText(rawClaims)}.unsigned`;
 
     expect(() =>
-      validateIdTokenClaims(idToken, {
+      validateAuthorizationCodeIdTokenClaims(idToken, {
         config,
         transaction,
         now: 1_000,
       }),
-    ).toThrow('invalid_id_token');
+    ).toThrow('Invalid ID token');
   });
 
   it('rejects expiry at the exact 60-second skew boundary', () => {
-    const idToken = unsignedJwt({ ...validClaims, exp: 2_000 });
+    const idToken = makeIdToken({ ...validClaims, exp: 2_000 });
 
     expect(() =>
-      validateIdTokenClaims(idToken, {
+      validateAuthorizationCodeIdTokenClaims(idToken, {
         config,
         transaction,
         now: 2_060_000,
       }),
-    ).toThrow('invalid_id_token');
+    ).toThrow('Invalid ID token');
     expect(() =>
-      validateIdTokenClaims(idToken, {
+      validateAuthorizationCodeIdTokenClaims(idToken, {
         config,
         transaction,
         now: 2_059_999,
@@ -383,13 +471,13 @@ describe('OAuth token parsing and ID-token claim validation', () => {
     let thrown: unknown;
 
     try {
-      validateIdTokenClaims(idToken, { config, transaction, now: 1_000 });
+      validateAuthorizationCodeIdTokenClaims(idToken, { config, transaction, now: 1_000 });
     } catch (error) {
       thrown = error;
     }
 
     expect(thrown).toBeInstanceOf(Error);
-    expect((thrown as Error).message).toBe('invalid_id_token');
+    expect((thrown as Error).message).toBe('Invalid ID token');
     if (idToken !== '') {
       expect((thrown as Error).message).not.toContain(idToken);
     }

--- a/apps/vela-mobile/src/auth/mobile-oauth.ts
+++ b/apps/vela-mobile/src/auth/mobile-oauth.ts
@@ -32,7 +32,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isNonEmptyString(value: unknown): value is string {
-  return typeof value === 'string' && value.length > 0;
+  return typeof value === 'string' && value.trim().length > 0;
 }
 
 function invalidTokenResponse(): never {

--- a/apps/vela-mobile/src/auth/mobile-oauth.ts
+++ b/apps/vela-mobile/src/auth/mobile-oauth.ts
@@ -191,10 +191,9 @@ export function parseOAuthCallback(rawUrl: string): ParsedOAuthCallback {
   return { kind: 'success', code, state };
 }
 
-export function buildAuthorizationCodeTokenRequest(
+function buildTokenRequest(
   config: MobileOAuthConfig,
-  transaction: OAuthTransaction,
-  code: string,
+  formParameters: Record<string, string>,
   options: { timeoutMs?: number } = {},
 ): MobileTokenRequest {
   const request: MobileTokenRequest = {
@@ -203,13 +202,7 @@ export function buildAuthorizationCodeTokenRequest(
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
     },
-    data: new URLSearchParams({
-      grant_type: 'authorization_code',
-      client_id: config.mobileClientId,
-      code,
-      redirect_uri: MOBILE_OAUTH_CALLBACK_URI,
-      code_verifier: transaction.codeVerifier,
-    }).toString(),
+    data: new URLSearchParams(formParameters).toString(),
   };
   if (options.timeoutMs !== undefined) {
     request.timeoutMs = options.timeoutMs;
@@ -217,27 +210,39 @@ export function buildAuthorizationCodeTokenRequest(
   return request;
 }
 
+export function buildAuthorizationCodeTokenRequest(
+  config: MobileOAuthConfig,
+  transaction: OAuthTransaction,
+  code: string,
+  options: { timeoutMs?: number } = {},
+): MobileTokenRequest {
+  return buildTokenRequest(
+    config,
+    {
+      grant_type: 'authorization_code',
+      client_id: config.mobileClientId,
+      code,
+      redirect_uri: MOBILE_OAUTH_CALLBACK_URI,
+      code_verifier: transaction.codeVerifier,
+    },
+    options,
+  );
+}
+
 export function buildRefreshTokenRequest(
   config: MobileOAuthConfig,
   refreshToken: string,
   options: { timeoutMs?: number } = {},
 ): MobileTokenRequest {
-  const request: MobileTokenRequest = {
-    url: `https://${config.oauthDomain}/oauth2/token`,
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    data: new URLSearchParams({
+  return buildTokenRequest(
+    config,
+    {
       grant_type: 'refresh_token',
       client_id: config.mobileClientId,
       refresh_token: refreshToken,
-    }).toString(),
-  };
-  if (options.timeoutMs !== undefined) {
-    request.timeoutMs = options.timeoutMs;
-  }
-  return request;
+    },
+    options,
+  );
 }
 
 function parseTokenResponseBase(
@@ -339,8 +344,8 @@ function validateIdTokenClaimsBase(
 export function validateAuthorizationCodeIdTokenClaims(
   idToken: string,
   expected: AuthorizationCodeClaimExpectation,
-): void {
-  validateIdTokenClaimsBase(idToken, {
+): string {
+  return validateIdTokenClaimsBase(idToken, {
     config: expected.config,
     now: expected.now,
     expectedNonce: expected.transaction.nonce,

--- a/apps/vela-mobile/src/auth/mobile-oauth.ts
+++ b/apps/vela-mobile/src/auth/mobile-oauth.ts
@@ -1,11 +1,12 @@
 import {
   MOBILE_OAUTH_CALLBACK_URI,
   MOBILE_OAUTH_SCHEME,
+  type AuthorizationCodeTokenBundle,
   type MobileOAuthConfig,
   type MobileTokenRequest,
-  type OAuthTokenBundle,
   type OAuthTransaction,
   type ParsedOAuthCallback,
+  type RefreshedTokenBundle,
 } from './mobile-auth-contract';
 
 const OAUTH_RANDOM_BYTE_LENGTH = 32;
@@ -35,11 +36,11 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 function invalidTokenResponse(): never {
-  throw new Error('invalid_token_response');
+  throw new Error('Invalid token response');
 }
 
 function invalidIdToken(): never {
-  throw new Error('invalid_id_token');
+  throw new Error('Invalid ID token');
 }
 
 function decodeJwtPayload(idToken: string): Record<string, unknown> {
@@ -190,7 +191,7 @@ export function parseOAuthCallback(rawUrl: string): ParsedOAuthCallback {
   return { kind: 'success', code, state };
 }
 
-export function buildTokenRequest(
+export function buildAuthorizationCodeTokenRequest(
   config: MobileOAuthConfig,
   transaction: OAuthTransaction,
   code: string,
@@ -216,14 +217,42 @@ export function buildTokenRequest(
   return request;
 }
 
-export function parseTokenResponse(value: unknown, now: number): OAuthTokenBundle {
+export function buildRefreshTokenRequest(
+  config: MobileOAuthConfig,
+  refreshToken: string,
+  options: { timeoutMs?: number } = {},
+): MobileTokenRequest {
+  const request: MobileTokenRequest = {
+    url: `https://${config.oauthDomain}/oauth2/token`,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    data: new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: config.mobileClientId,
+      refresh_token: refreshToken,
+    }).toString(),
+  };
+  if (options.timeoutMs !== undefined) {
+    request.timeoutMs = options.timeoutMs;
+  }
+  return request;
+}
+
+function parseTokenResponseBase(
+  value: unknown,
+  now: number,
+  requireRefreshToken: boolean,
+): RefreshedTokenBundle {
   if (
     !isRecord(value) ||
     !isNonEmptyString(value.access_token) ||
     !isNonEmptyString(value.id_token) ||
     typeof value.expires_in !== 'number' ||
     !Number.isFinite(value.expires_in) ||
-    value.expires_in <= 0
+    value.expires_in <= 0 ||
+    (requireRefreshToken && !isNonEmptyString(value.refresh_token))
   ) {
     return invalidTokenResponse();
   }
@@ -233,7 +262,7 @@ export function parseTokenResponse(value: unknown, now: number): OAuthTokenBundl
     return invalidTokenResponse();
   }
 
-  const tokenBundle: OAuthTokenBundle = {
+  const tokenBundle: RefreshedTokenBundle = {
     accessToken: value.access_token,
     idToken: value.id_token,
     expiresAt,
@@ -249,14 +278,40 @@ export function parseTokenResponse(value: unknown, now: number): OAuthTokenBundl
   return tokenBundle;
 }
 
-export function validateIdTokenClaims(
+export function parseAuthorizationCodeTokenResponse(
+  value: unknown,
+  now: number,
+): AuthorizationCodeTokenBundle {
+  const parsed = parseTokenResponseBase(value, now, true);
+  if (!parsed.refreshToken) return invalidTokenResponse();
+  return { ...parsed, refreshToken: parsed.refreshToken };
+}
+
+export function parseRefreshTokenResponse(value: unknown, now: number): RefreshedTokenBundle {
+  return parseTokenResponseBase(value, now, false);
+}
+
+type AuthorizationCodeClaimExpectation = {
+  config: MobileOAuthConfig;
+  transaction: OAuthTransaction;
+  now: number;
+};
+
+type RefreshedClaimExpectation = {
+  config: MobileOAuthConfig;
+  now: number;
+  expectedSubject?: string;
+};
+
+function validateIdTokenClaimsBase(
   idToken: string,
   expected: {
     config: MobileOAuthConfig;
-    transaction: OAuthTransaction;
     now: number;
+    expectedNonce?: string;
+    expectedSubject?: string;
   },
-): void {
+): string {
   const claims = decodeJwtPayload(idToken);
   const expectedIssuer = `https://cognito-idp.${expected.config.region}.amazonaws.com/${expected.config.userPoolId}`;
   const expiryWithSkew =
@@ -267,7 +322,9 @@ export function validateIdTokenClaims(
     typeof claims.aud !== 'string' ||
     claims.aud !== expected.config.mobileClientId ||
     claims.iss !== expectedIssuer ||
-    claims.nonce !== expected.transaction.nonce ||
+    !isNonEmptyString(claims.sub) ||
+    (expected.expectedNonce !== undefined && claims.nonce !== expected.expectedNonce) ||
+    (expected.expectedSubject !== undefined && claims.sub !== expected.expectedSubject) ||
     typeof claims.exp !== 'number' ||
     !Number.isFinite(claims.exp) ||
     !Number.isFinite(expiryWithSkew) ||
@@ -275,4 +332,24 @@ export function validateIdTokenClaims(
   ) {
     return invalidIdToken();
   }
+
+  return claims.sub;
+}
+
+export function validateAuthorizationCodeIdTokenClaims(
+  idToken: string,
+  expected: AuthorizationCodeClaimExpectation,
+): void {
+  validateIdTokenClaimsBase(idToken, {
+    config: expected.config,
+    now: expected.now,
+    expectedNonce: expected.transaction.nonce,
+  });
+}
+
+export function validateRefreshedIdTokenClaims(
+  idToken: string,
+  expected: RefreshedClaimExpectation,
+): string {
+  return validateIdTokenClaimsBase(idToken, expected);
 }

--- a/apps/vela-mobile/src/auth/mobile-session-store.test.ts
+++ b/apps/vela-mobile/src/auth/mobile-session-store.test.ts
@@ -67,6 +67,25 @@ describe('mobile session store', () => {
     await expect(store.loadRefreshToken()).resolves.toBeNull();
   });
 
+  it.each(['', '   '])(
+    'rejects blank refresh token saves without invoking secure storage',
+    async (refreshToken) => {
+      const secureStorage = {
+        get: vi.fn(),
+        set: vi.fn(),
+        remove: vi.fn(),
+      };
+      const store = createNativeStore(secureStorage);
+
+      await expect(store.saveRefreshToken(refreshToken)).rejects.toMatchObject({
+        name: 'MobileSessionStoreError',
+        code: 'corrupt',
+        message: 'corrupt',
+      } satisfies Partial<MobileSessionStoreError>);
+      expect(secureStorage.set).not.toHaveBeenCalled();
+    },
+  );
+
   it.each([[''], ['   '], [42], [false], [{}], [[]]])(
     'rejects malformed stored refresh token %p as corrupt',
     async (value) => {

--- a/apps/vela-mobile/src/auth/mobile-session-store.test.ts
+++ b/apps/vela-mobile/src/auth/mobile-session-store.test.ts
@@ -1,0 +1,166 @@
+import {
+  KeychainAccess,
+  StorageError,
+  StorageErrorType,
+} from '@aparajita/capacitor-secure-storage';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  MobileSessionStoreError,
+  createIosKeychainSessionStore,
+  createMobileSessionKey,
+  createUnsupportedMobileSessionStore,
+} from './mobile-session-store';
+
+const config = {
+  userPoolId: 'ca-central-1_pool',
+  mobileClientId: 'mobile-client',
+};
+
+function createNativeStore(secureStorage: {
+  get: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+}) {
+  return createIosKeychainSessionStore({
+    secureStorage,
+    runtime: {
+      isNativePlatform: () => true,
+      getPlatform: () => 'ios',
+    },
+    config,
+  });
+}
+
+describe('mobile session store', () => {
+  it('uses the exact environment key and non-synchronizing typed calls', async () => {
+    const secureStorage = {
+      get: vi.fn().mockResolvedValue('refresh-token'),
+      set: vi.fn().mockResolvedValue(undefined),
+      remove: vi.fn().mockResolvedValue(true),
+    };
+    const store = createNativeStore(secureStorage);
+    const key = 'vela:mobile:cognito:ca-central-1_pool:mobile-client:refresh:v1';
+
+    await expect(store.loadRefreshToken()).resolves.toBe('refresh-token');
+    await store.saveRefreshToken('rotated-token');
+    await store.clearRefreshToken();
+
+    expect(createMobileSessionKey(config)).toBe(key);
+    expect(secureStorage.get).toHaveBeenCalledWith(key, false, false);
+    expect(secureStorage.set).toHaveBeenCalledWith(
+      key,
+      'rotated-token',
+      false,
+      false,
+      KeychainAccess.afterFirstUnlockThisDeviceOnly,
+    );
+    expect(secureStorage.remove).toHaveBeenCalledWith(key, false);
+  });
+
+  it('returns null only when no refresh token is stored', async () => {
+    const store = createNativeStore({
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn(),
+      remove: vi.fn(),
+    });
+
+    await expect(store.loadRefreshToken()).resolves.toBeNull();
+  });
+
+  it.each([[''], ['   '], [42], [false], [{}], [[]]])(
+    'rejects malformed stored refresh token %p as corrupt',
+    async (value) => {
+      const store = createNativeStore({
+        get: vi.fn().mockResolvedValue(value),
+        set: vi.fn(),
+        remove: vi.fn(),
+      });
+
+      await expect(store.loadRefreshToken()).rejects.toMatchObject({
+        name: 'MobileSessionStoreError',
+        code: 'corrupt',
+        message: 'corrupt',
+      } satisfies Partial<MobileSessionStoreError>);
+    },
+  );
+
+  it.each([
+    [new StorageError('bad json', StorageErrorType.invalidData), 'corrupt'],
+    [new StorageError('native failure', StorageErrorType.osError), 'unavailable'],
+    [new Error('bridge failure'), 'unavailable'],
+  ] as const)('normalizes %p without exposing its message', async (failure, code) => {
+    const store = createNativeStore({
+      get: vi.fn().mockRejectedValue(failure),
+      set: vi.fn(),
+      remove: vi.fn(),
+    });
+
+    await expect(store.loadRefreshToken()).rejects.toMatchObject({
+      name: 'MobileSessionStoreError',
+      code,
+      message: code,
+    } satisfies Partial<MobileSessionStoreError>);
+  });
+
+  it.each([
+    ['save', (store: ReturnType<typeof createNativeStore>) => store.saveRefreshToken('token')],
+    ['clear', (store: ReturnType<typeof createNativeStore>) => store.clearRefreshToken()],
+  ])('normalizes %s failures without exposing their messages', async (_operation, invoke) => {
+    const failure = new Error('native secret');
+    const store = createNativeStore({
+      get: vi.fn(),
+      set: vi.fn().mockRejectedValue(failure),
+      remove: vi.fn().mockRejectedValue(failure),
+    });
+
+    await expect(invoke(store)).rejects.toMatchObject({
+      name: 'MobileSessionStoreError',
+      code: 'unavailable',
+      message: 'unavailable',
+    } satisfies Partial<MobileSessionStoreError>);
+  });
+
+  it.each([
+    ['browser', false, 'web'],
+    ['android', true, 'android'],
+    ['unknown platform', true, 'desktop'],
+  ])('refuses %s without invoking secure storage', async (_name, isNativePlatform, platform) => {
+    const secureStorage = {
+      get: vi.fn(),
+      set: vi.fn(),
+      remove: vi.fn(),
+    };
+    const store = createIosKeychainSessionStore({
+      secureStorage,
+      runtime: { isNativePlatform: () => isNativePlatform, getPlatform: () => platform },
+      config,
+    });
+
+    await expect(store.loadRefreshToken()).rejects.toMatchObject({
+      code: 'unsupported_platform',
+    });
+    await expect(store.saveRefreshToken('token')).rejects.toMatchObject({
+      code: 'unsupported_platform',
+    });
+    await expect(store.clearRefreshToken()).rejects.toMatchObject({
+      code: 'unsupported_platform',
+    });
+    expect(secureStorage.get).not.toHaveBeenCalled();
+    expect(secureStorage.set).not.toHaveBeenCalled();
+    expect(secureStorage.remove).not.toHaveBeenCalled();
+  });
+
+  it('provides an explicitly unsupported store for non-native composition roots', async () => {
+    const store = createUnsupportedMobileSessionStore();
+
+    await expect(store.loadRefreshToken()).rejects.toMatchObject({
+      code: 'unsupported_platform',
+    });
+    await expect(store.saveRefreshToken('token')).rejects.toMatchObject({
+      code: 'unsupported_platform',
+    });
+    await expect(store.clearRefreshToken()).rejects.toMatchObject({
+      code: 'unsupported_platform',
+    });
+  });
+});

--- a/apps/vela-mobile/src/auth/mobile-session-store.ts
+++ b/apps/vela-mobile/src/auth/mobile-session-store.ts
@@ -74,6 +74,9 @@ export function createIosKeychainSessionStore(options: {
 
     async saveRefreshToken(refreshToken) {
       assertNativeIos(options.runtime);
+      if (refreshToken.trim().length === 0) {
+        throw new MobileSessionStoreError('corrupt');
+      }
       try {
         await options.secureStorage.set(
           key,

--- a/apps/vela-mobile/src/auth/mobile-session-store.ts
+++ b/apps/vela-mobile/src/auth/mobile-session-store.ts
@@ -1,0 +1,113 @@
+import {
+  KeychainAccess,
+  StorageError,
+  StorageErrorType,
+  type SecureStoragePlugin,
+} from '@aparajita/capacitor-secure-storage';
+import type { MobileOAuthConfig } from './mobile-auth-contract';
+
+export type MobileSessionStore = {
+  loadRefreshToken(): Promise<string | null>;
+  saveRefreshToken(refreshToken: string): Promise<void>;
+  clearRefreshToken(): Promise<void>;
+};
+
+export type MobileSessionStoreErrorCode = 'corrupt' | 'unavailable' | 'unsupported_platform';
+
+export class MobileSessionStoreError extends Error {
+  constructor(readonly code: MobileSessionStoreErrorCode) {
+    super(code);
+    this.name = 'MobileSessionStoreError';
+  }
+}
+
+export type MobileRuntimeAdapter = {
+  isNativePlatform(): boolean;
+  getPlatform(): string;
+};
+
+export function createMobileSessionKey(
+  config: Pick<MobileOAuthConfig, 'userPoolId' | 'mobileClientId'>,
+): string {
+  return `vela:mobile:cognito:${config.userPoolId}:${config.mobileClientId}:refresh:v1`;
+}
+
+function normalizeFailure(error: unknown): MobileSessionStoreError {
+  if (error instanceof MobileSessionStoreError) return error;
+  if (error instanceof StorageError && error.code === StorageErrorType.invalidData) {
+    return new MobileSessionStoreError('corrupt');
+  }
+  return new MobileSessionStoreError('unavailable');
+}
+
+function assertNativeIos(runtime: MobileRuntimeAdapter): void {
+  if (!runtime.isNativePlatform() || runtime.getPlatform() !== 'ios') {
+    throw new MobileSessionStoreError('unsupported_platform');
+  }
+}
+
+function unsupportedPlatform(): never {
+  throw new MobileSessionStoreError('unsupported_platform');
+}
+
+export function createIosKeychainSessionStore(options: {
+  secureStorage: Pick<SecureStoragePlugin, 'get' | 'set' | 'remove'>;
+  runtime: MobileRuntimeAdapter;
+  config: Pick<MobileOAuthConfig, 'userPoolId' | 'mobileClientId'>;
+}): MobileSessionStore {
+  const key = createMobileSessionKey(options.config);
+
+  return {
+    async loadRefreshToken() {
+      assertNativeIos(options.runtime);
+      try {
+        const refreshToken = await options.secureStorage.get(key, false, false);
+        if (refreshToken === null) return null;
+        if (typeof refreshToken !== 'string' || refreshToken.trim().length === 0) {
+          throw new MobileSessionStoreError('corrupt');
+        }
+        return refreshToken;
+      } catch (error) {
+        throw normalizeFailure(error);
+      }
+    },
+
+    async saveRefreshToken(refreshToken) {
+      assertNativeIos(options.runtime);
+      try {
+        await options.secureStorage.set(
+          key,
+          refreshToken,
+          false,
+          false,
+          KeychainAccess.afterFirstUnlockThisDeviceOnly,
+        );
+      } catch (error) {
+        throw normalizeFailure(error);
+      }
+    },
+
+    async clearRefreshToken() {
+      assertNativeIos(options.runtime);
+      try {
+        await options.secureStorage.remove(key, false);
+      } catch (error) {
+        throw normalizeFailure(error);
+      }
+    },
+  };
+}
+
+export function createUnsupportedMobileSessionStore(): MobileSessionStore {
+  return {
+    async loadRefreshToken() {
+      return unsupportedPlatform();
+    },
+    async saveRefreshToken() {
+      return unsupportedPlatform();
+    },
+    async clearRefreshToken() {
+      return unsupportedPlatform();
+    },
+  };
+}

--- a/apps/vela-mobile/src/boot/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/boot/mobile-auth.test.ts
@@ -88,83 +88,17 @@ vi.mock('../auth/mobile-installation-store', () => ({
 
 import { MOBILE_AUTH_KEY } from '../services/mobile-auth';
 import { config } from '../config';
+import {
+  captureConsoleCalls,
+  createSecretLeakAssertions,
+  searchable,
+  storageSnapshot,
+} from '../test/secret-leak-helpers';
 import boot from './mobile-auth';
 
-const SECRET_SENTINELS = [
-  'SECRET-access-token',
-  'SECRET-id-token',
-  'SECRET-refresh-token',
-  'SECRET-rotated-refresh-token',
-] as const;
-
-const LOG_AND_DOM_SENTINELS = [
-  ...SECRET_SENTINELS,
-  'SECRET-authorization-url',
-  'SECRET-callback-code',
-  'SECRET-code-verifier',
-  'SECRET-nonce',
-  'SECRET-claim-email',
-] as const;
-
-function searchable(value: unknown): string {
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
-}
-
-function storageSnapshot(storage: Storage): string {
-  return Array.from({ length: storage.length }, (_, index) => {
-    const key = storage.key(index) ?? '';
-    return `${key}=${storage.getItem(key) ?? ''}`;
-  }).join('\n');
-}
-
-function expectNoSecretLeak(input: {
-  consoleCalls: unknown[][];
-  preferenceCalls: unknown[][];
-  renderedText?: string;
-}): void {
-  const logsAndDom = [
-    searchable(input.consoleCalls),
-    input.renderedText ?? document.body.textContent ?? '',
-  ].join('\n');
-  const browserAndPreferenceStorage = [
-    searchable(input.preferenceCalls),
-    storageSnapshot(window.localStorage),
-    storageSnapshot(window.sessionStorage),
-  ].join('\n');
-
-  for (const secret of LOG_AND_DOM_SENTINELS) {
-    expect(logsAndDom).not.toContain(secret);
-  }
-  for (const secret of SECRET_SENTINELS) {
-    expect(browserAndPreferenceStorage).not.toContain(secret);
-  }
-}
-
-function captureConsoleCalls(): {
-  calls: () => unknown[][];
-  restore: () => void;
-} {
-  const spies = (['debug', 'info', 'log', 'warn', 'error'] as const).map((method) =>
-    vi.spyOn(console, method).mockImplementation(() => undefined),
-  );
-  return {
-    calls: () =>
-      spies.flatMap((spy) =>
-        spy.mock.calls.map((call) =>
-          call.map((value) =>
-            value instanceof Error ? { ...value, name: value.name, message: value.message } : value,
-          ),
-        ),
-      ),
-    restore: () => {
-      for (const spy of spies) spy.mockRestore();
-    },
-  };
-}
+const { expectNoSecretLeak } = createSecretLeakAssertions({
+  installationKey: 'vela:installation:boot-test',
+});
 
 describe('mobile auth boot', () => {
   const runBoot = boot as unknown as (params: {

--- a/apps/vela-mobile/src/boot/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/boot/mobile-auth.test.ts
@@ -322,6 +322,7 @@ describe('mobile auth boot', () => {
         refreshToken: 'SECRET-refresh-token',
         rotatedRefreshToken: 'SECRET-rotated-refresh-token',
         email: 'SECRET-claim-email',
+        rawResponse: 'SECRET-raw-response',
       },
     };
     const nativeFailure = Object.assign(
@@ -332,6 +333,9 @@ describe('mobile auth boot', () => {
         codeVerifier: 'SECRET-code-verifier',
         nonce: 'SECRET-nonce',
         decodedClaimEmail: 'SECRET-claim-email',
+        rawRequest: 'SECRET-raw-request',
+        rawResponse: 'SECRET-raw-response',
+        nativeException: 'SECRET-native-exception',
       },
     );
     mocks.capacitorHttpRequest
@@ -364,6 +368,10 @@ describe('mobile auth boot', () => {
         preferenceCalls: mocks.preferencesPlugin.set.mock.calls,
         renderedText: '',
       });
+      expect(searchable(consoleCapture.calls())).not.toContain('SECRET-');
+      expect(mocks.preferencesPlugin.set).not.toHaveBeenCalled();
+      expect(storageSnapshot(window.localStorage)).toBe('');
+      expect(storageSnapshot(window.sessionStorage)).toBe('');
     } finally {
       if (originalFetch === undefined) {
         Reflect.deleteProperty(window, 'fetch');

--- a/apps/vela-mobile/src/boot/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/boot/mobile-auth.test.ts
@@ -20,22 +20,52 @@ const mocks = vi.hoisted(() => {
       set: vi.fn(),
       remove: vi.fn(),
     },
+    secureStorage: {
+      get: vi.fn(),
+      set: vi.fn(),
+      remove: vi.fn(),
+    },
+    capacitor: {
+      isNativePlatform: vi.fn(),
+      getPlatform: vi.fn(),
+    },
     capacitorHttpRequest: vi.fn(),
     transactionStore: {
       replace: vi.fn(),
       load: vi.fn(),
       clear: vi.fn(),
     },
+    sessionStore: {
+      loadRefreshToken: vi.fn(),
+      saveRefreshToken: vi.fn(),
+      clearRefreshToken: vi.fn(),
+    },
+    unsupportedSessionStore: {
+      loadRefreshToken: vi.fn(),
+      saveRefreshToken: vi.fn(),
+      clearRefreshToken: vi.fn(),
+    },
+    installationStore: {
+      isCurrentInstallationMarked: vi.fn(),
+      markCurrentInstallation: vi.fn(),
+    },
     coordinator,
     createCoordinator: vi.fn((_dependencies: unknown) => coordinator),
     createTransactionStore: vi.fn(),
+    createIosStore: vi.fn(),
+    createUnsupportedStore: vi.fn(),
+    createInstallationStore: vi.fn(),
   };
 });
 
+vi.mock('@aparajita/capacitor-secure-storage', () => ({
+  SecureStorage: mocks.secureStorage,
+}));
 vi.mock('@capacitor/app', () => ({ App: mocks.appPlugin }));
 vi.mock('@capacitor/browser', () => ({ Browser: mocks.browserPlugin }));
 vi.mock('@capacitor/preferences', () => ({ Preferences: mocks.preferencesPlugin }));
 vi.mock('@capacitor/core', () => ({
+  Capacitor: mocks.capacitor,
   CapacitorHttp: { request: mocks.capacitorHttpRequest },
 }));
 vi.mock('../services/mobile-auth', async (importOriginal) => {
@@ -47,6 +77,13 @@ vi.mock('../services/mobile-auth', async (importOriginal) => {
 });
 vi.mock('../auth/oauth-transaction-store', () => ({
   createOAuthTransactionStore: mocks.createTransactionStore,
+}));
+vi.mock('../auth/mobile-session-store', () => ({
+  createIosKeychainSessionStore: mocks.createIosStore,
+  createUnsupportedMobileSessionStore: mocks.createUnsupportedStore,
+}));
+vi.mock('../auth/mobile-installation-store', () => ({
+  createMobileInstallationStore: mocks.createInstallationStore,
 }));
 
 import { MOBILE_AUTH_KEY } from '../services/mobile-auth';
@@ -60,7 +97,53 @@ describe('mobile auth boot', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.capacitor.isNativePlatform.mockReturnValue(true);
+    mocks.capacitor.getPlatform.mockReturnValue('ios');
     mocks.createTransactionStore.mockReturnValue(mocks.transactionStore);
+    mocks.createIosStore.mockReturnValue(mocks.sessionStore);
+    mocks.createUnsupportedStore.mockReturnValue(mocks.unsupportedSessionStore);
+    mocks.createInstallationStore.mockReturnValue(mocks.installationStore);
+  });
+
+  it('injects Keychain storage only on native iOS', () => {
+    mocks.capacitor.isNativePlatform.mockReturnValue(true);
+    mocks.capacitor.getPlatform.mockReturnValue('ios');
+
+    runBoot({ app: { provide: vi.fn() } });
+
+    expect(mocks.createIosStore).toHaveBeenCalledWith({
+      secureStorage: mocks.secureStorage,
+      runtime: mocks.capacitor,
+      config: {
+        userPoolId: config.auth.userPoolId,
+        mobileClientId: config.auth.mobileClientId,
+      },
+    });
+    expect(mocks.createUnsupportedStore).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [false, 'web'],
+    [true, 'android'],
+  ] as const)('injects the unsupported store for native=%s platform=%s', (isNative, platform) => {
+    mocks.capacitor.isNativePlatform.mockReturnValue(isNative);
+    mocks.capacitor.getPlatform.mockReturnValue(platform);
+
+    runBoot({ app: { provide: vi.fn() } });
+
+    expect(mocks.createUnsupportedStore).toHaveBeenCalledOnce();
+    expect(mocks.createIosStore).not.toHaveBeenCalled();
+    const dependencies = mocks.createCoordinator.mock.calls[0]?.[0] as
+      | MobileAuthCoordinatorDependencies
+      | undefined;
+    expect(dependencies).toMatchObject({
+      sessionStore: mocks.unsupportedSessionStore,
+      installationStore: mocks.installationStore,
+      isNativeIos: false,
+    });
+    expect(mocks.secureStorage.get).not.toHaveBeenCalled();
+    expect(mocks.secureStorage.set).not.toHaveBeenCalled();
+    expect(mocks.secureStorage.remove).not.toHaveBeenCalled();
   });
 
   it('provides the coordinator and starts initialization without blocking app mount', () => {
@@ -83,6 +166,10 @@ describe('mobile auth boot', () => {
     try {
       runBoot({ app });
       expect(mocks.createTransactionStore).toHaveBeenCalledWith(mocks.preferencesPlugin, Date.now);
+      expect(mocks.createInstallationStore).toHaveBeenCalledWith(mocks.preferencesPlugin, {
+        userPoolId: config.auth.userPoolId,
+        mobileClientId: config.auth.mobileClientId,
+      });
 
       const dependencies = mocks.createCoordinator.mock.calls[0]?.[0] as
         | MobileAuthCoordinatorDependencies
@@ -91,6 +178,9 @@ describe('mobile auth boot', () => {
         app: mocks.appPlugin,
         browser: mocks.browserPlugin,
         transactionStore: mocks.transactionStore,
+        sessionStore: mocks.sessionStore,
+        installationStore: mocks.installationStore,
+        isNativeIos: true,
         crypto: window.crypto,
         isSecureContext: true,
         now: Date.now,

--- a/apps/vela-mobile/src/boot/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/boot/mobile-auth.test.ts
@@ -90,6 +90,82 @@ import { MOBILE_AUTH_KEY } from '../services/mobile-auth';
 import { config } from '../config';
 import boot from './mobile-auth';
 
+const SECRET_SENTINELS = [
+  'SECRET-access-token',
+  'SECRET-id-token',
+  'SECRET-refresh-token',
+  'SECRET-rotated-refresh-token',
+] as const;
+
+const LOG_AND_DOM_SENTINELS = [
+  ...SECRET_SENTINELS,
+  'SECRET-authorization-url',
+  'SECRET-callback-code',
+  'SECRET-code-verifier',
+  'SECRET-nonce',
+  'SECRET-claim-email',
+] as const;
+
+function searchable(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function storageSnapshot(storage: Storage): string {
+  return Array.from({ length: storage.length }, (_, index) => {
+    const key = storage.key(index) ?? '';
+    return `${key}=${storage.getItem(key) ?? ''}`;
+  }).join('\n');
+}
+
+function expectNoSecretLeak(input: {
+  consoleCalls: unknown[][];
+  preferenceCalls: unknown[][];
+  renderedText?: string;
+}): void {
+  const logsAndDom = [
+    searchable(input.consoleCalls),
+    input.renderedText ?? document.body.textContent ?? '',
+  ].join('\n');
+  const browserAndPreferenceStorage = [
+    searchable(input.preferenceCalls),
+    storageSnapshot(window.localStorage),
+    storageSnapshot(window.sessionStorage),
+  ].join('\n');
+
+  for (const secret of LOG_AND_DOM_SENTINELS) {
+    expect(logsAndDom).not.toContain(secret);
+  }
+  for (const secret of SECRET_SENTINELS) {
+    expect(browserAndPreferenceStorage).not.toContain(secret);
+  }
+}
+
+function captureConsoleCalls(): {
+  calls: () => unknown[][];
+  restore: () => void;
+} {
+  const spies = (['debug', 'info', 'log', 'warn', 'error'] as const).map((method) =>
+    vi.spyOn(console, method).mockImplementation(() => undefined),
+  );
+  return {
+    calls: () =>
+      spies.flatMap((spy) =>
+        spy.mock.calls.map((call) =>
+          call.map((value) =>
+            value instanceof Error ? { ...value, name: value.name, message: value.message } : value,
+          ),
+        ),
+      ),
+    restore: () => {
+      for (const spy of spies) spy.mockRestore();
+    },
+  };
+}
+
 describe('mobile auth boot', () => {
   const runBoot = boot as unknown as (params: {
     app: { provide: ReturnType<typeof vi.fn> };
@@ -225,6 +301,81 @@ describe('mobile auth boot', () => {
         value: originalSecureContext,
       });
       Reflect.deleteProperty(window, 'fetch');
+    }
+  });
+
+  it('keeps secret-bearing native transport results and exceptions out of logging and non-secure storage', async () => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    const consoleCapture = captureConsoleCalls();
+    const app = { provide: vi.fn() };
+    const originalFetch = window.fetch;
+    Object.defineProperty(window, 'fetch', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    const rawResponse = {
+      status: 400,
+      data: {
+        accessToken: 'SECRET-access-token',
+        idToken: 'SECRET-id-token',
+        refreshToken: 'SECRET-refresh-token',
+        rotatedRefreshToken: 'SECRET-rotated-refresh-token',
+        email: 'SECRET-claim-email',
+      },
+    };
+    const nativeFailure = Object.assign(
+      new Error('SECRET-access-token SECRET-id-token SECRET-refresh-token'),
+      {
+        authorizationUrl: 'SECRET-authorization-url',
+        callbackCode: 'SECRET-callback-code',
+        codeVerifier: 'SECRET-code-verifier',
+        nonce: 'SECRET-nonce',
+        decodedClaimEmail: 'SECRET-claim-email',
+      },
+    );
+    mocks.capacitorHttpRequest
+      .mockResolvedValueOnce(rawResponse)
+      .mockRejectedValueOnce(nativeFailure);
+
+    try {
+      runBoot({ app });
+      const dependencies = mocks.createCoordinator.mock.calls[0]?.[0] as
+        | MobileAuthCoordinatorDependencies
+        | undefined;
+      const request = {
+        url: 'https://example.invalid/SECRET-authorization-url',
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        data: [
+          'code=SECRET-callback-code',
+          'code_verifier=SECRET-code-verifier',
+          'nonce=SECRET-nonce',
+          'access_token=SECRET-access-token',
+          'refresh_token=SECRET-refresh-token',
+        ].join('&'),
+      } as const;
+
+      await expect(dependencies?.tokenTransport.request(request)).resolves.toEqual(rawResponse);
+      await expect(dependencies?.tokenTransport.request(request)).rejects.toBe(nativeFailure);
+
+      expectNoSecretLeak({
+        consoleCalls: consoleCapture.calls(),
+        preferenceCalls: mocks.preferencesPlugin.set.mock.calls,
+        renderedText: '',
+      });
+    } finally {
+      if (originalFetch === undefined) {
+        Reflect.deleteProperty(window, 'fetch');
+      } else {
+        Object.defineProperty(window, 'fetch', {
+          configurable: true,
+          value: originalFetch,
+        });
+      }
+      consoleCapture.restore();
+      window.localStorage.clear();
+      window.sessionStorage.clear();
     }
   });
 });

--- a/apps/vela-mobile/src/boot/mobile-auth.ts
+++ b/apps/vela-mobile/src/boot/mobile-auth.ts
@@ -1,17 +1,41 @@
+import { SecureStorage } from '@aparajita/capacitor-secure-storage';
 import { App as CapacitorApp } from '@capacitor/app';
 import { Browser } from '@capacitor/browser';
-import { CapacitorHttp } from '@capacitor/core';
+import { Capacitor, CapacitorHttp } from '@capacitor/core';
 import { Preferences } from '@capacitor/preferences';
 import { defineBoot } from '#q-app/wrappers';
+import { createMobileInstallationStore } from '../auth/mobile-installation-store';
+import {
+  createIosKeychainSessionStore,
+  createUnsupportedMobileSessionStore,
+} from '../auth/mobile-session-store';
 import { createOAuthTransactionStore } from '../auth/oauth-transaction-store';
 import { config } from '../config';
 import { createMobileAuthCoordinator, MOBILE_AUTH_KEY } from '../services/mobile-auth';
 
 export default defineBoot(({ app }) => {
+  const isNativeIos = Capacitor.isNativePlatform() && Capacitor.getPlatform() === 'ios';
+  const sessionStore = isNativeIos
+    ? createIosKeychainSessionStore({
+        secureStorage: SecureStorage,
+        runtime: Capacitor,
+        config: {
+          userPoolId: config.auth.userPoolId,
+          mobileClientId: config.auth.mobileClientId,
+        },
+      })
+    : createUnsupportedMobileSessionStore();
+  const installationStore = createMobileInstallationStore(Preferences, {
+    userPoolId: config.auth.userPoolId,
+    mobileClientId: config.auth.mobileClientId,
+  });
   const coordinator = createMobileAuthCoordinator({
     app: CapacitorApp,
     browser: Browser,
     transactionStore: createOAuthTransactionStore(Preferences, Date.now),
+    sessionStore,
+    installationStore,
+    isNativeIos,
     tokenTransport: {
       request: (options) => {
         const { timeoutMs, ...httpOptions } = options;

--- a/apps/vela-mobile/src/components/mobile/MobileAuthGate.navigation.test.ts
+++ b/apps/vela-mobile/src/components/mobile/MobileAuthGate.navigation.test.ts
@@ -1,0 +1,147 @@
+import { defineComponent, nextTick, reactive } from 'vue';
+import { flushPromises, mount } from '@vue/test-utils';
+import { createMemoryHistory, createRouter, type RouteRecordRaw } from 'vue-router';
+import { describe, expect, it, vi } from 'vitest';
+import type { MobileAuthCoordinator, MobileAuthState } from '../../auth/mobile-auth-contract';
+import { MOBILE_AUTH_KEY } from '../../services/mobile-auth';
+import MobileAuthGate from './MobileAuthGate.vue';
+
+const ProtectedSlot = defineComponent({
+  template: '<div data-testid="protected-slot">Protected content</div>',
+});
+
+const routes: RouteRecordRaw[] = [
+  { path: '/', component: ProtectedSlot },
+  { path: '/review', component: ProtectedSlot },
+];
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve'];
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function mountGate(path = '/review') {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes,
+  });
+  await router.push(path);
+  await router.isReady();
+
+  const state = reactive<MobileAuthState>({
+    phase: 'signedOut',
+    operation: 'idle',
+    sessionUsable: false,
+    errorCode: null,
+    retryAction: null,
+    notice: null,
+    user: null,
+  });
+  const coordinator: MobileAuthCoordinator = {
+    state,
+    initialize: vi.fn().mockResolvedValue(undefined),
+    startSignIn: vi.fn().mockResolvedValue(undefined),
+    completeCallback: vi.fn().mockResolvedValue(undefined),
+    retryCurrentOperation: vi.fn().mockResolvedValue(undefined),
+    signOut: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn().mockResolvedValue(undefined),
+  };
+  const wrapper = mount(MobileAuthGate, {
+    slots: { default: ProtectedSlot },
+    global: {
+      plugins: [router],
+      provide: {
+        [MOBILE_AUTH_KEY as symbol]: coordinator,
+      },
+    },
+  });
+  await nextTick();
+
+  return { router, state, wrapper };
+}
+
+function authenticate(state: MobileAuthState): void {
+  Object.assign(state, {
+    phase: 'authenticated',
+    operation: 'idle',
+    sessionUsable: true,
+    errorCode: null,
+    retryAction: null,
+    notice: null,
+    user: { userId: 'user-1', email: null },
+  });
+}
+
+function signOut(state: MobileAuthState): void {
+  Object.assign(state, {
+    phase: 'signedOut',
+    operation: 'idle',
+    sessionUsable: false,
+    errorCode: null,
+    retryAction: null,
+    notice: null,
+    user: null,
+  });
+}
+
+describe('MobileAuthGate landing navigation races', () => {
+  it('ignores a stale successful replacement after the session becomes unusable', async () => {
+    const landing = deferred<void>();
+    const { router, state, wrapper } = await mountGate();
+    const originalReplace = router.replace.bind(router);
+    vi.spyOn(router, 'replace').mockImplementation(async (target) => {
+      await landing.promise;
+      return originalReplace(target);
+    });
+
+    authenticate(state);
+    await nextTick();
+    signOut(state);
+    await nextTick();
+    landing.resolve();
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.find('[role="alert"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(false);
+  });
+
+  it('ignores a stale rejected replacement after the session becomes unusable', async () => {
+    const landing = deferred<void>();
+    const { router, state, wrapper } = await mountGate();
+    vi.spyOn(router, 'replace').mockImplementation(async () => {
+      await landing.promise;
+      throw new Error('navigation failed');
+    });
+
+    authenticate(state);
+    await nextTick();
+    signOut(state);
+    await nextTick();
+    landing.resolve();
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.find('[role="alert"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(false);
+  });
+
+  it('accepts a duplicated replacement when the router is already at home', async () => {
+    const { router, state, wrapper } = await mountGate('/');
+
+    authenticate(state);
+    await flushPromises();
+    await nextTick();
+
+    expect(router.currentRoute.value.fullPath).toBe('/');
+    expect(wrapper.get('[data-testid="protected-slot"]').text()).toBe('Protected content');
+  });
+});

--- a/apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts
+++ b/apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts
@@ -159,6 +159,9 @@ function withRawSecretState(state: Partial<MobileAuthState>): Partial<MobileAuth
     codeVerifier: 'SECRET-code-verifier',
     nonce: 'SECRET-nonce',
     decodedClaimEmail: 'SECRET-claim-email',
+    rawRequest: 'SECRET-raw-request',
+    rawResponse: 'SECRET-raw-response',
+    nativeException: 'SECRET-native-exception',
   });
 }
 
@@ -419,6 +422,10 @@ describe('MobileAuthGate', () => {
         preferenceCalls: [],
         renderedText: wrapper.text(),
       });
+      expect(searchable(consoleCapture.calls())).not.toContain('SECRET-');
+      expect(wrapper.text()).not.toContain('SECRET-');
+      expect(storageSnapshot(window.localStorage)).toBe('');
+      expect(storageSnapshot(window.sessionStorage)).toBe('');
     } finally {
       wrapper?.unmount();
       consoleCapture.restore();

--- a/apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts
+++ b/apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts
@@ -9,67 +9,33 @@ import type {
   MobileAuthState,
 } from '../../auth/mobile-auth-contract';
 import { MOBILE_AUTH_KEY } from '../../services/mobile-auth';
+import {
+  captureConsoleCalls,
+  createSecretLeakAssertions,
+  searchable,
+  storageSnapshot,
+} from '../../test/secret-leak-helpers';
 import MobileAuthGate, { shouldBypassMobileAuth } from './MobileAuthGate.vue';
 
-const SECRET_SENTINELS = [
-  'SECRET-access-token',
-  'SECRET-id-token',
-  'SECRET-refresh-token',
-  'SECRET-rotated-refresh-token',
-] as const;
-
-const LOG_AND_DOM_SENTINELS = [
-  ...SECRET_SENTINELS,
-  'SECRET-authorization-url',
-  'SECRET-callback-code',
-  'SECRET-code-verifier',
-  'SECRET-nonce',
-  'SECRET-claim-email',
-] as const;
-
-function searchable(value: unknown): string {
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
-}
-
-function storageSnapshot(storage: Storage): string {
-  return Array.from({ length: storage.length }, (_, index) => {
-    const key = storage.key(index) ?? '';
-    return `${key}=${storage.getItem(key) ?? ''}`;
-  }).join('\n');
-}
-
-function expectNoSecretLeak(input: {
-  consoleCalls: unknown[][];
-  preferenceCalls: unknown[][];
-  renderedText?: string;
-}): void {
-  const logsAndDom = [
-    searchable(input.consoleCalls),
-    input.renderedText ?? document.body.textContent ?? '',
-  ].join('\n');
-  const browserAndPreferenceStorage = [
-    searchable(input.preferenceCalls),
-    storageSnapshot(window.localStorage),
-    storageSnapshot(window.sessionStorage),
-  ].join('\n');
-
-  for (const secret of LOG_AND_DOM_SENTINELS) {
-    expect(logsAndDom).not.toContain(secret);
-  }
-  for (const secret of SECRET_SENTINELS) {
-    expect(browserAndPreferenceStorage).not.toContain(secret);
-  }
-}
+const { expectNoSecretLeak } = createSecretLeakAssertions({
+  installationKey: 'vela:installation:us-east-1_example:mobile-client-id',
+});
 
 const ProtectedSlot = defineComponent({
   template: '<div data-testid="protected-slot">Protected content</div>',
 });
 
 const user = { userId: 'user-1', email: 'vela@example.com' };
+
+const BLOCKING_OPERATION_STATES: Record<MobileAuthState['operation'], Partial<MobileAuthState>> = {
+  idle: {},
+  restoring: { phase: 'initializing' },
+  refreshing: { phase: 'authenticated', user },
+  persisting: { phase: 'exchangingCode' },
+  verifying: { phase: 'verifyingSession' },
+  signingOut: { phase: 'authenticated', user },
+  cleaningUp: { phase: 'signedOut' },
+};
 
 const routes: RouteRecordRaw[] = [
   { path: '/', component: ProtectedSlot },
@@ -124,28 +90,6 @@ function contrastRatio(first: [number, number, number], second: [number, number,
   const brighter = Math.max(relativeLuminance(first), relativeLuminance(second));
   const darker = Math.min(relativeLuminance(first), relativeLuminance(second));
   return (brighter + 0.05) / (darker + 0.05);
-}
-
-function captureConsoleCalls(): {
-  calls: () => unknown[][];
-  restore: () => void;
-} {
-  const spies = (['debug', 'info', 'log', 'warn', 'error'] as const).map((method) =>
-    vi.spyOn(console, method).mockImplementation(() => undefined),
-  );
-  return {
-    calls: () =>
-      spies.flatMap((spy) =>
-        spy.mock.calls.map((call) =>
-          call.map((value) =>
-            value instanceof Error ? { ...value, name: value.name, message: value.message } : value,
-          ),
-        ),
-      ),
-    restore: () => {
-      for (const spy of spies) spy.mockRestore();
-    },
-  };
 }
 
 function withRawSecretState(state: Partial<MobileAuthState>): Partial<MobileAuthState> {
@@ -665,29 +609,26 @@ describe('MobileAuthGate', () => {
     expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(true);
   });
 
-  it.each(['browser', 'Android'])(
-    'renders %s as a dedicated native-iOS-only non-retryable gate',
-    async () => {
-      const { wrapper } = await mountGate({
-        phase: 'error',
-        operation: 'idle',
-        sessionUsable: false,
-        errorCode: 'unsupported_platform',
-        retryAction: null,
-        notice: null,
-        user: null,
-      });
+  it('renders unsupported_platform as a dedicated native-iOS-only non-retryable gate', async () => {
+    const { wrapper } = await mountGate({
+      phase: 'error',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: 'unsupported_platform',
+      retryAction: null,
+      notice: null,
+      user: null,
+    });
 
-      expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(false);
-      expect(wrapper.get('[role="alert"]').text()).toContain(
-        'Vela mobile sign-in is unavailable here',
-      );
-      expect(wrapper.get('[role="alert"]').text()).toContain(
-        'Vela mobile sign-in is supported only on native iOS.',
-      );
-      expect(wrapper.find('button').exists()).toBe(false);
-    },
-  );
+    expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(false);
+    expect(wrapper.get('[role="alert"]').text()).toContain(
+      'Vela mobile sign-in is unavailable here',
+    );
+    expect(wrapper.get('[role="alert"]').text()).toContain(
+      'Vela mobile sign-in is supported only on native iOS.',
+    );
+    expect(wrapper.find('button').exists()).toBe(false);
+  });
 
   it('shows non-configuration auth errors instead of marked diagnostics', async () => {
     const { wrapper } = await mountGate(
@@ -810,18 +751,10 @@ describe('MobileAuthGate', () => {
     ['signingOut', 'Signing out…'],
     ['cleaningUp', 'Finishing secure sign-out…'],
   ])('announces blocking %s operation with exact copy', async (operation, copy) => {
-    const operationState: Partial<MobileAuthState> =
-      operation === 'restoring'
-        ? { phase: 'initializing', operation }
-        : operation === 'refreshing'
-          ? { phase: 'authenticated', operation, user }
-          : operation === 'persisting'
-            ? { phase: 'exchangingCode', operation }
-            : operation === 'verifying'
-              ? { phase: 'verifyingSession', operation }
-              : operation === 'signingOut'
-                ? { phase: 'authenticated', operation, user }
-                : { phase: 'signedOut', operation };
+    const operationState: Partial<MobileAuthState> = {
+      operation,
+      ...BLOCKING_OPERATION_STATES[operation],
+    };
     const { wrapper } = await mountGate(operationState);
 
     const status = wrapper.get('[role="status"]');
@@ -919,6 +852,32 @@ describe('MobileAuthGate', () => {
 
     Object.assign(state, {
       operation: 'idle',
+      errorCode: 'session_refresh_failed',
+      retryAction: 'refresh',
+    });
+    await nextTick();
+    await nextTick();
+
+    expect(document.activeElement).toBe(wrapper.get('[data-testid="auth-error-heading"]').element);
+  });
+
+  it('returns focus to the error heading when usable content becomes a blocking session failure', async () => {
+    const host = document.createElement('div');
+    document.body.append(host);
+    const { state, wrapper } = await mountGate(
+      { phase: 'signedOut' },
+      { attachTo: host, path: '/review' },
+    );
+
+    state.phase = 'authenticated';
+    state.sessionUsable = true;
+    state.user = { userId: 'user-1', email: null };
+    await flushPromises();
+    await nextTick();
+    expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(true);
+
+    Object.assign(state, {
+      sessionUsable: false,
       errorCode: 'session_refresh_failed',
       retryAction: 'refresh',
     });

--- a/apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts
+++ b/apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts
@@ -665,21 +665,29 @@ describe('MobileAuthGate', () => {
     expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(true);
   });
 
-  it('renders unsupported runtime as a closed non-retryable gate outside diagnostics', async () => {
-    const { wrapper } = await mountGate({
-      phase: 'error',
-      operation: 'idle',
-      sessionUsable: false,
-      errorCode: 'unsupported_platform',
-      retryAction: null,
-      notice: null,
-      user: null,
-    });
+  it.each(['browser', 'Android'])(
+    'renders %s as a dedicated native-iOS-only non-retryable gate',
+    async () => {
+      const { wrapper } = await mountGate({
+        phase: 'error',
+        operation: 'idle',
+        sessionUsable: false,
+        errorCode: 'unsupported_platform',
+        retryAction: null,
+        notice: null,
+        user: null,
+      });
 
-    expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(false);
-    expect(wrapper.get('[role="alert"]').text()).toContain('Vela cannot use this session');
-    expect(wrapper.find('button').exists()).toBe(false);
-  });
+      expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(false);
+      expect(wrapper.get('[role="alert"]').text()).toContain(
+        'Vela mobile sign-in is unavailable here',
+      );
+      expect(wrapper.get('[role="alert"]').text()).toContain(
+        'Vela mobile sign-in is supported only on native iOS.',
+      );
+      expect(wrapper.find('button').exists()).toBe(false);
+    },
+  );
 
   it('shows non-configuration auth errors instead of marked diagnostics', async () => {
     const { wrapper } = await mountGate(
@@ -720,7 +728,9 @@ describe('MobileAuthGate', () => {
     expect(
       shouldBypassMobileAuth(true, true, {
         ...signedOut,
+        phase: 'authenticated',
         operation: 'signingOut',
+        user,
       }),
     ).toBe(false);
     expect(
@@ -809,7 +819,9 @@ describe('MobileAuthGate', () => {
             ? { phase: 'exchangingCode', operation }
             : operation === 'verifying'
               ? { phase: 'verifyingSession', operation }
-              : { phase: 'signedOut', operation };
+              : operation === 'signingOut'
+                ? { phase: 'authenticated', operation, user }
+                : { phase: 'signedOut', operation };
     const { wrapper } = await mountGate(operationState);
 
     const status = wrapper.get('[role="status"]');
@@ -870,7 +882,7 @@ describe('MobileAuthGate', () => {
     const retryCurrentOperation = vi.fn(() => pending.promise);
     const { coordinator } = createFakeCoordinator(
       {
-        phase: 'error',
+        phase: 'initializing',
         errorCode: 'session_restore_failed',
         retryAction: 'restore',
       },

--- a/apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts
+++ b/apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts
@@ -90,6 +90,7 @@ function createFakeCoordinator(
     startSignIn: vi.fn().mockResolvedValue(undefined),
     completeCallback: vi.fn().mockResolvedValue(undefined),
     retryCurrentOperation: vi.fn().mockResolvedValue(undefined),
+    signOut: vi.fn().mockResolvedValue(undefined),
     dispose: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };

--- a/apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts
+++ b/apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts
@@ -15,6 +15,8 @@ const ProtectedSlot = defineComponent({
   template: '<div data-testid="protected-slot">Protected content</div>',
 });
 
+const user = { userId: 'user-1', email: 'vela@example.com' };
+
 const routes: RouteRecordRaw[] = [
   { path: '/', component: ProtectedSlot },
   { path: '/review', component: ProtectedSlot },
@@ -164,15 +166,22 @@ describe('MobileAuthGate', () => {
   it('retries only API session verification for session_verification_failed', async () => {
     const retryCurrentOperation = vi.fn().mockResolvedValue(undefined);
     const { coordinator } = createFakeCoordinator(
-      { phase: 'error', errorCode: 'session_verification_failed' },
+      {
+        phase: 'error',
+        errorCode: 'session_verification_failed',
+        retryAction: 'verify',
+      },
       { retryCurrentOperation },
     );
     const { wrapper } = await mountGate({}, { coordinator });
 
     const alert = wrapper.get('[role="alert"]');
     expect(alert.text()).toContain('Vela could not verify your session');
-    expect(wrapper.findAll('button')).toHaveLength(1);
-    await wrapper.get('button').trigger('click');
+    expect(wrapper.findAll('button').map((button) => button.text())).toEqual([
+      'Retry',
+      'Sign out and start over',
+    ]);
+    await wrapper.findAll('button')[0]?.trigger('click');
 
     expect(retryCurrentOperation).toHaveBeenCalledOnce();
     expect(coordinator.startSignIn).not.toHaveBeenCalled();
@@ -348,6 +357,8 @@ describe('MobileAuthGate', () => {
     const { wrapper } = await mountGate({
       phase: 'authenticated',
       sessionUsable: false,
+      errorCode: 'session_refresh_failed',
+      retryAction: 'refresh',
       user: { userId: 'user-1', email: null },
     });
 
@@ -430,6 +441,23 @@ describe('MobileAuthGate', () => {
     expect(wrapper.find('[role="alert"]').exists()).toBe(false);
   });
 
+  it('allows marked development diagnostics for unsupported browser boot', async () => {
+    const { wrapper } = await mountGate(
+      {
+        phase: 'error',
+        operation: 'idle',
+        sessionUsable: false,
+        errorCode: 'unsupported_platform',
+        retryAction: null,
+        notice: null,
+        user: null,
+      },
+      { path: '/diagnostics' },
+    );
+
+    expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(true);
+  });
+
   it('shows non-configuration auth errors instead of marked diagnostics', async () => {
     const { wrapper } = await mountGate(
       { phase: 'error', errorCode: 'provider_error' },
@@ -453,6 +481,33 @@ describe('MobileAuthGate', () => {
     expect(shouldBypassMobileAuth(true, true, signedOut)).toBe(true);
     expect(shouldBypassMobileAuth(false, true, signedOut)).toBe(false);
     expect(shouldBypassMobileAuth(true, false, signedOut)).toBe(false);
+    expect(
+      shouldBypassMobileAuth(true, true, {
+        ...signedOut,
+        phase: 'error',
+        errorCode: 'unsupported_platform',
+      }),
+    ).toBe(true);
+    expect(
+      shouldBypassMobileAuth(true, true, {
+        ...signedOut,
+        notice: 'session_unusable',
+      }),
+    ).toBe(false);
+    expect(
+      shouldBypassMobileAuth(true, true, {
+        ...signedOut,
+        operation: 'signingOut',
+      }),
+    ).toBe(false);
+    expect(
+      shouldBypassMobileAuth(true, true, {
+        ...signedOut,
+        errorCode: 'session_cleanup_failed',
+        retryAction: 'cleanup',
+        notice: 'cleanup_incomplete',
+      }),
+    ).toBe(false);
 
     const { wrapper } = await mountGate(
       { phase: 'signedOut' },
@@ -467,5 +522,204 @@ describe('MobileAuthGate', () => {
     const ratio = contrastRatio(parseRgb(styles.color), parseRgb(styles.backgroundColor));
 
     expect(ratio).toBeGreaterThanOrEqual(7);
+  });
+
+  it('renders retry and start-over for an expired refresh failure', async () => {
+    const { wrapper, coordinator } = await mountGate({
+      phase: 'authenticated',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: 'session_refresh_failed',
+      retryAction: 'refresh',
+      notice: null,
+      user,
+    });
+
+    expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(false);
+    expect(wrapper.findAll('button').map((button) => button.text())).toEqual([
+      'Retry',
+      'Sign out and start over',
+    ]);
+    await wrapper.findAll('button')[1]?.trigger('click');
+    expect(coordinator.signOut).toHaveBeenCalledOnce();
+  });
+
+  it('renders a non-blocking retry banner over usable content', async () => {
+    const retryCurrentOperation = vi.fn().mockResolvedValue(undefined);
+    const { coordinator } = createFakeCoordinator(
+      {
+        phase: 'authenticated',
+        operation: 'idle',
+        sessionUsable: true,
+        errorCode: 'session_refresh_failed',
+        retryAction: 'refresh',
+        notice: null,
+        user,
+      },
+      { retryCurrentOperation },
+    );
+    const { wrapper } = await mountGate({}, { coordinator });
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(true);
+    const alert = wrapper.get('[role="alert"]');
+    expect(alert.text()).toContain('Vela cannot use this session');
+    expect(alert.get('button').text()).toBe('Retry');
+    await alert.get('button').trigger('click');
+    expect(retryCurrentOperation).toHaveBeenCalledOnce();
+  });
+
+  it.each<[MobileAuthState['operation'], string]>([
+    ['restoring', 'Restoring your Vela session…'],
+    ['refreshing', 'Refreshing your Vela session…'],
+    ['persisting', 'Securing your Vela session…'],
+    ['verifying', 'Verifying your Vela session…'],
+    ['signingOut', 'Signing out…'],
+    ['cleaningUp', 'Finishing secure sign-out…'],
+  ])('announces blocking %s operation with exact copy', async (operation, copy) => {
+    const operationState: Partial<MobileAuthState> =
+      operation === 'restoring'
+        ? { phase: 'initializing', operation }
+        : operation === 'refreshing'
+          ? { phase: 'authenticated', operation, user }
+          : operation === 'persisting'
+            ? { phase: 'exchangingCode', operation }
+            : operation === 'verifying'
+              ? { phase: 'verifyingSession', operation }
+              : { phase: 'signedOut', operation };
+    const { wrapper } = await mountGate(operationState);
+
+    const status = wrapper.get('[role="status"]');
+    expect(status.attributes('aria-live')).toBe('polite');
+    expect(status.text()).toContain(copy);
+    expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(false);
+  });
+
+  it('does not announce a successful background refresh while content stays usable', async () => {
+    const { wrapper } = await mountGate({
+      phase: 'authenticated',
+      operation: 'refreshing',
+      sessionUsable: true,
+      user,
+    });
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(true);
+    expect(wrapper.find('[aria-live]').exists()).toBe(false);
+  });
+
+  it('offers only cleanup retry with the exact incomplete-cleanup warning', async () => {
+    const { wrapper, coordinator } = await mountGate({
+      phase: 'signedOut',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: 'session_cleanup_failed',
+      retryAction: 'cleanup',
+      notice: 'cleanup_incomplete',
+      user: null,
+    });
+
+    const alert = wrapper.get('[role="alert"]');
+    expect(alert.text()).toContain(
+      'Vela could not finish secure sign-out. Your session may return if you close and reopen the app before cleanup succeeds.',
+    );
+    expect(wrapper.findAll('button').map((button) => button.text())).toEqual(['Retry']);
+    await wrapper.get('button').trigger('click');
+    expect(coordinator.retryCurrentOperation).toHaveBeenCalledOnce();
+    expect(coordinator.signOut).not.toHaveBeenCalled();
+  });
+
+  it('renders the terminal session notice as an alert with a Google action', async () => {
+    const { wrapper } = await mountGate({
+      phase: 'signedOut',
+      notice: 'session_unusable',
+    });
+
+    const alert = wrapper.get('[role="alert"]');
+    expect(alert.text()).toContain(
+      'Your Vela session is no longer usable. Continue with Google to sign in again.',
+    );
+    expect(alert.get('button').text()).toBe('Continue with Google');
+  });
+
+  it('deduplicates blocking retry actions and disables both recovery controls', async () => {
+    const pending = deferred<void>();
+    const retryCurrentOperation = vi.fn(() => pending.promise);
+    const { coordinator } = createFakeCoordinator(
+      {
+        phase: 'error',
+        errorCode: 'session_restore_failed',
+        retryAction: 'restore',
+      },
+      { retryCurrentOperation },
+    );
+    const { wrapper } = await mountGate({}, { coordinator });
+    const [retry, startOver] = wrapper.findAll('button');
+
+    retry?.element.click();
+    retry?.element.click();
+    startOver?.element.click();
+    await nextTick();
+
+    expect(retryCurrentOperation).toHaveBeenCalledOnce();
+    expect(coordinator.signOut).not.toHaveBeenCalled();
+    expect(retry?.attributes('disabled')).toBeDefined();
+    expect(startOver?.attributes('disabled')).toBeDefined();
+    pending.resolve();
+    await flushPromises();
+  });
+
+  it('returns focus when a background refresh becomes a blocking failure', async () => {
+    const host = document.createElement('div');
+    document.body.append(host);
+    const { state, wrapper } = await mountGate(
+      {
+        phase: 'authenticated',
+        operation: 'refreshing',
+        sessionUsable: false,
+        user,
+      },
+      { attachTo: host },
+    );
+
+    Object.assign(state, {
+      operation: 'idle',
+      errorCode: 'session_refresh_failed',
+      retryAction: 'refresh',
+    });
+    await nextTick();
+    await nextTick();
+
+    expect(document.activeElement).toBe(wrapper.get('[data-testid="auth-error-heading"]').element);
+  });
+
+  it('fails closed and emits only the sanitized diagnostic once per invalid-state entry', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { state, wrapper } = await mountGate({
+      phase: 'signedOut',
+      sessionUsable: true,
+    });
+
+    expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(false);
+    expect(wrapper.get('[role="alert"]').text()).not.toContain('signedOut');
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(error).toHaveBeenLastCalledWith('mobile_auth_invalid_state');
+
+    state.errorCode = 'provider_error';
+    await nextTick();
+    expect(error).toHaveBeenCalledTimes(1);
+
+    Object.assign(state, {
+      phase: 'signedOut',
+      sessionUsable: false,
+      errorCode: null,
+    });
+    await nextTick();
+    state.sessionUsable = true;
+    await nextTick();
+
+    expect(error).toHaveBeenCalledTimes(2);
+    expect(error).toHaveBeenLastCalledWith('mobile_auth_invalid_state');
+    error.mockRestore();
   });
 });

--- a/apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts
+++ b/apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts
@@ -11,6 +11,60 @@ import type {
 import { MOBILE_AUTH_KEY } from '../../services/mobile-auth';
 import MobileAuthGate, { shouldBypassMobileAuth } from './MobileAuthGate.vue';
 
+const SECRET_SENTINELS = [
+  'SECRET-access-token',
+  'SECRET-id-token',
+  'SECRET-refresh-token',
+  'SECRET-rotated-refresh-token',
+] as const;
+
+const LOG_AND_DOM_SENTINELS = [
+  ...SECRET_SENTINELS,
+  'SECRET-authorization-url',
+  'SECRET-callback-code',
+  'SECRET-code-verifier',
+  'SECRET-nonce',
+  'SECRET-claim-email',
+] as const;
+
+function searchable(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function storageSnapshot(storage: Storage): string {
+  return Array.from({ length: storage.length }, (_, index) => {
+    const key = storage.key(index) ?? '';
+    return `${key}=${storage.getItem(key) ?? ''}`;
+  }).join('\n');
+}
+
+function expectNoSecretLeak(input: {
+  consoleCalls: unknown[][];
+  preferenceCalls: unknown[][];
+  renderedText?: string;
+}): void {
+  const logsAndDom = [
+    searchable(input.consoleCalls),
+    input.renderedText ?? document.body.textContent ?? '',
+  ].join('\n');
+  const browserAndPreferenceStorage = [
+    searchable(input.preferenceCalls),
+    storageSnapshot(window.localStorage),
+    storageSnapshot(window.sessionStorage),
+  ].join('\n');
+
+  for (const secret of LOG_AND_DOM_SENTINELS) {
+    expect(logsAndDom).not.toContain(secret);
+  }
+  for (const secret of SECRET_SENTINELS) {
+    expect(browserAndPreferenceStorage).not.toContain(secret);
+  }
+}
+
 const ProtectedSlot = defineComponent({
   template: '<div data-testid="protected-slot">Protected content</div>',
 });
@@ -70,6 +124,42 @@ function contrastRatio(first: [number, number, number], second: [number, number,
   const brighter = Math.max(relativeLuminance(first), relativeLuminance(second));
   const darker = Math.min(relativeLuminance(first), relativeLuminance(second));
   return (brighter + 0.05) / (darker + 0.05);
+}
+
+function captureConsoleCalls(): {
+  calls: () => unknown[][];
+  restore: () => void;
+} {
+  const spies = (['debug', 'info', 'log', 'warn', 'error'] as const).map((method) =>
+    vi.spyOn(console, method).mockImplementation(() => undefined),
+  );
+  return {
+    calls: () =>
+      spies.flatMap((spy) =>
+        spy.mock.calls.map((call) =>
+          call.map((value) =>
+            value instanceof Error ? { ...value, name: value.name, message: value.message } : value,
+          ),
+        ),
+      ),
+    restore: () => {
+      for (const spy of spies) spy.mockRestore();
+    },
+  };
+}
+
+function withRawSecretState(state: Partial<MobileAuthState>): Partial<MobileAuthState> {
+  return Object.assign(state, {
+    accessToken: 'SECRET-access-token',
+    idToken: 'SECRET-id-token',
+    refreshToken: 'SECRET-refresh-token',
+    rotatedRefreshToken: 'SECRET-rotated-refresh-token',
+    authorizationUrl: 'SECRET-authorization-url',
+    callbackCode: 'SECRET-callback-code',
+    codeVerifier: 'SECRET-code-verifier',
+    nonce: 'SECRET-nonce',
+    decodedClaimEmail: 'SECRET-claim-email',
+  });
 }
 
 function createFakeCoordinator(
@@ -133,6 +223,29 @@ async function mountGate(
 }
 
 describe('MobileAuthGate', () => {
+  it('fails closed when the mobile auth coordinator is missing', async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes,
+    });
+    await router.push('/review');
+    await router.isReady();
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      expect(() =>
+        mount(MobileAuthGate, {
+          slots: { default: ProtectedSlot },
+          global: { plugins: [router] },
+        }),
+      ).toThrow('Mobile auth coordinator was not provided');
+    } finally {
+      error.mockRestore();
+      warn.mockRestore();
+    }
+  });
+
   it('announces initialization and keeps protected content unmounted', async () => {
     const { wrapper } = await mountGate({ phase: 'initializing' });
 
@@ -225,6 +338,93 @@ describe('MobileAuthGate', () => {
     expect(wrapper.find('button').exists()).toBe(false);
     expect(coordinator.startSignIn).not.toHaveBeenCalled();
     expect(coordinator.retryCurrentOperation).not.toHaveBeenCalled();
+  });
+
+  it.each<[string, Partial<MobileAuthState>]>([
+    [
+      'callback failure',
+      withRawSecretState({
+        phase: 'error',
+        errorCode: 'code_exchange_failed',
+      }),
+    ],
+    [
+      'cold restore',
+      withRawSecretState({
+        phase: 'initializing',
+        operation: 'restoring',
+      }),
+    ],
+    [
+      'soft refresh',
+      withRawSecretState({
+        phase: 'authenticated',
+        sessionUsable: true,
+        errorCode: 'session_refresh_failed',
+        retryAction: 'refresh',
+        user: { userId: 'user-1', email: 'SECRET-claim-email' },
+      }),
+    ],
+    [
+      'rotated-token save failure',
+      withRawSecretState({
+        phase: 'initializing',
+        errorCode: 'session_persistence_failed',
+        retryAction: 'persist',
+      }),
+    ],
+    [
+      'API rejection',
+      withRawSecretState({
+        phase: 'signedOut',
+        notice: 'session_unusable',
+      }),
+    ],
+    [
+      'start over',
+      withRawSecretState({
+        phase: 'initializing',
+        errorCode: 'session_restore_failed',
+        retryAction: 'restore',
+      }),
+    ],
+    [
+      'cleanup failure',
+      withRawSecretState({
+        phase: 'signedOut',
+        errorCode: 'session_cleanup_failed',
+        retryAction: 'cleanup',
+        notice: 'cleanup_incomplete',
+      }),
+    ],
+    [
+      'disposal',
+      withRawSecretState({
+        phase: 'signedOut',
+      }),
+    ],
+  ])('keeps %s sentinels out of rendered gate text and console output', async (_name, state) => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    const consoleCapture = captureConsoleCalls();
+    let wrapper: Awaited<ReturnType<typeof mountGate>>['wrapper'] | undefined;
+
+    try {
+      ({ wrapper } = await mountGate(state));
+      await flushPromises();
+      await nextTick();
+
+      expectNoSecretLeak({
+        consoleCalls: consoleCapture.calls(),
+        preferenceCalls: [],
+        renderedText: wrapper.text(),
+      });
+    } finally {
+      wrapper?.unmount();
+      consoleCapture.restore();
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+    }
   });
 
   it('keeps content closed until the authenticated home replacement settles', async () => {
@@ -456,6 +656,22 @@ describe('MobileAuthGate', () => {
     );
 
     expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(true);
+  });
+
+  it('renders unsupported runtime as a closed non-retryable gate outside diagnostics', async () => {
+    const { wrapper } = await mountGate({
+      phase: 'error',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: 'unsupported_platform',
+      retryAction: null,
+      notice: null,
+      user: null,
+    });
+
+    expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(false);
+    expect(wrapper.get('[role="alert"]').text()).toContain('Vela cannot use this session');
+    expect(wrapper.find('button').exists()).toBe(false);
   });
 
   it('shows non-configuration auth errors instead of marked diagnostics', async () => {

--- a/apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts
+++ b/apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts
@@ -89,7 +89,7 @@ function createFakeCoordinator(
     initialize: vi.fn().mockResolvedValue(undefined),
     startSignIn: vi.fn().mockResolvedValue(undefined),
     completeCallback: vi.fn().mockResolvedValue(undefined),
-    retrySessionVerification: vi.fn().mockResolvedValue(undefined),
+    retryCurrentOperation: vi.fn().mockResolvedValue(undefined),
     dispose: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
@@ -161,10 +161,10 @@ describe('MobileAuthGate', () => {
   });
 
   it('retries only API session verification for session_verification_failed', async () => {
-    const retrySessionVerification = vi.fn().mockResolvedValue(undefined);
+    const retryCurrentOperation = vi.fn().mockResolvedValue(undefined);
     const { coordinator } = createFakeCoordinator(
       { phase: 'error', errorCode: 'session_verification_failed' },
-      { retrySessionVerification },
+      { retryCurrentOperation },
     );
     const { wrapper } = await mountGate({}, { coordinator });
 
@@ -173,7 +173,7 @@ describe('MobileAuthGate', () => {
     expect(wrapper.findAll('button')).toHaveLength(1);
     await wrapper.get('button').trigger('click');
 
-    expect(retrySessionVerification).toHaveBeenCalledOnce();
+    expect(retryCurrentOperation).toHaveBeenCalledOnce();
     expect(coordinator.startSignIn).not.toHaveBeenCalled();
   });
 
@@ -201,7 +201,7 @@ describe('MobileAuthGate', () => {
     await wrapper.get('button').trigger('click');
 
     expect(startSignIn).toHaveBeenCalledOnce();
-    expect(coordinator.retrySessionVerification).not.toHaveBeenCalled();
+    expect(coordinator.retryCurrentOperation).not.toHaveBeenCalled();
   });
 
   it('renders configuration_error without a retry loop', async () => {
@@ -214,7 +214,7 @@ describe('MobileAuthGate', () => {
     expect(wrapper.get('[role="alert"]').text()).toContain('configured');
     expect(wrapper.find('button').exists()).toBe(false);
     expect(coordinator.startSignIn).not.toHaveBeenCalled();
-    expect(coordinator.retrySessionVerification).not.toHaveBeenCalled();
+    expect(coordinator.retryCurrentOperation).not.toHaveBeenCalled();
   });
 
   it('keeps content closed until the authenticated home replacement settles', async () => {

--- a/apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts
+++ b/apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts
@@ -76,7 +76,11 @@ function createFakeCoordinator(
 ): { coordinator: MobileAuthCoordinator; state: MobileAuthState } {
   const state = reactive<MobileAuthState>({
     phase: 'initializing',
+    operation: 'idle',
+    sessionUsable: false,
     errorCode: null,
+    retryAction: null,
+    notice: null,
     user: null,
     ...initial,
   });
@@ -223,6 +227,7 @@ describe('MobileAuthGate', () => {
     });
 
     state.phase = 'authenticated';
+    state.sessionUsable = true;
     state.user = { userId: 'user-1', email: 'vela@example.com' };
     await nextTick();
 
@@ -246,6 +251,7 @@ describe('MobileAuthGate', () => {
     });
 
     state.phase = 'authenticated';
+    state.sessionUsable = true;
     state.user = { userId: 'user-1', email: null };
     await flushPromises();
     await nextTick();
@@ -275,6 +281,7 @@ describe('MobileAuthGate', () => {
     });
 
     state.phase = 'authenticated';
+    state.sessionUsable = true;
     state.user = { userId: 'user-1', email: null };
     await nextTick();
     await router.push('/diagnostics-without-bypass');
@@ -304,6 +311,7 @@ describe('MobileAuthGate', () => {
       .mockImplementation(originalReplace);
 
     state.phase = 'authenticated';
+    state.sessionUsable = true;
     state.user = { userId: 'user-1', email: null };
     await flushPromises();
     await nextTick();
@@ -326,12 +334,26 @@ describe('MobileAuthGate', () => {
     const { state, router, wrapper } = await mountGate({ phase: 'signedOut' }, { path: '/review' });
 
     state.phase = 'authenticated';
+    state.sessionUsable = true;
     state.user = { userId: 'user-1', email: null };
     await flushPromises();
     await nextTick();
 
     expect(router.currentRoute.value.fullPath).toBe('/');
     expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(true);
+  });
+
+  it('keeps protected content unmounted when the authenticated phase is not usable', async () => {
+    const { wrapper } = await mountGate({
+      phase: 'authenticated',
+      sessionUsable: false,
+      user: { userId: 'user-1', email: null },
+    });
+
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(false);
   });
 
   it('suppresses duplicate sign-in actions while the first action is pending', async () => {
@@ -418,7 +440,15 @@ describe('MobileAuthGate', () => {
   });
 
   it('requires the development build flag and explicit metadata for a bypass', async () => {
-    const signedOut: MobileAuthState = { phase: 'signedOut', errorCode: null, user: null };
+    const signedOut: MobileAuthState = {
+      phase: 'signedOut',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: null,
+      retryAction: null,
+      notice: null,
+      user: null,
+    };
     expect(shouldBypassMobileAuth(true, true, signedOut)).toBe(true);
     expect(shouldBypassMobileAuth(false, true, signedOut)).toBe(false);
     expect(shouldBypassMobileAuth(true, false, signedOut)).toBe(false);

--- a/apps/vela-mobile/src/components/mobile/MobileAuthGate.vue
+++ b/apps/vela-mobile/src/components/mobile/MobileAuthGate.vue
@@ -6,11 +6,29 @@ export function shouldBypassMobileAuth(
   hasBypassMetadata: boolean,
   state: Readonly<MobileAuthState>,
 ): boolean {
+  const ordinarySignedOut =
+    state.phase === 'signedOut' &&
+    state.operation === 'idle' &&
+    state.sessionUsable === false &&
+    state.errorCode === null &&
+    state.retryAction === null &&
+    state.notice === null &&
+    state.user === null;
+
+  const bypassableBootError =
+    state.phase === 'error' &&
+    state.operation === 'idle' &&
+    state.sessionUsable === false &&
+    (state.errorCode === 'configuration_error' || state.errorCode === 'unsupported_platform') &&
+    state.retryAction === null &&
+    state.notice === null &&
+    state.user === null;
+
   return (
     isDevelopment &&
     hasBypassMetadata &&
-    (state.phase === 'signedOut' ||
-      (state.phase === 'error' && state.errorCode === 'configuration_error'))
+    state.operation === 'idle' &&
+    (ordinarySignedOut || bypassableBootError)
   );
 }
 </script>
@@ -18,10 +36,15 @@ export function shouldBypassMobileAuth(
 <script setup lang="ts">
 import { computed, inject, nextTick, ref, watch } from 'vue';
 import { isNavigationFailure, NavigationFailureType, useRoute, useRouter } from 'vue-router';
-import type { MobileAuthErrorCode, MobileAuthPhase } from '../../auth/mobile-auth-contract';
+import type {
+  MobileAuthErrorCode,
+  MobileAuthOperation,
+  MobileAuthPhase,
+} from '../../auth/mobile-auth-contract';
 import { MOBILE_AUTH_KEY } from '../../services/mobile-auth';
+import { selectMobileAuthGateView, type AuthenticatedLandingState } from './mobile-auth-gate-view';
 
-type ErrorAction = 'restart' | 'retrySession' | null;
+type ErrorAction = 'restart' | null;
 
 type ErrorPresentation = {
   heading: string;
@@ -94,8 +117,7 @@ const ERROR_PRESENTATIONS: Partial<Record<MobileAuthErrorCode, ErrorPresentation
   session_verification_failed: {
     heading: 'Vela could not verify your session',
     message: 'The sign-in succeeded, but Vela could not confirm the API session.',
-    action: 'retrySession',
-    actionLabel: 'Retry session verification',
+    action: null,
   },
 };
 
@@ -105,7 +127,7 @@ const SESSION_STATE_FALLBACK: ErrorPresentation = {
   action: null,
 };
 
-const PROGRESS_COPY: Partial<Record<MobileAuthPhase, string>> = {
+const OAUTH_PROGRESS_COPY: Partial<Record<MobileAuthPhase, string>> = {
   initializing: 'Preparing secure sign-in…',
   openingBrowser: 'Opening Google sign-in…',
   awaitingCallback: 'Waiting for Google sign-in…',
@@ -113,12 +135,19 @@ const PROGRESS_COPY: Partial<Record<MobileAuthPhase, string>> = {
   verifyingSession: 'Verifying your Vela session…',
 };
 
-const FOCUS_RETURN_PHASES = new Set<MobileAuthPhase>([
-  'openingBrowser',
-  'awaitingCallback',
-  'exchangingCode',
-  'verifyingSession',
-]);
+const OPERATION_COPY: Partial<Record<MobileAuthOperation, string>> = {
+  restoring: 'Restoring your Vela session…',
+  refreshing: 'Refreshing your Vela session…',
+  persisting: 'Securing your Vela session…',
+  verifying: 'Verifying your Vela session…',
+  signingOut: 'Signing out…',
+  cleaningUp: 'Finishing secure sign-out…',
+};
+
+const SESSION_UNUSABLE_COPY =
+  'Your Vela session is no longer usable. Continue with Google to sign in again.';
+const CLEANUP_INCOMPLETE_COPY =
+  'Vela could not finish secure sign-out. Your session may return if you close and reopen the app before cleanup succeeds.';
 
 const LANDING_NAVIGATION_ERROR = {
   heading: 'Vela could not open your home',
@@ -143,9 +172,6 @@ const primaryAction = ref<HTMLButtonElement | null>(null);
 const errorHeading = ref<HTMLHeadingElement | null>(null);
 const landingErrorHeading = ref<HTMLHeadingElement | null>(null);
 let landingAttempt = 0;
-// Single source for the gate surface colors. Applied via `:style` below; the
-// scoped `.mobile-auth-gate` rule intentionally omits `background`/`color` so
-// the literals live in one place and the contrast test reads this surface.
 const gateSurfaceStyle = {
   backgroundColor: '#f7f7fb',
   color: '#1f2030',
@@ -154,21 +180,35 @@ const gateSurfaceStyle = {
 const diagnosticBypass = computed(() =>
   shouldBypassMobileAuth(import.meta.env.DEV, route.meta.bypassMobileAuth === true, state),
 );
-const contentVisible = computed(
-  () => diagnosticBypass.value || (state.sessionUsable && authenticatedLandingReady.value),
-);
+const landingState = computed<AuthenticatedLandingState>(() => {
+  if (landingNavigationFailed.value) {
+    return 'failed';
+  }
+  return authenticatedLandingReady.value ? 'ready' : 'pending';
+});
+const gateView = computed(() => selectMobileAuthGateView(state, landingState.value));
+const contentVisible = computed(() => diagnosticBypass.value || gateView.value.kind === 'content');
 const progressCopy = computed(() => {
-  if (state.phase === 'authenticated' && landingNavigationPending.value) {
+  if (gateView.value.kind !== 'progress') {
+    return null;
+  }
+  if (gateView.value.operation !== 'idle') {
+    return OPERATION_COPY[gateView.value.operation] ?? null;
+  }
+  if (gateView.value.phase === 'authenticated') {
     return 'Opening Vela…';
   }
-  return PROGRESS_COPY[state.phase] ?? null;
+  return OAUTH_PROGRESS_COPY[gateView.value.phase] ?? null;
 });
-const errorPresentation = computed(() =>
-  state.errorCode ? (ERROR_PRESENTATIONS[state.errorCode] ?? SESSION_STATE_FALLBACK) : null,
-);
+const activeErrorPresentation = computed(() => {
+  if (gateView.value.kind !== 'oauth_error' && gateView.value.kind !== 'blocking_session_failure') {
+    return SESSION_STATE_FALLBACK;
+  }
+  return ERROR_PRESENTATIONS[gateView.value.errorCode] ?? SESSION_STATE_FALLBACK;
+});
 
 async function showLandingNavigationFailure(attempt: number): Promise<void> {
-  if (attempt !== landingAttempt || state.phase !== 'authenticated') {
+  if (attempt !== landingAttempt || state.phase !== 'authenticated' || !state.sessionUsable) {
     return;
   }
 
@@ -179,7 +219,7 @@ async function showLandingNavigationFailure(attempt: number): Promise<void> {
 }
 
 async function attemptLandingNavigation(): Promise<void> {
-  if (state.phase !== 'authenticated' || landingNavigationPending.value) {
+  if (state.phase !== 'authenticated' || !state.sessionUsable || landingNavigationPending.value) {
     return;
   }
 
@@ -196,7 +236,7 @@ async function attemptLandingNavigation(): Promise<void> {
     return;
   }
 
-  if (attempt !== landingAttempt || state.phase !== 'authenticated') {
+  if (attempt !== landingAttempt || state.phase !== 'authenticated' || !state.sessionUsable) {
     return;
   }
 
@@ -217,9 +257,9 @@ async function attemptLandingNavigation(): Promise<void> {
 }
 
 watch(
-  () => state.phase,
-  async (phase) => {
-    if (phase !== 'authenticated') {
+  [() => state.phase, () => state.sessionUsable],
+  async ([phase, sessionUsable]) => {
+    if (phase !== 'authenticated' || !sessionUsable) {
       landingAttempt += 1;
       authenticatedLandingReady.value = false;
       landingNavigationFailed.value = false;
@@ -233,30 +273,44 @@ watch(
 );
 
 watch(
-  () => state.phase,
-  async (phase, previousPhase) => {
-    if (
-      !previousPhase ||
-      !FOCUS_RETURN_PHASES.has(previousPhase) ||
-      (phase !== 'signedOut' && phase !== 'error')
-    ) {
+  () => gateView.value.kind,
+  async (kind, previousKind) => {
+    if (previousKind !== 'progress') {
       return;
     }
 
     await nextTick();
-    if (phase === 'signedOut') {
+    if (kind === 'signed_out') {
       primaryAction.value?.focus();
-    } else {
+      return;
+    }
+    if (
+      kind === 'oauth_error' ||
+      kind === 'blocking_session_failure' ||
+      kind === 'cleanup_failure' ||
+      kind === 'unsupported' ||
+      kind === 'invalid_state'
+    ) {
       errorHeading.value?.focus();
     }
   },
   { flush: 'post' },
 );
 
+watch(
+  () => gateView.value.kind,
+  (kind, previousKind) => {
+    if (kind === 'invalid_state' && previousKind !== 'invalid_state') {
+      console.error('mobile_auth_invalid_state');
+    }
+  },
+  { immediate: true },
+);
+
 async function beginSignIn(): Promise<void> {
   const mayStart =
-    state.phase === 'signedOut' ||
-    (state.phase === 'error' && errorPresentation.value?.action === 'restart');
+    gateView.value.kind === 'signed_out' ||
+    (gateView.value.kind === 'oauth_error' && activeErrorPresentation.value.action === 'restart');
   if (!mayStart || actionPending.value) {
     return;
   }
@@ -270,7 +324,10 @@ async function beginSignIn(): Promise<void> {
 }
 
 async function retryCurrentOperation(): Promise<void> {
-  const mayRetry = state.phase === 'error' && errorPresentation.value?.action === 'retrySession';
+  const mayRetry =
+    gateView.value.kind === 'blocking_session_failure' ||
+    gateView.value.kind === 'cleanup_failure' ||
+    (gateView.value.kind === 'content' && gateView.value.retry !== null);
   if (!mayRetry || actionPending.value) {
     return;
   }
@@ -282,19 +339,50 @@ async function retryCurrentOperation(): Promise<void> {
     actionPending.value = false;
   }
 }
+
+async function signOutAndStartOver(): Promise<void> {
+  if (gateView.value.kind !== 'blocking_session_failure' || actionPending.value) {
+    return;
+  }
+
+  actionPending.value = true;
+  try {
+    await coordinator.signOut();
+  } finally {
+    actionPending.value = false;
+  }
+}
 </script>
 
 <template>
-  <slot v-if="contentVisible" />
+  <template v-if="contentVisible">
+    <slot />
+    <section
+      v-if="!diagnosticBypass && gateView.kind === 'content' && gateView.retry"
+      class="mobile-auth-gate__banner"
+      role="alert"
+    >
+      <h1>
+        {{ (ERROR_PRESENTATIONS[gateView.retry.errorCode] ?? SESSION_STATE_FALLBACK).heading }}
+      </h1>
+      <p>{{ (ERROR_PRESENTATIONS[gateView.retry.errorCode] ?? SESSION_STATE_FALLBACK).message }}</p>
+      <button type="button" :disabled="actionPending" @click="retryCurrentOperation">Retry</button>
+    </section>
+  </template>
 
   <main v-else class="mobile-auth-gate" :style="gateSurfaceStyle">
-    <section v-if="progressCopy" class="mobile-auth-gate__panel" role="status" aria-live="polite">
+    <section
+      v-if="gateView.kind === 'progress'"
+      class="mobile-auth-gate__panel"
+      role="status"
+      aria-live="polite"
+    >
       <h1>Vela</h1>
       <p>{{ progressCopy }}</p>
     </section>
 
     <section
-      v-else-if="state.phase === 'authenticated' && landingNavigationFailed"
+      v-else-if="gateView.kind === 'landing_failure'"
       class="mobile-auth-gate__panel"
       role="alert"
     >
@@ -312,41 +400,86 @@ async function retryCurrentOperation(): Promise<void> {
       </button>
     </section>
 
-    <section v-else-if="state.phase === 'signedOut'" class="mobile-auth-gate__panel">
+    <section
+      v-else-if="gateView.kind === 'blocking_session_failure'"
+      class="mobile-auth-gate__panel"
+      role="alert"
+    >
+      <h1 ref="errorHeading" data-testid="auth-error-heading" tabindex="-1">
+        {{ activeErrorPresentation.heading }}
+      </h1>
+      <p>{{ activeErrorPresentation.message }}</p>
+      <button type="button" :disabled="actionPending" @click="retryCurrentOperation">Retry</button>
+      <button type="button" :disabled="actionPending" @click="signOutAndStartOver">
+        Sign out and start over
+      </button>
+    </section>
+
+    <section
+      v-else-if="gateView.kind === 'signed_out'"
+      class="mobile-auth-gate__panel"
+      :role="gateView.notice ? 'alert' : undefined"
+    >
       <h1>Vela</h1>
-      <p>Continue with Google to open your learning space.</p>
+      <p v-if="gateView.notice === 'session_unusable'">{{ SESSION_UNUSABLE_COPY }}</p>
+      <p v-else>Continue with Google to open your learning space.</p>
       <button ref="primaryAction" type="button" :disabled="actionPending" @click="beginSignIn">
         Continue with Google
       </button>
     </section>
 
     <section
-      v-else-if="state.phase === 'error' && errorPresentation"
+      v-else-if="gateView.kind === 'cleanup_failure'"
       class="mobile-auth-gate__panel"
       role="alert"
     >
       <h1 ref="errorHeading" data-testid="auth-error-heading" tabindex="-1">
-        {{ errorPresentation.heading }}
+        Vela could not finish secure sign-out
       </h1>
-      <p>{{ errorPresentation.message }}</p>
+      <p>{{ CLEANUP_INCOMPLETE_COPY }}</p>
+      <button type="button" :disabled="actionPending" @click="retryCurrentOperation">Retry</button>
+    </section>
+
+    <section
+      v-else-if="gateView.kind === 'unsupported'"
+      class="mobile-auth-gate__panel"
+      role="alert"
+    >
+      <h1 ref="errorHeading" data-testid="auth-error-heading" tabindex="-1">
+        {{ SESSION_STATE_FALLBACK.heading }}
+      </h1>
+      <p>{{ SESSION_STATE_FALLBACK.message }}</p>
+    </section>
+
+    <section
+      v-else-if="gateView.kind === 'oauth_error'"
+      class="mobile-auth-gate__panel"
+      role="alert"
+    >
+      <h1 ref="errorHeading" data-testid="auth-error-heading" tabindex="-1">
+        {{ activeErrorPresentation.heading }}
+      </h1>
+      <p>{{ activeErrorPresentation.message }}</p>
       <button
-        v-if="errorPresentation.action === 'restart'"
+        v-if="activeErrorPresentation.action === 'restart'"
         ref="primaryAction"
         type="button"
         :disabled="actionPending"
         @click="beginSignIn"
       >
-        {{ errorPresentation.actionLabel }}
+        {{ activeErrorPresentation.actionLabel }}
       </button>
-      <button
-        v-else-if="errorPresentation.action === 'retrySession'"
-        ref="primaryAction"
-        type="button"
-        :disabled="actionPending"
-        @click="retryCurrentOperation"
-      >
-        {{ errorPresentation.actionLabel }}
-      </button>
+    </section>
+
+    <section
+      v-else-if="gateView.kind === 'invalid_state'"
+      class="mobile-auth-gate__panel"
+      role="alert"
+    >
+      <h1 ref="errorHeading" data-testid="auth-error-heading" tabindex="-1">
+        {{ SESSION_STATE_FALLBACK.heading }}
+      </h1>
+      <p>{{ SESSION_STATE_FALLBACK.message }}</p>
     </section>
   </main>
 </template>
@@ -360,24 +493,34 @@ async function retryCurrentOperation(): Promise<void> {
     max(1.5rem, env(safe-area-inset-bottom)) max(1.5rem, env(safe-area-inset-left));
 }
 
-.mobile-auth-gate__panel {
+.mobile-auth-gate__panel,
+.mobile-auth-gate__banner {
   width: min(100%, 28rem);
   text-align: center;
 }
 
-.mobile-auth-gate__panel h1 {
+.mobile-auth-gate__banner {
+  margin: 1rem auto;
+  padding: 1rem;
+}
+
+.mobile-auth-gate__panel h1,
+.mobile-auth-gate__banner h1 {
   margin: 0 0 0.75rem;
 }
 
-.mobile-auth-gate__panel p {
+.mobile-auth-gate__panel p,
+.mobile-auth-gate__banner p {
   margin: 0 0 1.5rem;
   line-height: 1.5;
 }
 
-.mobile-auth-gate__panel button {
+.mobile-auth-gate__panel button,
+.mobile-auth-gate__banner button {
   min-height: 44px;
   border: 0;
   border-radius: 0.75rem;
+  margin: 0.25rem;
   padding: 0.75rem 1.25rem;
   background: var(--q-primary, #6750a4);
   color: #fff;
@@ -385,7 +528,8 @@ async function retryCurrentOperation(): Promise<void> {
   font-weight: 600;
 }
 
-.mobile-auth-gate__panel button:disabled {
+.mobile-auth-gate__panel button:disabled,
+.mobile-auth-gate__banner button:disabled {
   cursor: wait;
   opacity: 0.65;
 }

--- a/apps/vela-mobile/src/components/mobile/MobileAuthGate.vue
+++ b/apps/vela-mobile/src/components/mobile/MobileAuthGate.vue
@@ -24,12 +24,7 @@ export function shouldBypassMobileAuth(
     state.notice === null &&
     state.user === null;
 
-  return (
-    isDevelopment &&
-    hasBypassMetadata &&
-    state.operation === 'idle' &&
-    (ordinarySignedOut || bypassableBootError)
-  );
+  return isDevelopment && hasBypassMetadata && (ordinarySignedOut || bypassableBootError);
 }
 </script>
 
@@ -42,7 +37,11 @@ import type {
   MobileAuthPhase,
 } from '../../auth/mobile-auth-contract';
 import { MOBILE_AUTH_KEY } from '../../services/mobile-auth';
-import { selectMobileAuthGateView, type AuthenticatedLandingState } from './mobile-auth-gate-view';
+import {
+  selectMobileAuthGateView,
+  type AuthenticatedLandingState,
+  type MobileAuthGateView,
+} from './mobile-auth-gate-view';
 
 type ErrorAction = 'restart' | null;
 
@@ -276,27 +275,37 @@ watch(
   { immediate: true },
 );
 
+const ERROR_HEADING_KINDS = new Set<MobileAuthGateView['kind']>([
+  'oauth_error',
+  'blocking_session_failure',
+  'cleanup_failure',
+  'unsupported',
+  'invalid_state',
+]);
+
 watch(
   () => gateView.value.kind,
   async (kind, previousKind) => {
-    if (previousKind !== 'progress') {
+    // The signed-out primary action only claims focus when a prior progress
+    // surface resolves to signed out; reaching signed out from usable content
+    // is not a focus-handoff point. Error headings, by contrast, also need to
+    // claim focus when usable content is replaced by a blocking failure (for
+    // example a soft refresh banner whose session expires), so the user is
+    // moved to the rendered error panel rather than left focused inside the
+    // now-hidden content slot.
+    const focusPrimaryAction = kind === 'signed_out' && previousKind === 'progress';
+    const focusErrorHeading =
+      ERROR_HEADING_KINDS.has(kind) && (previousKind === 'progress' || previousKind === 'content');
+    if (!focusPrimaryAction && !focusErrorHeading) {
       return;
     }
 
     await nextTick();
-    if (kind === 'signed_out') {
+    if (focusPrimaryAction) {
       primaryAction.value?.focus();
       return;
     }
-    if (
-      kind === 'oauth_error' ||
-      kind === 'blocking_session_failure' ||
-      kind === 'cleanup_failure' ||
-      kind === 'unsupported' ||
-      kind === 'invalid_state'
-    ) {
-      errorHeading.value?.focus();
-    }
+    errorHeading.value?.focus();
   },
   { flush: 'post' },
 );

--- a/apps/vela-mobile/src/components/mobile/MobileAuthGate.vue
+++ b/apps/vela-mobile/src/components/mobile/MobileAuthGate.vue
@@ -148,6 +148,10 @@ const SESSION_UNUSABLE_COPY =
   'Your Vela session is no longer usable. Continue with Google to sign in again.';
 const CLEANUP_INCOMPLETE_COPY =
   'Vela could not finish secure sign-out. Your session may return if you close and reopen the app before cleanup succeeds.';
+const UNSUPPORTED_PLATFORM_COPY = {
+  heading: 'Vela mobile sign-in is unavailable here',
+  message: 'Vela mobile sign-in is supported only on native iOS.',
+} as const;
 
 const LANDING_NAVIGATION_ERROR = {
   heading: 'Vela could not open your home',
@@ -446,9 +450,9 @@ async function signOutAndStartOver(): Promise<void> {
       role="alert"
     >
       <h1 ref="errorHeading" data-testid="auth-error-heading" tabindex="-1">
-        {{ SESSION_STATE_FALLBACK.heading }}
+        {{ UNSUPPORTED_PLATFORM_COPY.heading }}
       </h1>
-      <p>{{ SESSION_STATE_FALLBACK.message }}</p>
+      <p>{{ UNSUPPORTED_PLATFORM_COPY.message }}</p>
     </section>
 
     <section

--- a/apps/vela-mobile/src/components/mobile/MobileAuthGate.vue
+++ b/apps/vela-mobile/src/components/mobile/MobileAuthGate.vue
@@ -269,7 +269,7 @@ async function beginSignIn(): Promise<void> {
   }
 }
 
-async function retrySessionVerification(): Promise<void> {
+async function retryCurrentOperation(): Promise<void> {
   const mayRetry = state.phase === 'error' && errorPresentation.value?.action === 'retrySession';
   if (!mayRetry || actionPending.value) {
     return;
@@ -277,7 +277,7 @@ async function retrySessionVerification(): Promise<void> {
 
   actionPending.value = true;
   try {
-    await coordinator.retrySessionVerification();
+    await coordinator.retryCurrentOperation();
   } finally {
     actionPending.value = false;
   }
@@ -343,7 +343,7 @@ async function retrySessionVerification(): Promise<void> {
         ref="primaryAction"
         type="button"
         :disabled="actionPending"
-        @click="retrySessionVerification"
+        @click="retryCurrentOperation"
       >
         {{ errorPresentation.actionLabel }}
       </button>

--- a/apps/vela-mobile/src/components/mobile/MobileAuthGate.vue
+++ b/apps/vela-mobile/src/components/mobile/MobileAuthGate.vue
@@ -30,7 +30,7 @@ type ErrorPresentation = {
   actionLabel?: string;
 };
 
-const ERROR_PRESENTATIONS: Record<MobileAuthErrorCode, ErrorPresentation> = {
+const ERROR_PRESENTATIONS: Partial<Record<MobileAuthErrorCode, ErrorPresentation>> = {
   configuration_error: {
     heading: 'Vela is not configured for sign-in',
     message:
@@ -99,6 +99,12 @@ const ERROR_PRESENTATIONS: Record<MobileAuthErrorCode, ErrorPresentation> = {
   },
 };
 
+const SESSION_STATE_FALLBACK: ErrorPresentation = {
+  heading: 'Vela cannot use this session',
+  message: 'Vela could not safely continue with the current session.',
+  action: null,
+};
+
 const PROGRESS_COPY: Partial<Record<MobileAuthPhase, string>> = {
   initializing: 'Preparing secure sign-in…',
   openingBrowser: 'Opening Google sign-in…',
@@ -148,7 +154,9 @@ const gateSurfaceStyle = {
 const diagnosticBypass = computed(() =>
   shouldBypassMobileAuth(import.meta.env.DEV, route.meta.bypassMobileAuth === true, state),
 );
-const contentVisible = computed(() => authenticatedLandingReady.value || diagnosticBypass.value);
+const contentVisible = computed(
+  () => diagnosticBypass.value || (state.sessionUsable && authenticatedLandingReady.value),
+);
 const progressCopy = computed(() => {
   if (state.phase === 'authenticated' && landingNavigationPending.value) {
     return 'Opening Vela…';
@@ -156,7 +164,7 @@ const progressCopy = computed(() => {
   return PROGRESS_COPY[state.phase] ?? null;
 });
 const errorPresentation = computed(() =>
-  state.errorCode ? ERROR_PRESENTATIONS[state.errorCode] : null,
+  state.errorCode ? (ERROR_PRESENTATIONS[state.errorCode] ?? SESSION_STATE_FALLBACK) : null,
 );
 
 async function showLandingNavigationFailure(attempt: number): Promise<void> {

--- a/apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.test.ts
+++ b/apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.test.ts
@@ -123,7 +123,7 @@ describe('selectMobileAuthGateView', () => {
     [
       'blocking restore failure',
       state({
-        phase: 'error',
+        phase: 'initializing',
         errorCode: 'session_restore_failed',
         retryAction: 'restore',
       }),
@@ -201,7 +201,7 @@ describe('selectMobileAuthGateView', () => {
     expect(selectMobileAuthGateView(current, landingState)).toEqual(expected);
   });
 
-  it.each<[MobileAuthOperation, MobileAuthState]>([
+  it.each<[string, MobileAuthState]>([
     ['restoring', state({ phase: 'initializing', operation: 'restoring' })],
     [
       'refreshing',
@@ -209,12 +209,15 @@ describe('selectMobileAuthGateView', () => {
     ],
     ['persisting', state({ phase: 'exchangingCode', operation: 'persisting' })],
     ['verifying', state({ phase: 'verifyingSession', operation: 'verifying' })],
-    ['signingOut', state({ operation: 'signingOut' })],
-    ['cleaningUp', state({ operation: 'cleaningUp' })],
-  ])('maps blocking %s operation to progress', (operation, current) => {
+    ['authenticated signingOut', state({ phase: 'authenticated', operation: 'signingOut', user })],
+    ['initializing signingOut', state({ phase: 'initializing', operation: 'signingOut' })],
+    ['initializing cleaningUp', state({ phase: 'initializing', operation: 'cleaningUp' })],
+    ['authenticated cleaningUp', state({ phase: 'authenticated', operation: 'cleaningUp', user })],
+    ['signedOut cleanup retry', state({ phase: 'signedOut', operation: 'cleaningUp' })],
+  ])('maps blocking %s operation to progress', (_label, current) => {
     expect(selectMobileAuthGateView(current, 'ready')).toEqual({
       kind: 'progress',
-      operation,
+      operation: current.operation,
       phase: current.phase,
     });
   });
@@ -280,6 +283,10 @@ describe('selectMobileAuthGateView', () => {
     state({
       operation: 'refreshing',
       errorCode: 'session_refresh_failed',
+    }),
+    state({
+      phase: 'signedOut',
+      operation: 'signingOut',
     }),
     state({
       phase: 'authenticated',

--- a/apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.test.ts
+++ b/apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.test.ts
@@ -132,7 +132,6 @@ describe('selectMobileAuthGateView', () => {
         kind: 'blocking_session_failure',
         errorCode: 'session_restore_failed',
         retryAction: 'restore',
-        allowStartOver: true,
       },
     ],
     [
@@ -147,7 +146,6 @@ describe('selectMobileAuthGateView', () => {
         kind: 'blocking_session_failure',
         errorCode: 'session_persistence_failed',
         retryAction: 'persist',
-        allowStartOver: true,
       },
     ],
     [
@@ -162,7 +160,6 @@ describe('selectMobileAuthGateView', () => {
         kind: 'blocking_session_failure',
         errorCode: 'session_verification_failed',
         retryAction: 'verify',
-        allowStartOver: true,
       },
     ],
     [
@@ -178,7 +175,6 @@ describe('selectMobileAuthGateView', () => {
         kind: 'blocking_session_failure',
         errorCode: 'session_refresh_failed',
         retryAction: 'refresh',
-        allowStartOver: true,
       },
     ],
     [
@@ -193,7 +189,6 @@ describe('selectMobileAuthGateView', () => {
         kind: 'blocking_session_failure',
         errorCode: 'session_refresh_failed',
         retryAction: 'refresh',
-        allowStartOver: true,
       },
     ],
     [
@@ -209,7 +204,6 @@ describe('selectMobileAuthGateView', () => {
         kind: 'blocking_session_failure',
         errorCode: 'session_refresh_failed',
         retryAction: 'refresh',
-        allowStartOver: true,
       },
     ],
     [
@@ -224,7 +218,6 @@ describe('selectMobileAuthGateView', () => {
         kind: 'blocking_session_failure',
         errorCode: 'session_persistence_failed',
         retryAction: 'persist',
-        allowStartOver: true,
       },
     ],
     [
@@ -239,10 +232,9 @@ describe('selectMobileAuthGateView', () => {
         kind: 'blocking_session_failure',
         errorCode: 'session_verification_failed',
         retryAction: 'verify',
-        allowStartOver: true,
       },
     ],
-  ])('maps $label to an explicit gate view', (_label, current, landingState, expected) => {
+  ])('maps %s to an explicit gate view', (_label, current, landingState, expected) => {
     expect(selectMobileAuthGateView(current, landingState)).toEqual(expected);
   });
 
@@ -317,34 +309,49 @@ describe('selectMobileAuthGateView', () => {
     },
   );
 
-  it.each([
-    state({ sessionUsable: true }),
-    state({ phase: 'error' }),
-    state({
-      phase: 'error',
-      errorCode: 'session_restore_failed',
-      retryAction: 'refresh',
-    }),
-    state({
-      phase: 'initializing',
-      errorCode: 'session_refresh_failed',
-      retryAction: 'refresh',
-    }),
-    state({
-      operation: 'refreshing',
-      errorCode: 'session_refresh_failed',
-    }),
-    state({
-      phase: 'signedOut',
-      operation: 'signingOut',
-    }),
-    state({
-      phase: 'authenticated',
-      sessionUsable: true,
-      notice: 'session_unusable',
-      user,
-    }),
-  ])('fails closed for an invariant-breaking tuple', (current) => {
+  it.each<[string, MobileAuthState]>([
+    ['usable session outside authenticated phase', state({ sessionUsable: true })],
+    ['error phase without an error code', state({ phase: 'error' })],
+    [
+      'session_restore_failed paired with a refresh retry action',
+      state({
+        phase: 'error',
+        errorCode: 'session_restore_failed',
+        retryAction: 'refresh',
+      }),
+    ],
+    [
+      'session_refresh_failed retryable from the initializing phase',
+      state({
+        phase: 'initializing',
+        errorCode: 'session_refresh_failed',
+        retryAction: 'refresh',
+      }),
+    ],
+    [
+      'refreshing operation carrying a refresh-failure error code',
+      state({
+        operation: 'refreshing',
+        errorCode: 'session_refresh_failed',
+      }),
+    ],
+    [
+      'signingOut operation on the signedOut phase',
+      state({
+        phase: 'signedOut',
+        operation: 'signingOut',
+      }),
+    ],
+    [
+      'authenticated usable session with a terminal session_unusable notice',
+      state({
+        phase: 'authenticated',
+        sessionUsable: true,
+        notice: 'session_unusable',
+        user,
+      }),
+    ],
+  ])('fails closed for an invariant-breaking tuple (%s)', (_label, current) => {
     expect(selectMobileAuthGateView(current, 'ready')).toEqual({ kind: 'invalid_state' });
   });
 });

--- a/apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.test.ts
+++ b/apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  MobileAuthErrorCode,
+  MobileAuthOperation,
+  MobileAuthState,
+} from '../../auth/mobile-auth-contract';
+import {
+  selectMobileAuthGateView,
+  type AuthenticatedLandingState,
+  type MobileAuthGateView,
+} from './mobile-auth-gate-view';
+
+const user = { userId: 'user-1', email: 'vela@example.com' };
+
+function state(overrides: Partial<MobileAuthState>): MobileAuthState {
+  return {
+    phase: 'signedOut',
+    operation: 'idle',
+    sessionUsable: false,
+    errorCode: null,
+    retryAction: null,
+    notice: null,
+    user: null,
+    ...overrides,
+  };
+}
+
+describe('selectMobileAuthGateView', () => {
+  it.each<
+    [
+      label: string,
+      state: MobileAuthState,
+      landingState: AuthenticatedLandingState,
+      expected: MobileAuthGateView,
+    ]
+  >([
+    ['ordinary signed out', state({}), 'ready', { kind: 'signed_out', notice: null }],
+    [
+      'terminal unusable session notice',
+      state({ notice: 'session_unusable' }),
+      'ready',
+      { kind: 'signed_out', notice: 'session_unusable' },
+    ],
+    [
+      'cleanup failure',
+      state({
+        errorCode: 'session_cleanup_failed',
+        retryAction: 'cleanup',
+        notice: 'cleanup_incomplete',
+      }),
+      'ready',
+      { kind: 'cleanup_failure' },
+    ],
+    [
+      'unsupported platform',
+      state({ phase: 'error', errorCode: 'unsupported_platform' }),
+      'ready',
+      { kind: 'unsupported' },
+    ],
+    [
+      'authenticated landing pending',
+      state({ phase: 'authenticated', sessionUsable: true, user }),
+      'pending',
+      { kind: 'progress', operation: 'idle', phase: 'authenticated' },
+    ],
+    [
+      'authenticated landing failure',
+      state({ phase: 'authenticated', sessionUsable: true, user }),
+      'failed',
+      { kind: 'landing_failure' },
+    ],
+    [
+      'authenticated content',
+      state({ phase: 'authenticated', sessionUsable: true, user }),
+      'ready',
+      { kind: 'content', retry: null },
+    ],
+    [
+      'soft refresh failure banner',
+      state({
+        phase: 'authenticated',
+        sessionUsable: true,
+        errorCode: 'session_refresh_failed',
+        retryAction: 'refresh',
+        user,
+      }),
+      'ready',
+      {
+        kind: 'content',
+        retry: { errorCode: 'session_refresh_failed', action: 'refresh' },
+      },
+    ],
+    [
+      'soft persistence failure banner',
+      state({
+        phase: 'authenticated',
+        sessionUsable: true,
+        errorCode: 'session_persistence_failed',
+        retryAction: 'persist',
+        user,
+      }),
+      'ready',
+      {
+        kind: 'content',
+        retry: { errorCode: 'session_persistence_failed', action: 'persist' },
+      },
+    ],
+    [
+      'soft verification failure banner',
+      state({
+        phase: 'authenticated',
+        sessionUsable: true,
+        errorCode: 'session_verification_failed',
+        retryAction: 'verify',
+        user,
+      }),
+      'ready',
+      {
+        kind: 'content',
+        retry: { errorCode: 'session_verification_failed', action: 'verify' },
+      },
+    ],
+    [
+      'blocking restore failure',
+      state({
+        phase: 'error',
+        errorCode: 'session_restore_failed',
+        retryAction: 'restore',
+      }),
+      'ready',
+      {
+        kind: 'blocking_session_failure',
+        errorCode: 'session_restore_failed',
+        retryAction: 'restore',
+        allowStartOver: true,
+      },
+    ],
+    [
+      'blocking expired refresh failure',
+      state({
+        phase: 'authenticated',
+        errorCode: 'session_refresh_failed',
+        retryAction: 'refresh',
+        user,
+      }),
+      'ready',
+      {
+        kind: 'blocking_session_failure',
+        errorCode: 'session_refresh_failed',
+        retryAction: 'refresh',
+        allowStartOver: true,
+      },
+    ],
+    [
+      'blocking expired refresh failure before landing can complete',
+      state({
+        phase: 'authenticated',
+        errorCode: 'session_refresh_failed',
+        retryAction: 'refresh',
+        user,
+      }),
+      'pending',
+      {
+        kind: 'blocking_session_failure',
+        errorCode: 'session_refresh_failed',
+        retryAction: 'refresh',
+        allowStartOver: true,
+      },
+    ],
+    [
+      'blocking sign-in persistence failure',
+      state({
+        phase: 'error',
+        errorCode: 'session_persistence_failed',
+        retryAction: 'persist',
+      }),
+      'ready',
+      {
+        kind: 'blocking_session_failure',
+        errorCode: 'session_persistence_failed',
+        retryAction: 'persist',
+        allowStartOver: true,
+      },
+    ],
+    [
+      'blocking sign-in verification failure',
+      state({
+        phase: 'error',
+        errorCode: 'session_verification_failed',
+        retryAction: 'verify',
+      }),
+      'ready',
+      {
+        kind: 'blocking_session_failure',
+        errorCode: 'session_verification_failed',
+        retryAction: 'verify',
+        allowStartOver: true,
+      },
+    ],
+  ])('maps $label to an explicit gate view', (_label, current, landingState, expected) => {
+    expect(selectMobileAuthGateView(current, landingState)).toEqual(expected);
+  });
+
+  it.each<[MobileAuthOperation, MobileAuthState]>([
+    ['restoring', state({ phase: 'initializing', operation: 'restoring' })],
+    [
+      'refreshing',
+      state({ phase: 'authenticated', operation: 'refreshing', sessionUsable: false, user }),
+    ],
+    ['persisting', state({ phase: 'exchangingCode', operation: 'persisting' })],
+    ['verifying', state({ phase: 'verifyingSession', operation: 'verifying' })],
+    ['signingOut', state({ operation: 'signingOut' })],
+    ['cleaningUp', state({ operation: 'cleaningUp' })],
+  ])('maps blocking %s operation to progress', (operation, current) => {
+    expect(selectMobileAuthGateView(current, 'ready')).toEqual({
+      kind: 'progress',
+      operation,
+      phase: current.phase,
+    });
+  });
+
+  it.each([
+    'initializing',
+    'openingBrowser',
+    'awaitingCallback',
+    'exchangingCode',
+    'verifyingSession',
+  ] as const)('maps error-free idle %s to OAuth progress', (phase) => {
+    const current = state({ phase });
+    expect(selectMobileAuthGateView(current, 'ready')).toEqual({
+      kind: 'progress',
+      operation: 'idle',
+      phase,
+    });
+  });
+
+  it.each<MobileAuthErrorCode>([
+    'configuration_error',
+    'browser_launch_failed',
+    'cancelled',
+    'interrupted',
+    'transaction_expired',
+    'malformed_callback',
+    'provider_error',
+    'code_exchange_failed',
+    'token_validation_failed',
+    'session_unauthorized',
+  ])('maps HPA-205 error %s without inventing recovery data', (errorCode) => {
+    expect(selectMobileAuthGateView(state({ phase: 'error', errorCode }), 'ready')).toEqual({
+      kind: 'oauth_error',
+      errorCode,
+    });
+  });
+
+  it.each<MobileAuthOperation>(['refreshing', 'persisting', 'verifying'])(
+    'keeps usable content visible during background %s without a live retry banner',
+    (operation) => {
+      expect(
+        selectMobileAuthGateView(
+          state({
+            phase: 'authenticated',
+            operation,
+            sessionUsable: true,
+            user,
+          }),
+          'ready',
+        ),
+      ).toEqual({ kind: 'content', retry: null });
+    },
+  );
+
+  it.each([
+    state({ sessionUsable: true }),
+    state({ phase: 'error' }),
+    state({
+      phase: 'error',
+      errorCode: 'session_restore_failed',
+      retryAction: 'refresh',
+    }),
+    state({
+      operation: 'refreshing',
+      errorCode: 'session_refresh_failed',
+    }),
+    state({
+      phase: 'authenticated',
+      sessionUsable: true,
+      notice: 'session_unusable',
+      user,
+    }),
+  ])('fails closed for an invariant-breaking tuple', (current) => {
+    expect(selectMobileAuthGateView(current, 'ready')).toEqual({ kind: 'invalid_state' });
+  });
+});

--- a/apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.test.ts
+++ b/apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.test.ts
@@ -136,12 +136,57 @@ describe('selectMobileAuthGateView', () => {
       },
     ],
     [
+      'blocking restore persistence failure',
+      state({
+        phase: 'initializing',
+        errorCode: 'session_persistence_failed',
+        retryAction: 'persist',
+      }),
+      'ready',
+      {
+        kind: 'blocking_session_failure',
+        errorCode: 'session_persistence_failed',
+        retryAction: 'persist',
+        allowStartOver: true,
+      },
+    ],
+    [
+      'blocking restore verification failure',
+      state({
+        phase: 'initializing',
+        errorCode: 'session_verification_failed',
+        retryAction: 'verify',
+      }),
+      'ready',
+      {
+        kind: 'blocking_session_failure',
+        errorCode: 'session_verification_failed',
+        retryAction: 'verify',
+        allowStartOver: true,
+      },
+    ],
+    [
       'blocking expired refresh failure',
       state({
         phase: 'authenticated',
         errorCode: 'session_refresh_failed',
         retryAction: 'refresh',
         user,
+      }),
+      'ready',
+      {
+        kind: 'blocking_session_failure',
+        errorCode: 'session_refresh_failed',
+        retryAction: 'refresh',
+        allowStartOver: true,
+      },
+    ],
+    [
+      'blocking refresh failure without an active session',
+      state({
+        phase: 'error',
+        errorCode: 'session_refresh_failed',
+        retryAction: 'refresh',
       }),
       'ready',
       {
@@ -278,6 +323,11 @@ describe('selectMobileAuthGateView', () => {
     state({
       phase: 'error',
       errorCode: 'session_restore_failed',
+      retryAction: 'refresh',
+    }),
+    state({
+      phase: 'initializing',
+      errorCode: 'session_refresh_failed',
       retryAction: 'refresh',
     }),
     state({

--- a/apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.ts
+++ b/apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.ts
@@ -79,20 +79,26 @@ function hasValidOperationTuple(state: Readonly<MobileAuthState>): boolean {
     case 'persisting':
       return (
         (state.phase === 'authenticated' && state.user !== null) ||
+        (state.phase === 'initializing' && !state.sessionUsable && state.user === null) ||
         (state.phase === 'exchangingCode' && !state.sessionUsable && state.user === null)
       );
     case 'verifying':
       return (
         (state.phase === 'authenticated' && state.user !== null) ||
+        (state.phase === 'initializing' && !state.sessionUsable && state.user === null) ||
         (state.phase === 'verifyingSession' && !state.sessionUsable && state.user === null)
       );
     case 'signingOut':
-      return state.phase === 'signedOut' && !state.sessionUsable && state.user === null;
+      return (
+        !state.sessionUsable &&
+        ((state.phase === 'initializing' && state.user === null) ||
+          (state.phase === 'authenticated' && state.user !== null))
+      );
     case 'cleaningUp':
       return (
-        (state.phase === 'signedOut' || state.phase === 'initializing') &&
         !state.sessionUsable &&
-        state.user === null
+        ((state.phase === 'authenticated' && state.user !== null) ||
+          ((state.phase === 'signedOut' || state.phase === 'initializing') && state.user === null))
       );
   }
 }
@@ -152,9 +158,10 @@ function hasValidIdleTuple(state: Readonly<MobileAuthState>): boolean {
       return false;
     }
     if (state.errorCode === 'session_restore_failed') {
-      return state.phase === 'error' && !state.sessionUsable && state.user === null;
+      return state.phase === 'initializing' && !state.sessionUsable && state.user === null;
     }
     return (
+      (state.phase === 'initializing' && !state.sessionUsable && state.user === null) ||
       (state.phase === 'error' && !state.sessionUsable && state.user === null) ||
       (state.phase === 'authenticated' && state.user !== null)
     );

--- a/apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.ts
+++ b/apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.ts
@@ -22,7 +22,6 @@ export type MobileAuthGateView =
       kind: 'blocking_session_failure';
       errorCode: MobileAuthErrorCode;
       retryAction: Exclude<MobileAuthRetryAction, 'cleanup'>;
-      allowStartOver: true;
     }
   | { kind: 'signed_out'; notice: 'session_unusable' | null }
   | { kind: 'cleanup_failure' }
@@ -240,7 +239,6 @@ export function selectMobileAuthGateView(
       kind: 'blocking_session_failure',
       errorCode: state.errorCode,
       retryAction: state.retryAction,
-      allowStartOver: true,
     };
   }
 

--- a/apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.ts
+++ b/apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.ts
@@ -160,6 +160,12 @@ function hasValidIdleTuple(state: Readonly<MobileAuthState>): boolean {
     if (state.errorCode === 'session_restore_failed') {
       return state.phase === 'initializing' && !state.sessionUsable && state.user === null;
     }
+    if (state.errorCode === 'session_refresh_failed') {
+      return (
+        (state.phase === 'error' && !state.sessionUsable && state.user === null) ||
+        (state.phase === 'authenticated' && state.user !== null)
+      );
+    }
     return (
       (state.phase === 'initializing' && !state.sessionUsable && state.user === null) ||
       (state.phase === 'error' && !state.sessionUsable && state.user === null) ||

--- a/apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.ts
+++ b/apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.ts
@@ -1,0 +1,246 @@
+import type {
+  MobileAuthErrorCode,
+  MobileAuthOperation,
+  MobileAuthPhase,
+  MobileAuthRetryAction,
+  MobileAuthState,
+} from '../../auth/mobile-auth-contract';
+
+export type AuthenticatedLandingState = 'pending' | 'ready' | 'failed';
+
+export type MobileAuthGateView =
+  | {
+      kind: 'content';
+      retry: {
+        errorCode: MobileAuthErrorCode;
+        action: Exclude<MobileAuthRetryAction, 'cleanup'>;
+      } | null;
+    }
+  | { kind: 'progress'; operation: MobileAuthOperation; phase: MobileAuthPhase }
+  | { kind: 'landing_failure' }
+  | {
+      kind: 'blocking_session_failure';
+      errorCode: MobileAuthErrorCode;
+      retryAction: Exclude<MobileAuthRetryAction, 'cleanup'>;
+      allowStartOver: true;
+    }
+  | { kind: 'signed_out'; notice: 'session_unusable' | null }
+  | { kind: 'cleanup_failure' }
+  | { kind: 'unsupported' }
+  | { kind: 'oauth_error'; errorCode: MobileAuthErrorCode }
+  | { kind: 'invalid_state' };
+
+const OAUTH_PROGRESS_PHASES = new Set<MobileAuthPhase>([
+  'initializing',
+  'openingBrowser',
+  'awaitingCallback',
+  'exchangingCode',
+  'verifyingSession',
+]);
+
+const OAUTH_ERROR_CODES = new Set<MobileAuthErrorCode>([
+  'configuration_error',
+  'browser_launch_failed',
+  'cancelled',
+  'interrupted',
+  'transaction_expired',
+  'malformed_callback',
+  'provider_error',
+  'code_exchange_failed',
+  'token_validation_failed',
+  'session_unauthorized',
+  'unsupported_platform',
+]);
+
+const SESSION_RETRY_BY_ERROR: Partial<
+  Record<MobileAuthErrorCode, Exclude<MobileAuthRetryAction, 'cleanup'>>
+> = {
+  session_restore_failed: 'restore',
+  session_refresh_failed: 'refresh',
+  session_persistence_failed: 'persist',
+  session_verification_failed: 'verify',
+};
+
+function hasValidOperationTuple(state: Readonly<MobileAuthState>): boolean {
+  if (
+    state.errorCode !== null ||
+    state.retryAction !== null ||
+    state.notice !== null ||
+    state.operation === 'idle'
+  ) {
+    return false;
+  }
+
+  switch (state.operation) {
+    case 'restoring':
+      return state.phase === 'initializing' && !state.sessionUsable && state.user === null;
+    case 'refreshing':
+      return state.phase === 'authenticated' && state.user !== null;
+    case 'persisting':
+      return (
+        (state.phase === 'authenticated' && state.user !== null) ||
+        (state.phase === 'exchangingCode' && !state.sessionUsable && state.user === null)
+      );
+    case 'verifying':
+      return (
+        (state.phase === 'authenticated' && state.user !== null) ||
+        (state.phase === 'verifyingSession' && !state.sessionUsable && state.user === null)
+      );
+    case 'signingOut':
+      return state.phase === 'signedOut' && !state.sessionUsable && state.user === null;
+    case 'cleaningUp':
+      return (
+        (state.phase === 'signedOut' || state.phase === 'initializing') &&
+        !state.sessionUsable &&
+        state.user === null
+      );
+  }
+}
+
+function hasValidIdleTuple(state: Readonly<MobileAuthState>): boolean {
+  if (state.operation !== 'idle') {
+    return false;
+  }
+
+  if (state.notice === 'session_unusable') {
+    return (
+      state.phase === 'signedOut' &&
+      !state.sessionUsable &&
+      state.errorCode === null &&
+      state.retryAction === null &&
+      state.user === null
+    );
+  }
+
+  if (state.notice === 'cleanup_incomplete') {
+    return (
+      state.phase === 'signedOut' &&
+      !state.sessionUsable &&
+      state.errorCode === 'session_cleanup_failed' &&
+      state.retryAction === 'cleanup' &&
+      state.user === null
+    );
+  }
+
+  if (state.sessionUsable && (state.phase !== 'authenticated' || state.user === null)) {
+    return false;
+  }
+  if (state.phase === 'authenticated' && state.user === null) {
+    return false;
+  }
+  if (state.phase !== 'authenticated' && state.user !== null) {
+    return false;
+  }
+
+  if (state.errorCode === null) {
+    if (state.retryAction !== null || state.phase === 'error') {
+      return false;
+    }
+    if (state.phase === 'authenticated') {
+      return state.sessionUsable;
+    }
+    return !state.sessionUsable;
+  }
+
+  if (state.errorCode === 'session_cleanup_failed') {
+    return false;
+  }
+
+  const sessionRetry = SESSION_RETRY_BY_ERROR[state.errorCode];
+  if (sessionRetry !== undefined) {
+    if (state.retryAction !== sessionRetry) {
+      return false;
+    }
+    if (state.errorCode === 'session_restore_failed') {
+      return state.phase === 'error' && !state.sessionUsable && state.user === null;
+    }
+    return (
+      (state.phase === 'error' && !state.sessionUsable && state.user === null) ||
+      (state.phase === 'authenticated' && state.user !== null)
+    );
+  }
+
+  return (
+    OAUTH_ERROR_CODES.has(state.errorCode) &&
+    state.phase === 'error' &&
+    !state.sessionUsable &&
+    state.retryAction === null &&
+    state.user === null
+  );
+}
+
+function hasValidStateTuple(state: Readonly<MobileAuthState>): boolean {
+  return state.operation === 'idle' ? hasValidIdleTuple(state) : hasValidOperationTuple(state);
+}
+
+export function selectMobileAuthGateView(
+  state: Readonly<MobileAuthState>,
+  landingState: AuthenticatedLandingState,
+): MobileAuthGateView {
+  if (!hasValidStateTuple(state)) {
+    return { kind: 'invalid_state' };
+  }
+
+  if (state.errorCode === 'unsupported_platform') {
+    return { kind: 'unsupported' };
+  }
+  if (state.errorCode === 'session_cleanup_failed') {
+    return { kind: 'cleanup_failure' };
+  }
+
+  if (
+    !state.sessionUsable &&
+    (state.operation !== 'idle' ||
+      (state.errorCode === null && OAUTH_PROGRESS_PHASES.has(state.phase)))
+  ) {
+    return { kind: 'progress', operation: state.operation, phase: state.phase };
+  }
+
+  if (state.sessionUsable && landingState === 'ready') {
+    const retryAction =
+      state.retryAction === null || state.retryAction === 'cleanup' ? null : state.retryAction;
+    return {
+      kind: 'content',
+      retry:
+        state.errorCode !== null && retryAction !== null
+          ? { errorCode: state.errorCode, action: retryAction }
+          : null,
+    };
+  }
+
+  if (state.phase === 'authenticated' && state.sessionUsable) {
+    if (landingState === 'pending') {
+      return { kind: 'progress', operation: state.operation, phase: state.phase };
+    }
+    if (landingState === 'failed') {
+      return { kind: 'landing_failure' };
+    }
+  }
+
+  if (
+    !state.sessionUsable &&
+    state.errorCode !== null &&
+    state.retryAction !== null &&
+    state.retryAction !== 'cleanup'
+  ) {
+    return {
+      kind: 'blocking_session_failure',
+      errorCode: state.errorCode,
+      retryAction: state.retryAction,
+      allowStartOver: true,
+    };
+  }
+
+  if (state.phase === 'signedOut') {
+    return {
+      kind: 'signed_out',
+      notice: state.notice === 'session_unusable' ? state.notice : null,
+    };
+  }
+
+  if (state.phase === 'error' && state.errorCode !== null) {
+    return { kind: 'oauth_error', errorCode: state.errorCode };
+  }
+
+  return { kind: 'invalid_state' };
+}

--- a/apps/vela-mobile/src/pages/MorePage.test.ts
+++ b/apps/vela-mobile/src/pages/MorePage.test.ts
@@ -1,0 +1,105 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { Quasar, QLayout, QPageContainer } from 'quasar';
+import { defineComponent } from 'vue';
+import { describe, expect, it, vi } from 'vitest';
+import type { MobileAuthCoordinator, MobileAuthState } from '../auth/mobile-auth-contract';
+import { MOBILE_AUTH_KEY } from '../services/mobile-auth';
+import MorePage from './MorePage.vue';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve'];
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+const authenticatedState: MobileAuthState = {
+  phase: 'authenticated',
+  operation: 'idle',
+  sessionUsable: true,
+  errorCode: null,
+  retryAction: null,
+  notice: null,
+  user: { userId: 'user-1', email: 'vela@example.com' },
+};
+
+function createCoordinatorStub(
+  overrides: Partial<MobileAuthCoordinator> = {},
+): MobileAuthCoordinator {
+  return {
+    state: authenticatedState,
+    initialize: vi.fn().mockResolvedValue(undefined),
+    startSignIn: vi.fn().mockResolvedValue(undefined),
+    completeCallback: vi.fn().mockResolvedValue(undefined),
+    retryCurrentOperation: vi.fn().mockResolvedValue(undefined),
+    signOut: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function mountMorePage(coordinator: MobileAuthCoordinator) {
+  const Host = defineComponent({
+    components: { QLayout, QPageContainer, MorePage },
+    template:
+      '<q-layout view="hHh Lpr fFf"><q-page-container><more-page /></q-page-container></q-layout>',
+  });
+  return mount(Host, {
+    global: {
+      plugins: [Quasar],
+      provide: {
+        [MOBILE_AUTH_KEY as symbol]: coordinator,
+      },
+      stubs: {
+        DevelopmentDiagnosticsEntry: true,
+      },
+    },
+  });
+}
+
+describe('MorePage sign out', () => {
+  it('calls the mobile coordinator once and exposes progress', async () => {
+    const signOut = deferred<void>();
+    const coordinator = createCoordinatorStub({
+      signOut: vi.fn(() => signOut.promise),
+    });
+    const wrapper = mountMorePage(coordinator);
+
+    const button = wrapper.get('[aria-label="Sign out of Vela"]');
+    void button.trigger('click');
+    void button.trigger('click');
+    await flushPromises();
+
+    expect(button.attributes('disabled')).toBeDefined();
+    expect(button.attributes('aria-disabled')).toBe('true');
+    expect(coordinator.signOut).toHaveBeenCalledOnce();
+
+    signOut.resolve();
+    await flushPromises();
+    expect(button.attributes('disabled')).toBeUndefined();
+  });
+
+  it('requires the mobile auth coordinator', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      expect(() =>
+        mount(MorePage, {
+          global: {
+            plugins: [Quasar],
+            stubs: { DevelopmentDiagnosticsEntry: true },
+          },
+        }),
+      ).toThrowError('Mobile auth coordinator was not provided');
+    } finally {
+      warn.mockRestore();
+      error.mockRestore();
+    }
+  });
+});

--- a/apps/vela-mobile/src/pages/MorePage.vue
+++ b/apps/vela-mobile/src/pages/MorePage.vue
@@ -4,13 +4,40 @@
       <q-icon name="more_horiz" size="48px" color="primary" />
       <h2 class="text-h5 text-weight-medium q-mt-md">More</h2>
       <p class="text-body2 text-grey-6">Coming soon</p>
+      <q-btn
+        aria-label="Sign out of Vela"
+        color="negative"
+        outline
+        :loading="signOutPending"
+        :disable="signOutPending"
+        label="Sign out"
+        @click="handleSignOut"
+      />
       <development-diagnostics-entry v-if="DevelopmentDiagnosticsEntry" />
     </div>
   </q-page>
 </template>
 
 <script setup lang="ts">
-import { defineAsyncComponent } from 'vue';
+import { defineAsyncComponent, inject, ref } from 'vue';
+import { MOBILE_AUTH_KEY } from '../services/mobile-auth';
+
+const providedCoordinator = inject(MOBILE_AUTH_KEY);
+if (!providedCoordinator) {
+  throw new Error('Mobile auth coordinator was not provided');
+}
+const coordinator = providedCoordinator;
+const signOutPending = ref(false);
+
+async function handleSignOut(): Promise<void> {
+  if (signOutPending.value) return;
+  signOutPending.value = true;
+  try {
+    await coordinator.signOut();
+  } finally {
+    signOutPending.value = false;
+  }
+}
 
 const DevelopmentDiagnosticsEntry = import.meta.env.DEV
   ? defineAsyncComponent(() => import('src/components/mobile/IosInteractionDiagnosticsEntry.vue'))

--- a/apps/vela-mobile/src/pages/StubPages.test.ts
+++ b/apps/vela-mobile/src/pages/StubPages.test.ts
@@ -7,6 +7,26 @@ import LearnPage from './LearnPage.vue';
 import ReviewPage from './ReviewPage.vue';
 import WordsPage from './WordsPage.vue';
 import MorePage from './MorePage.vue';
+import type { MobileAuthCoordinator } from '../auth/mobile-auth-contract';
+import { MOBILE_AUTH_KEY } from '../services/mobile-auth';
+
+const coordinator: MobileAuthCoordinator = {
+  state: {
+    phase: 'authenticated',
+    operation: 'idle',
+    sessionUsable: true,
+    errorCode: null,
+    retryAction: null,
+    notice: null,
+    user: { userId: 'user-1', email: null },
+  },
+  initialize: vi.fn().mockResolvedValue(undefined),
+  startSignIn: vi.fn().mockResolvedValue(undefined),
+  completeCallback: vi.fn().mockResolvedValue(undefined),
+  retryCurrentOperation: vi.fn().mockResolvedValue(undefined),
+  signOut: vi.fn().mockResolvedValue(undefined),
+  dispose: vi.fn().mockResolvedValue(undefined),
+};
 
 // q-page must be a deep child of q-layout; wrap so Quasar renders under jsdom.
 const mountPage = (Page: Component) => {
@@ -19,7 +39,14 @@ const mountPage = (Page: Component) => {
     template:
       '<q-layout view="hHh Lpr fFf"><q-page-container><page/></q-page-container></q-layout>',
   });
-  return mount(Host, { global: { plugins: [Quasar, router] } });
+  return mount(Host, {
+    global: {
+      plugins: [Quasar, router],
+      provide: {
+        [MOBILE_AUTH_KEY as symbol]: coordinator,
+      },
+    },
+  });
 };
 
 describe.each([

--- a/apps/vela-mobile/src/services/mobile-auth-disposal.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth-disposal.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { MOBILE_OAUTH_CALLBACK_URI } from '../auth/mobile-auth-contract';
+import {
+  createMobileAuthCoordinator,
+  type MobileAuthCoordinatorDependencies,
+} from './mobile-auth';
+
+function createDependencies(): MobileAuthCoordinatorDependencies {
+  return {
+    app: {} as MobileAuthCoordinatorDependencies['app'],
+    browser: {} as MobileAuthCoordinatorDependencies['browser'],
+    transactionStore: {} as MobileAuthCoordinatorDependencies['transactionStore'],
+    tokenTransport: {} as MobileAuthCoordinatorDependencies['tokenTransport'],
+    sessionStore: {} as MobileAuthCoordinatorDependencies['sessionStore'],
+    installationStore: {} as MobileAuthCoordinatorDependencies['installationStore'],
+    isNativeIos: true,
+    crypto: undefined,
+    isSecureContext: true,
+    fetch: vi.fn() as unknown as typeof fetch,
+    now: () => 0,
+    config: {
+      apiUrl: 'https://vela.example/api/',
+      userPoolId: 'us-east-1_example',
+      mobileClientId: 'mobile-client-id',
+      oauthDomain: 'vela.auth.us-east-1.amazoncognito.com',
+      region: 'us-east-1',
+      callbackUri: MOBILE_OAUTH_CALLBACK_URI,
+    },
+  };
+}
+
+describe('mobile auth disposal', () => {
+  it('coalesces concurrent disposal callers onto the serialized operation tail', async () => {
+    const coordinator = createMobileAuthCoordinator(createDependencies());
+
+    const firstDisposal = coordinator.dispose();
+    const concurrentDisposal = coordinator.dispose();
+
+    await expect(Promise.all([firstDisposal, concurrentDisposal])).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
+    expect(coordinator.state).toEqual({
+      phase: 'signedOut',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: null,
+      retryAction: null,
+      notice: null,
+      user: null,
+    });
+  });
+});

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { toRaw, watch } from 'vue';
 import {
   MOBILE_OAUTH_CALLBACK_URI,
@@ -22,6 +22,60 @@ import { MobileSessionStoreError, type MobileSessionStore } from '../auth/mobile
 import { createMobileAuthCoordinator, MOBILE_AUTH_NETWORK_TIMEOUT_MS } from './mobile-auth';
 
 const NOW = 1_000_000;
+
+const SECRET_SENTINELS = [
+  'SECRET-access-token',
+  'SECRET-id-token',
+  'SECRET-refresh-token',
+  'SECRET-rotated-refresh-token',
+] as const;
+
+const LOG_AND_DOM_SENTINELS = [
+  ...SECRET_SENTINELS,
+  'SECRET-authorization-url',
+  'SECRET-callback-code',
+  'SECRET-code-verifier',
+  'SECRET-nonce',
+  'SECRET-claim-email',
+] as const;
+
+function searchable(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function storageSnapshot(storage: Storage): string {
+  return Array.from({ length: storage.length }, (_, index) => {
+    const key = storage.key(index) ?? '';
+    return `${key}=${storage.getItem(key) ?? ''}`;
+  }).join('\n');
+}
+
+function expectNoSecretLeak(input: {
+  consoleCalls: unknown[][];
+  preferenceCalls: unknown[][];
+  renderedText?: string;
+}): void {
+  const logsAndDom = [
+    searchable(input.consoleCalls),
+    input.renderedText ?? document.body.textContent ?? '',
+  ].join('\n');
+  const browserAndPreferenceStorage = [
+    searchable(input.preferenceCalls),
+    storageSnapshot(window.localStorage),
+    storageSnapshot(window.sessionStorage),
+  ].join('\n');
+
+  for (const secret of LOG_AND_DOM_SENTINELS) {
+    expect(logsAndDom).not.toContain(secret);
+  }
+  for (const secret of SECRET_SENTINELS) {
+    expect(browserAndPreferenceStorage).not.toContain(secret);
+  }
+}
 
 const config: MobileOAuthConfig = {
   apiUrl: 'https://vela.example/api/',
@@ -63,7 +117,11 @@ function base64UrlJson(value: unknown): string {
   return btoa(JSON.stringify(value)).replace(/\+/gu, '-').replace(/\//gu, '_').replace(/=+$/u, '');
 }
 
-function idToken(transaction: OAuthTransaction, overrides: Record<string, unknown> = {}): string {
+function idToken(
+  transaction: OAuthTransaction,
+  overrides: Record<string, unknown> = {},
+  signature = 'unsigned',
+): string {
   const claims = {
     token_use: 'id',
     aud: config.mobileClientId,
@@ -73,10 +131,10 @@ function idToken(transaction: OAuthTransaction, overrides: Record<string, unknow
     exp: 2_000,
     ...overrides,
   };
-  return `${base64UrlJson({ alg: 'none' })}.${base64UrlJson(claims)}.unsigned`;
+  return `${base64UrlJson({ alg: 'none' })}.${base64UrlJson(claims)}.${signature}`;
 }
 
-function refreshedIdToken(overrides: Record<string, unknown> = {}): string {
+function refreshedIdToken(overrides: Record<string, unknown> = {}, signature = 'unsigned'): string {
   return `${base64UrlJson({ alg: 'none' })}.${base64UrlJson({
     token_use: 'id',
     aud: config.mobileClientId,
@@ -84,7 +142,7 @@ function refreshedIdToken(overrides: Record<string, unknown> = {}): string {
     sub: 'user-123',
     exp: 2_000,
     ...overrides,
-  })}.unsigned`;
+  })}.${signature}`;
 }
 
 function callback(transaction: OAuthTransaction, code = 'authorization-code'): string {
@@ -102,6 +160,8 @@ function response(status: number, value: unknown, jsonError?: unknown): Response
 class FakePreferences implements OAuthTransactionPreferences {
   value: string | null = null;
   readonly calls: string[] = [];
+  readonly setCalls: unknown[][] = [];
+  getGate: Promise<void> | undefined;
   setGate: Promise<void> | undefined;
   removeGate: Promise<void> | undefined;
   getFailure: unknown;
@@ -114,6 +174,7 @@ class FakePreferences implements OAuthTransactionPreferences {
     expect(key).toBe(MOBILE_OAUTH_TRANSACTION_KEY);
     this.calls.push('preferences:get');
     this.order?.push('preferences:get');
+    await this.getGate;
     if (this.getFailure) {
       throw this.getFailure;
     }
@@ -122,6 +183,7 @@ class FakePreferences implements OAuthTransactionPreferences {
 
   async set({ key, value }: { key: string; value: string }): Promise<void> {
     expect(key).toBe(MOBILE_OAUTH_TRANSACTION_KEY);
+    this.setCalls.push([{ key, value }]);
     this.calls.push('preferences:set:start');
     this.order?.push('preferences:set:start');
     if (this.setFailure) {
@@ -156,6 +218,7 @@ class FakeSessionStore implements MobileSessionStore {
   refreshToken: string | null = null;
   readonly saveAttempts: string[] = [];
   clearCalls = 0;
+  loadGate: Promise<void> | undefined;
   saveGate: Promise<void> | undefined;
   clearGate: Promise<void> | undefined;
   loadFailure: unknown;
@@ -166,6 +229,7 @@ class FakeSessionStore implements MobileSessionStore {
 
   async loadRefreshToken(): Promise<string | null> {
     this.order.push('session:load');
+    await this.loadGate;
     if (this.loadFailure) throw this.loadFailure;
     return this.refreshToken;
   }
@@ -191,6 +255,8 @@ class FakeInstallationStore implements MobileInstallationStore {
   marked = true;
   readFailure: unknown;
   markFailure: unknown;
+  readGate: Promise<void> | undefined;
+  markGate: Promise<void> | undefined;
   readCalls = 0;
   markCalls = 0;
 
@@ -199,6 +265,7 @@ class FakeInstallationStore implements MobileInstallationStore {
   async isCurrentInstallationMarked(): Promise<boolean> {
     this.order.push('installation:isMarked');
     this.readCalls += 1;
+    await this.readGate;
     if (this.readFailure) throw this.readFailure;
     return this.marked;
   }
@@ -206,6 +273,7 @@ class FakeInstallationStore implements MobileInstallationStore {
   async markCurrentInstallation(): Promise<void> {
     this.order.push('installation:mark');
     this.markCalls += 1;
+    await this.markGate;
     if (this.markFailure) throw this.markFailure;
     this.marked = true;
   }
@@ -216,6 +284,7 @@ class FakeApp implements MobileAppAdapter {
   launchUrl: { url: string } | undefined;
   urlListener: ((event: { url: string }) => void) | undefined;
   stateListener: ((event: { isActive: boolean }) => void) | undefined;
+  addGate: Promise<void> | undefined;
   failAdd = false;
   failLaunch = false;
   removeCalls = 0;
@@ -230,6 +299,7 @@ class FakeApp implements MobileAppAdapter {
     listener: ((event: { url: string }) => void) | ((event: { isActive: boolean }) => void),
   ): Promise<{ remove(): Promise<void> }> {
     this.order.push(`app:add:${eventName}`);
+    await this.addGate;
     if (this.failAdd) {
       throw new Error('SECRET-app-plugin-failure');
     }
@@ -282,6 +352,7 @@ class FakeBrowser implements MobileBrowserAdapter {
   failRemove = false;
   finishOnClose = false;
   openGate: Promise<void> | undefined;
+  closeGate: Promise<void> | undefined;
   onClose: (() => void) | undefined;
 
   constructor(order: string[]) {
@@ -320,6 +391,7 @@ class FakeBrowser implements MobileBrowserAdapter {
   async close(): Promise<void> {
     this.closeCalls += 1;
     this.onClose?.();
+    await this.closeGate;
     if (this.failClose) {
       throw new Error('SECRET-browser-close-failure');
     }
@@ -569,6 +641,69 @@ const activeTransaction: OAuthTransaction = {
   nonce: 'SECRET-nonce',
   createdAt: NOW - 1,
 };
+
+const securityTransaction: OAuthTransaction = {
+  state: 'SECRET-authorization-url',
+  codeVerifier: 'SECRET-code-verifier',
+  nonce: 'SECRET-nonce',
+  createdAt: NOW - 1,
+};
+
+function captureConsoleCalls(): {
+  calls: () => unknown[][];
+} {
+  const spies = (['debug', 'info', 'log', 'warn', 'error'] as const).map((method) =>
+    vi.spyOn(console, method).mockImplementation(() => undefined),
+  );
+  return {
+    calls: () =>
+      spies.flatMap((spy) =>
+        spy.mock.calls.map((call) =>
+          call.map((value) =>
+            value instanceof Error ? { ...value, name: value.name, message: value.message } : value,
+          ),
+        ),
+      ),
+  };
+}
+
+function prepareSentinelExchange(harness: ReturnType<typeof makeHarness>): void {
+  harness.tokenTransport.result = {
+    status: 200,
+    data: {
+      access_token: 'SECRET-access-token',
+      id_token: idToken(securityTransaction, { email: 'SECRET-claim-email' }, 'SECRET-id-token'),
+      refresh_token: 'SECRET-refresh-token',
+      expires_in: 3_600,
+    },
+  };
+}
+
+function prepareSentinelRefresh(
+  harness: ReturnType<typeof makeHarness>,
+  options: { rotated?: boolean; expiresInSeconds?: number } = {},
+): void {
+  harness.tokenTransport.result = {
+    status: 200,
+    data: {
+      access_token: 'SECRET-access-token',
+      id_token: refreshedIdToken({ email: 'SECRET-claim-email', exp: 10_000 }, 'SECRET-id-token'),
+      expires_in: options.expiresInSeconds ?? 3_600,
+      ...(options.rotated ? { refresh_token: 'SECRET-rotated-refresh-token' } : {}),
+    },
+  };
+}
+
+function expectHarnessHasNoSecretLeak(
+  harness: ReturnType<typeof makeHarness>,
+  consoleCalls: unknown[][],
+): void {
+  expectNoSecretLeak({
+    consoleCalls,
+    preferenceCalls: harness.preferences.setCalls,
+    renderedText: '',
+  });
+}
 
 describe('mobile auth initialization', () => {
   it('rejects invalid published state tuples with a stable internal error', () => {
@@ -3113,5 +3248,561 @@ describe('serialization, disposal, and secret handling', () => {
     for (const spy of spies) {
       spy.mockRestore();
     }
+  });
+});
+
+describe('cross-boundary secret leakage regressions', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it('keeps callback-success credentials, claims, URL, code, verifier, and nonce out of logs and non-secure storage', async () => {
+    const consoleCapture = captureConsoleCalls();
+    const harness = makeHarness({ isDevelopment: true });
+    await harness.persist(securityTransaction);
+    prepareSentinelExchange(harness);
+    harness.sessionFetch.mockResolvedValueOnce(
+      response(200, {
+        authenticated: true,
+        user: { userId: 'user-123', email: 'SECRET-claim-email' },
+      }),
+    );
+    await harness.coordinator.initialize();
+
+    await harness.coordinator.completeCallback(
+      callback(securityTransaction, 'SECRET-callback-code'),
+    );
+
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      sessionUsable: true,
+    });
+    expectHarnessHasNoSecretLeak(harness, consoleCapture.calls());
+  });
+
+  it('sanitizes callback failures containing request, response, token, and native exception sentinels', async () => {
+    const consoleCapture = captureConsoleCalls();
+    const harness = makeHarness({ isDevelopment: true });
+    await harness.persist(securityTransaction);
+    harness.tokenTransport.failure = Object.assign(
+      new Error(
+        [
+          'SECRET-callback-code',
+          'SECRET-code-verifier',
+          'SECRET-nonce',
+          'SECRET-access-token',
+          'SECRET-id-token',
+          'SECRET-refresh-token',
+          'SECRET-authorization-url',
+          'SECRET-claim-email',
+        ].join(' '),
+      ),
+      { rawResponse: 'SECRET-rotated-refresh-token' },
+    );
+    await harness.coordinator.initialize();
+
+    await harness.coordinator.completeCallback(
+      callback(securityTransaction, 'SECRET-callback-code'),
+    );
+
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'error',
+      errorCode: 'code_exchange_failed',
+    });
+    expectHarnessHasNoSecretLeak(harness, consoleCapture.calls());
+  });
+
+  it('keeps cold-restore credentials and decoded claims out of logs and non-secure storage', async () => {
+    const consoleCapture = captureConsoleCalls();
+    const harness = makeHarness({ isDevelopment: true });
+    harness.sessionStore.refreshToken = 'SECRET-refresh-token';
+    prepareSentinelRefresh(harness);
+    harness.sessionFetch.mockResolvedValueOnce(
+      response(200, {
+        authenticated: true,
+        user: { userId: 'user-123', email: 'SECRET-claim-email' },
+      }),
+    );
+
+    await harness.coordinator.initialize();
+
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      sessionUsable: true,
+    });
+    expectHarnessHasNoSecretLeak(harness, consoleCapture.calls());
+  });
+
+  it('keeps soft-refresh credentials and decoded claims out of logs and non-secure storage', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const consoleCapture = captureConsoleCalls();
+    const harness = makeHarness({ isDevelopment: true, now: () => Date.now() });
+    await harness.persist(securityTransaction);
+    harness.tokenTransport.result = {
+      status: 200,
+      data: {
+        access_token: 'SECRET-access-token',
+        id_token: idToken(
+          securityTransaction,
+          { email: 'SECRET-claim-email', exp: 10_000 },
+          'SECRET-id-token',
+        ),
+        refresh_token: 'SECRET-refresh-token',
+        expires_in: 61,
+      },
+    };
+    await harness.coordinator.initialize();
+    await harness.coordinator.completeCallback(
+      callback(securityTransaction, 'SECRET-callback-code'),
+    );
+    prepareSentinelRefresh(harness);
+    harness.sessionFetch.mockResolvedValueOnce(
+      response(200, {
+        authenticated: true,
+        user: { userId: 'user-123', email: 'SECRET-claim-email' },
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(refreshRequests(harness)).toHaveLength(1);
+    expect(harness.coordinator.state.sessionUsable).toBe(true);
+    expectHarnessHasNoSecretLeak(harness, consoleCapture.calls());
+  });
+
+  it('sanitizes a rotated-token save failure without writing the candidate to Preferences or browser storage', async () => {
+    const consoleCapture = captureConsoleCalls();
+    const harness = makeHarness({ isDevelopment: true });
+    harness.sessionStore.refreshToken = 'SECRET-refresh-token';
+    prepareSentinelRefresh(harness, { rotated: true });
+    harness.sessionStore.saveFailure = Object.assign(
+      new Error('SECRET-rotated-refresh-token SECRET-id-token SECRET-claim-email'),
+      { request: 'SECRET-access-token', response: 'SECRET-refresh-token' },
+    );
+
+    await harness.coordinator.initialize();
+
+    expect(harness.coordinator.state).toMatchObject({
+      errorCode: 'session_persistence_failed',
+      retryAction: 'persist',
+      sessionUsable: false,
+    });
+    expectHarnessHasNoSecretLeak(harness, consoleCapture.calls());
+  });
+
+  it('sanitizes an API rejection and clears its durable callback credential', async () => {
+    const consoleCapture = captureConsoleCalls();
+    const harness = makeHarness({ isDevelopment: true });
+    await harness.persist(securityTransaction);
+    prepareSentinelExchange(harness);
+    harness.sessionFetch.mockResolvedValueOnce(
+      response(401, {
+        request: 'SECRET-access-token',
+        idToken: 'SECRET-id-token',
+        refreshToken: 'SECRET-refresh-token',
+        rotatedRefreshToken: 'SECRET-rotated-refresh-token',
+        email: 'SECRET-claim-email',
+      }),
+    );
+    await harness.coordinator.initialize();
+
+    await harness.coordinator.completeCallback(
+      callback(securityTransaction, 'SECRET-callback-code'),
+    );
+
+    expect(harness.sessionStore.refreshToken).toBeNull();
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'signedOut',
+      sessionUsable: false,
+      notice: 'session_unusable',
+    });
+    expectHarnessHasNoSecretLeak(harness, consoleCapture.calls());
+  });
+
+  it('keeps start-over cleanup from exposing retained credentials or a raw state tuple', async () => {
+    const consoleCapture = captureConsoleCalls();
+    const harness = makeHarness({ isDevelopment: true });
+    harness.sessionStore.refreshToken = 'SECRET-refresh-token';
+    harness.tokenTransport.failure = Object.assign(
+      new Error('SECRET-access-token SECRET-id-token SECRET-refresh-token'),
+      {
+        authorizationUrl: 'SECRET-authorization-url',
+        code: 'SECRET-callback-code',
+        verifier: 'SECRET-code-verifier',
+        nonce: 'SECRET-nonce',
+        email: 'SECRET-claim-email',
+      },
+    );
+    await harness.persist(securityTransaction);
+    await harness.coordinator.initialize();
+    expect(harness.coordinator.state.retryAction).toBe('restore');
+
+    await harness.coordinator.signOut();
+
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'signedOut',
+      sessionUsable: false,
+      errorCode: null,
+      retryAction: null,
+      notice: null,
+    });
+    expectHarnessHasNoSecretLeak(harness, consoleCapture.calls());
+  });
+
+  it('sanitizes cleanup failure while preserving the exact incomplete-cleanup gate state', async () => {
+    const consoleCapture = captureConsoleCalls();
+    const harness = makeHarness({ isDevelopment: true });
+    await harness.persist(securityTransaction);
+    prepareSentinelExchange(harness);
+    await harness.coordinator.initialize();
+    await harness.coordinator.completeCallback(
+      callback(securityTransaction, 'SECRET-callback-code'),
+    );
+    await harness.persist(securityTransaction);
+    harness.sessionStore.clearFailure = Object.assign(
+      new Error('SECRET-refresh-token SECRET-rotated-refresh-token'),
+      {
+        accessToken: 'SECRET-access-token',
+        idToken: 'SECRET-id-token',
+        authorizationUrl: 'SECRET-authorization-url',
+        code: 'SECRET-callback-code',
+        verifier: 'SECRET-code-verifier',
+        nonce: 'SECRET-nonce',
+        email: 'SECRET-claim-email',
+      },
+    );
+
+    await harness.coordinator.signOut();
+
+    expect(harness.coordinator.state).toEqual({
+      phase: 'signedOut',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: 'session_cleanup_failed',
+      retryAction: 'cleanup',
+      notice: 'cleanup_incomplete',
+      user: null,
+    });
+    expectHarnessHasNoSecretLeak(harness, consoleCapture.calls());
+  });
+
+  it('sanitizes disposal failures without deleting or exposing durable state', async () => {
+    const consoleCapture = captureConsoleCalls();
+    const harness = makeHarness({ isDevelopment: true });
+    await harness.persist(securityTransaction);
+    prepareSentinelExchange(harness);
+    await harness.coordinator.initialize();
+    await harness.coordinator.completeCallback(
+      callback(securityTransaction, 'SECRET-callback-code'),
+    );
+    await harness.persist(securityTransaction);
+    harness.app.failRemove = true;
+    harness.browser.failRemove = true;
+
+    await harness.coordinator.dispose();
+
+    expect(harness.sessionStore.refreshToken).toBe('SECRET-refresh-token');
+    expect(harness.preferences.value).not.toBeNull();
+    expect(harness.coordinator.state).toEqual({
+      phase: 'signedOut',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: null,
+      retryAction: null,
+      notice: null,
+      user: null,
+    });
+    expectHarnessHasNoSecretLeak(harness, consoleCapture.calls());
+  });
+});
+
+describe('simulated process lifecycle persistence', () => {
+  it('restores after process relaunch but clears on a new installation marker', async () => {
+    const firstRelaunch = makeHarness();
+    firstRelaunch.sessionStore.refreshToken = 'refresh-token';
+    firstRelaunch.installationStore.marked = true;
+    prepareSuccessfulRefresh(firstRelaunch, { subject: 'user-123' });
+
+    await firstRelaunch.coordinator.initialize();
+
+    expect(firstRelaunch.coordinator.state.sessionUsable).toBe(true);
+
+    const reinstalled = makeHarness({
+      sessionStore: firstRelaunch.sessionStore,
+      installationStore: new FakeInstallationStore([]),
+    });
+    reinstalled.installationStore.marked = false;
+
+    await reinstalled.coordinator.initialize();
+
+    expect(firstRelaunch.sessionStore.clearCalls).toBe(1);
+    expect(reinstalled.coordinator.state.phase).toBe('signedOut');
+    expect(reinstalled.coordinator.state.sessionUsable).toBe(false);
+  });
+
+  it('keeps successful local sign-out durable across relaunch', async () => {
+    const first = makeHarness();
+    first.sessionStore.refreshToken = 'refresh-token';
+    prepareSuccessfulRefresh(first);
+    await first.coordinator.initialize();
+
+    await first.coordinator.signOut();
+
+    const relaunched = makeHarness({
+      sessionStore: first.sessionStore,
+      installationStore: first.installationStore,
+    });
+    await relaunched.coordinator.initialize();
+
+    expect(relaunched.coordinator.state.phase).toBe('signedOut');
+    expect(relaunched.tokenTransport.requests).toHaveLength(0);
+  });
+
+  it('restores after relaunch when secure sign-out cleanup was incomplete', async () => {
+    const first = makeHarness();
+    first.sessionStore.refreshToken = 'refresh-token';
+    prepareSuccessfulRefresh(first);
+    await first.coordinator.initialize();
+    first.sessionStore.clearFailure = new Error('SECRET-delete-failure');
+
+    await first.coordinator.signOut();
+
+    expect(first.coordinator.state.notice).toBe('cleanup_incomplete');
+
+    first.sessionStore.clearFailure = undefined;
+    const relaunched = makeHarness({
+      sessionStore: first.sessionStore,
+      installationStore: first.installationStore,
+    });
+    prepareSuccessfulRefresh(relaunched);
+
+    await relaunched.coordinator.initialize();
+
+    expect(relaunched.coordinator.state.sessionUsable).toBe(true);
+  });
+});
+
+describe('disposal race boundaries', () => {
+  it('stops initialization before storage when disposal begins during listener attachment', async () => {
+    const listener = deferred<void>();
+    const harness = makeHarness();
+    harness.app.addGate = listener.promise;
+
+    const initializing = harness.coordinator.initialize();
+    await vi.waitFor(() => expect(harness.order).toContain('app:add:appUrlOpen'));
+    const disposing = harness.coordinator.dispose();
+    listener.resolve();
+    await Promise.all([initializing, disposing]);
+
+    expect(harness.installationStore.readCalls).toBe(0);
+    expect(harness.sessionStore.clearCalls).toBe(0);
+    expect(harness.app.removeCalls).toBe(2);
+    expect(harness.browser.removeCalls).toBe(1);
+    expect(harness.coordinator.state.phase).toBe('signedOut');
+  });
+
+  it('stops initialization before cold-launch handling when disposal begins during marker read', async () => {
+    const markerRead = deferred<void>();
+    const harness = makeHarness();
+    harness.installationStore.readGate = markerRead.promise;
+
+    const initializing = harness.coordinator.initialize();
+    await vi.waitFor(() => expect(harness.installationStore.readCalls).toBe(1));
+    const disposing = harness.coordinator.dispose();
+    markerRead.resolve();
+    await Promise.all([initializing, disposing]);
+
+    expect(harness.order).not.toContain('app:getLaunchUrl');
+    expect(harness.tokenTransport.requests).toHaveLength(0);
+    expect(harness.coordinator.state.phase).toBe('signedOut');
+  });
+
+  it('does not mark an installation when disposal begins during first-install Keychain cleanup', async () => {
+    const keychainClear = deferred<void>();
+    const harness = makeHarness();
+    harness.installationStore.marked = false;
+    harness.sessionStore.clearGate = keychainClear.promise;
+
+    const initializing = harness.coordinator.initialize();
+    await vi.waitFor(() => expect(harness.sessionStore.clearCalls).toBe(1));
+    const disposing = harness.coordinator.dispose();
+    keychainClear.resolve();
+    await Promise.all([initializing, disposing]);
+
+    expect(harness.installationStore.markCalls).toBe(0);
+    expect(harness.order).not.toContain('app:getLaunchUrl');
+    expect(harness.coordinator.state.phase).toBe('signedOut');
+  });
+
+  it('stops cold initialization when disposal begins during transaction discovery', async () => {
+    const transactionRead = deferred<void>();
+    const harness = makeHarness();
+    harness.preferences.getGate = transactionRead.promise;
+
+    const initializing = harness.coordinator.initialize();
+    await vi.waitFor(() => expect(harness.preferences.calls).toContain('preferences:get'));
+    const disposing = harness.coordinator.dispose();
+    transactionRead.resolve();
+    await Promise.all([initializing, disposing]);
+
+    expect(harness.tokenTransport.requests).toHaveLength(0);
+    expect(harness.coordinator.state.phase).toBe('signedOut');
+  });
+
+  it('does not exchange a callback when disposal begins while its browser is closing', async () => {
+    const browserClose = deferred<void>();
+    const harness = makeHarness();
+    await harness.persist(activeTransaction);
+    await harness.coordinator.initialize();
+    harness.browser.closeGate = browserClose.promise;
+
+    const completing = harness.coordinator.completeCallback(callback(activeTransaction));
+    await vi.waitFor(() => expect(harness.browser.closeCalls).toBe(1));
+    const disposing = harness.coordinator.dispose();
+    browserClose.resolve();
+    await Promise.all([completing, disposing]);
+
+    expect(harness.tokenTransport.requests).toHaveLength(0);
+    expect(harness.preferences.value).not.toBeNull();
+    expect(harness.coordinator.state.phase).toBe('signedOut');
+  });
+
+  it('does not accept a callback response when disposal begins during token exchange', async () => {
+    const tokenResponse = deferred<{ status: number; data: unknown }>();
+    const harness = makeHarness();
+    await harness.persist(activeTransaction);
+    await harness.coordinator.initialize();
+    harness.tokenTransport.gate = tokenResponse.promise;
+
+    const completing = harness.coordinator.completeCallback(callback(activeTransaction));
+    await vi.waitFor(() => expect(harness.tokenTransport.requests).toHaveLength(1));
+    const disposing = harness.coordinator.dispose();
+    tokenResponse.resolve({
+      status: 200,
+      data: {
+        access_token: 'SECRET-access-token',
+        id_token: idToken(activeTransaction),
+        refresh_token: 'SECRET-refresh-token',
+        expires_in: 3_600,
+      },
+    });
+    await Promise.all([completing, disposing]);
+
+    expect(harness.sessionStore.saveAttempts).toEqual([]);
+    expect(harness.preferences.value).not.toBeNull();
+    expect(harness.coordinator.state.phase).toBe('signedOut');
+  });
+
+  it('does not promote a callback candidate when disposal begins during durable persistence', async () => {
+    const persistence = deferred<void>();
+    const harness = makeHarness();
+    await harness.persist(activeTransaction);
+    harness.prepareSuccessfulExchange(activeTransaction);
+    harness.sessionStore.saveGate = persistence.promise;
+    await harness.coordinator.initialize();
+
+    const completing = harness.coordinator.completeCallback(callback(activeTransaction));
+    await vi.waitFor(() =>
+      expect(harness.sessionStore.saveAttempts).toEqual(['SECRET-refresh-token']),
+    );
+    const disposing = harness.coordinator.dispose();
+    persistence.resolve();
+    await Promise.all([completing, disposing]);
+
+    expect(harness.sessionFetch).not.toHaveBeenCalled();
+    expect(harness.sessionStore.refreshToken).toBe('SECRET-refresh-token');
+    expect(harness.coordinator.state.phase).toBe('signedOut');
+  });
+
+  it('does not promote a callback candidate when disposal begins during API fetch', async () => {
+    const sessionResponse = deferred<Response>();
+    const harness = makeHarness();
+    await harness.persist(activeTransaction);
+    harness.prepareSuccessfulExchange(activeTransaction);
+    harness.sessionFetch.mockImplementationOnce(async () => sessionResponse.promise);
+    await harness.coordinator.initialize();
+
+    const completing = harness.coordinator.completeCallback(callback(activeTransaction));
+    await vi.waitFor(() => expect(harness.sessionFetch).toHaveBeenCalledOnce());
+    const disposing = harness.coordinator.dispose();
+    sessionResponse.resolve(
+      response(200, {
+        authenticated: true,
+        user: { userId: 'user-123', email: 'SECRET-claim-email' },
+      }),
+    );
+    await Promise.all([completing, disposing]);
+
+    expect(harness.sessionStore.refreshToken).toBe('SECRET-refresh-token');
+    expect(harness.coordinator.state.phase).toBe('signedOut');
+    expect(harness.coordinator.state.sessionUsable).toBe(false);
+  });
+
+  it('does not promote a callback candidate when disposal begins during API body parsing', async () => {
+    const sessionBody = deferred<unknown>();
+    const json = vi.fn(async () => sessionBody.promise);
+    const harness = makeHarness();
+    await harness.persist(activeTransaction);
+    harness.prepareSuccessfulExchange(activeTransaction);
+    harness.sessionFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json,
+    } as unknown as Response);
+    await harness.coordinator.initialize();
+
+    const completing = harness.coordinator.completeCallback(callback(activeTransaction));
+    await vi.waitFor(() => expect(json).toHaveBeenCalledOnce());
+    const disposing = harness.coordinator.dispose();
+    sessionBody.resolve({
+      authenticated: true,
+      user: { userId: 'user-123', email: 'SECRET-claim-email' },
+    });
+    await Promise.all([completing, disposing]);
+
+    expect(harness.coordinator.state.phase).toBe('signedOut');
+    expect(harness.coordinator.state.sessionUsable).toBe(false);
+  });
+
+  it('keeps the transaction durable when disposal begins during browser launch', async () => {
+    const browserOpen = deferred<void>();
+    const harness = makeHarness();
+    harness.browser.openGate = browserOpen.promise;
+    await harness.coordinator.initialize();
+
+    const starting = harness.coordinator.startSignIn();
+    await vi.waitFor(() => expect(harness.browser.openCalls).toHaveLength(1));
+    const disposing = harness.coordinator.dispose();
+    browserOpen.resolve();
+    await Promise.all([starting, disposing]);
+
+    expect(harness.preferences.value).not.toBeNull();
+    expect(harness.coordinator.state.phase).toBe('signedOut');
+  });
+
+  it('does not launch the browser when disposal begins during transaction persistence', async () => {
+    const transactionWrite = deferred<void>();
+    const harness = makeHarness();
+    harness.preferences.setGate = transactionWrite.promise;
+    await harness.coordinator.initialize();
+
+    const starting = harness.coordinator.startSignIn();
+    await vi.waitFor(() => expect(harness.preferences.calls).toContain('preferences:set:start'));
+    const disposing = harness.coordinator.dispose();
+    transactionWrite.resolve();
+    await Promise.all([starting, disposing]);
+
+    expect(harness.preferences.value).not.toBeNull();
+    expect(harness.browser.openCalls).toHaveLength(0);
+    expect(harness.coordinator.state.phase).toBe('signedOut');
   });
 });

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -2610,6 +2610,102 @@ describe('active-session lifecycle refresh', () => {
     expect(harness.sessionStore.clearCalls).toBe(0);
   });
 
+  it('reissues instead of terminal-cleaning when /auth/session 401s an in-flight-expired candidate', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 120_000);
+    // Candidate ID token expires at NOW + 62_000: valid when verification
+    // starts at NOW + 60_000 but expired by the time the response arrives.
+    prepareSuccessfulRefresh(harness, { expiresInSeconds: 2 });
+    const heldVerification = deferred<Response>();
+    harness.sessionFetch.mockImplementationOnce(async () => heldVerification.promise);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(harness.coordinator.state).toMatchObject({
+      operation: 'verifying',
+      sessionUsable: true,
+    });
+
+    // Advance past the candidate expiry while the response is still pending.
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(harness.coordinator.state.operation).toBe('verifying');
+
+    // The API returns 401 for an expired ID token. Without the post-response
+    // expiry recheck, the coordinator would treat this as a terminal
+    // credential failure and delete the still-valid durable refresh token.
+    prepareSuccessfulRefresh(harness);
+    heldVerification.resolve(response(401, { error: 'Unauthorized: Invalid or expired token' }));
+    await harness.flush();
+
+    expect(refreshRequests(harness)).toHaveLength(2);
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      operation: 'idle',
+      sessionUsable: true,
+    });
+    expect(harness.sessionStore.clearCalls).toBe(0);
+  });
+
+  it('retries a transiently-failed R2 reissue with R2, not the stale active R1', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 120_000);
+    // First refresh returns a rotated R2 with a short-lived candidate so it
+    // expires before the manual retry. R2 is persisted before verification,
+    // while active still holds R1.
+    prepareSuccessfulRefresh(harness, {
+      rotatedRefreshToken: 'SECRET-rotated-refresh-token',
+      expiresInSeconds: 10,
+    });
+    harness.sessionFetch
+      .mockResolvedValueOnce(response(500, { error: 'temporary' }))
+      .mockResolvedValueOnce(response(500, { error: 'temporary' }));
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(5_000);
+    // Candidate expired at NOW + 70_000; advance past it.
+    await vi.advanceTimersByTimeAsync(6_000);
+
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      errorCode: 'session_verification_failed',
+      retryAction: 'verify',
+    });
+    expect(harness.sessionStore.clearCalls).toBe(0);
+    expect(harness.sessionStore.saveAttempts).toContain('SECRET-rotated-refresh-token');
+
+    // The reissue sends R2 but fails transiently (503 is retryable, not
+    // invalid_grant). Without retaining R2 in active.bundle.refreshToken,
+    // the next retry would fall back to active R1 and, once R1's rotation
+    // grace ends, elicit invalid_grant and terminally delete the valid R2.
+    harness.tokenTransport.result = { status: 503, data: {} };
+    await harness.coordinator.retryCurrentOperation();
+
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      errorCode: 'session_refresh_failed',
+      retryAction: 'refresh',
+    });
+    expect(harness.sessionStore.clearCalls).toBe(0);
+    // The reissue attempt sent R2.
+    const grantsAfterReissue = refreshRequests(harness);
+    expect(grantsAfterReissue).toHaveLength(2);
+    expect(grantsAfterReissue[1]?.data).toContain('refresh_token=SECRET-rotated-refresh-token');
+
+    // The next manual retry must still send R2, not R1.
+    prepareSuccessfulRefresh(harness, { rotatedRefreshToken: 'SECRET-rotated-refresh-token' });
+    await harness.coordinator.retryCurrentOperation();
+
+    const grants = refreshRequests(harness);
+    expect(grants).toHaveLength(3);
+    expect(grants[2]?.data).toContain('refresh_token=SECRET-rotated-refresh-token');
+    expect(grants[2]?.data).not.toContain('refresh_token=SECRET-refresh-token');
+    expect(harness.sessionStore.clearCalls).toBe(0);
+    expect(harness.coordinator.state.sessionUsable).toBe(true);
+  });
+
   it('replaces both old deadlines after successful promotion', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -3,6 +3,7 @@ import {
   MOBILE_OAUTH_CALLBACK_URI,
   MOBILE_OAUTH_TRANSACTION_KEY,
   MOBILE_OAUTH_TRANSACTION_TTL_MS,
+  assertMobileAuthState,
   type MobileAppAdapter,
   type MobileAuthState,
   type MobileBrowserAdapter,
@@ -145,14 +146,16 @@ class FakeApp implements MobileAppAdapter {
   }
 
   async addListener(
-    eventName: 'appUrlOpen',
-    listener: (event: { url: string }) => void,
+    eventName: 'appUrlOpen' | 'appStateChange',
+    listener: ((event: { url: string }) => void) | ((event: { isActive: boolean }) => void),
   ): Promise<{ remove(): Promise<void> }> {
     this.order.push(`app:add:${eventName}`);
     if (this.failAdd) {
       throw new Error('SECRET-app-plugin-failure');
     }
-    this.listener = listener;
+    if (eventName === 'appUrlOpen') {
+      this.listener = listener as (event: { url: string }) => void;
+    }
     return {
       remove: async () => {
         this.removeCalls += 1;
@@ -341,6 +344,51 @@ const activeTransaction: OAuthTransaction = {
 };
 
 describe('mobile auth initialization', () => {
+  it('rejects invalid published state tuples with a stable internal error', () => {
+    expect(() =>
+      assertMobileAuthState(
+        {
+          phase: 'signedOut',
+          operation: 'idle',
+          sessionUsable: true,
+          errorCode: null,
+          retryAction: null,
+          notice: null,
+          user: null,
+        },
+        {
+          activeBundle: null,
+          now: NOW,
+        },
+      ),
+    ).toThrow('invalid_mobile_auth_state');
+  });
+
+  it('publishes the complete authenticated tuple after verification', async () => {
+    const harness = makeHarness();
+    await harness.persist(activeTransaction);
+    harness.prepareSuccessfulExchange(activeTransaction);
+    harness.sessionFetch.mockResolvedValueOnce(
+      response(200, {
+        authenticated: true,
+        user: { userId: 'user-1', email: null },
+      }),
+    );
+    await harness.coordinator.initialize();
+
+    await harness.coordinator.completeCallback(callback(activeTransaction));
+
+    expect(harness.coordinator.state).toEqual({
+      phase: 'authenticated',
+      operation: 'idle',
+      sessionUsable: true,
+      errorCode: null,
+      retryAction: null,
+      notice: null,
+      user: { userId: 'user-1', email: null },
+    });
+  });
+
   it('registers both listeners before reading the cold-launch URL', async () => {
     const harness = makeHarness();
 
@@ -353,7 +401,11 @@ describe('mobile auth initialization', () => {
     ]);
     expect(harness.coordinator.state).toEqual({
       phase: 'signedOut',
+      operation: 'idle',
+      sessionUsable: false,
       errorCode: null,
+      retryAction: null,
+      notice: null,
       user: null,
     });
   });
@@ -389,7 +441,11 @@ describe('mobile auth initialization', () => {
 
     expect(harness.coordinator.state).toEqual({
       phase: 'authenticated',
+      operation: 'idle',
+      sessionUsable: true,
       errorCode: null,
+      retryAction: null,
+      notice: null,
       user: { userId: 'user-123', email: 'person@example.com' },
     });
     expect(harness.preferences.value).toBeNull();
@@ -1258,7 +1314,11 @@ describe('session verification', () => {
       expect(harness.sessionFetch).toHaveBeenCalledTimes(2);
       expect(harness.coordinator.state).toEqual({
         phase: 'authenticated',
+        operation: 'idle',
+        sessionUsable: true,
         errorCode: null,
+        retryAction: null,
+        notice: null,
         user: { userId: 'retry-user', email: null },
       });
     },
@@ -1382,7 +1442,11 @@ describe('serialization, disposal, and secret handling', () => {
     expect(harness.preferences.value).not.toBeNull();
     expect(harness.coordinator.state).toEqual({
       phase: 'signedOut',
+      operation: 'idle',
+      sessionUsable: false,
       errorCode: null,
+      retryAction: null,
+      notice: null,
       user: null,
     });
   });

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -981,6 +981,26 @@ describe('callback completion and cleanup', () => {
     expect(harness.coordinator.state.errorCode).toBe('token_validation_failed');
   });
 
+  it('maps a whitespace-only callback refresh token to token validation failure', async () => {
+    const harness = makeHarness();
+    await harness.coordinator.initialize();
+    await harness.coordinator.startSignIn();
+    const transaction = harness.preferences.transaction();
+    harness.tokenTransport.result = {
+      status: 200,
+      data: {
+        access_token: 'access',
+        id_token: idToken(transaction),
+        refresh_token: ' \t\n',
+        expires_in: 3_600,
+      },
+    };
+
+    harness.app.emit(callback(transaction));
+    await harness.flush();
+    expect(harness.coordinator.state.errorCode).toBe('token_validation_failed');
+  });
+
   it('maps transaction-load failure safely without exchanging the code', async () => {
     const harness = makeHarness();
     await harness.coordinator.initialize();

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -1413,19 +1413,40 @@ describe('restore terminal and retryable classification', () => {
     return harness;
   }
 
-  it.each([
-    [400, { error: 'invalid_grant' }],
-    [401, { error: 'unauthorized' }],
-    [403, { error: 'forbidden' }],
-  ] as const)('clears terminal refresh failures with status %s', async (status, data) => {
+  it('clears terminal refresh failures only for confirmed invalid_grant', async () => {
     const harness = makeRestoreHarness();
-    harness.tokenTransport.result = { status, data };
+    harness.tokenTransport.result = { status: 400, data: { error: 'invalid_grant' } };
 
     await harness.coordinator.initialize();
 
     expect(harness.sessionStore.clearCalls).toBe(1);
     expect(harness.coordinator.state.notice).toBe('session_unusable');
   });
+
+  it.each([
+    ['invalid_client', 400, { error: 'invalid_client' }],
+    ['invalid_request', 400, { error: 'invalid_request' }],
+    ['unauthorized_client', 400, { error: 'unauthorized_client' }],
+    ['unsupported_grant_type', 400, { error: 'unsupported_grant_type' }],
+    ['unknown OAuth error', 400, { error: 'SECRET-provider' }],
+    ['gateway 401', 401, { error: 'unauthorized' }],
+    ['WAF 403', 403, { error: 'forbidden' }],
+  ] as const)(
+    'preserves the durable token for non-invalid_grant %s',
+    async (_label, status, data) => {
+      const harness = makeRestoreHarness();
+      harness.tokenTransport.result = { status, data };
+
+      await harness.coordinator.initialize();
+
+      expect(harness.sessionStore.clearCalls).toBe(0);
+      expect(harness.sessionStore.refreshToken).toBe('SECRET-durable-token');
+      expect(harness.coordinator.state).toMatchObject({
+        errorCode: 'session_restore_failed',
+        retryAction: 'restore',
+      });
+    },
+  );
 
   it('keeps terminal restore cleanup in initializing until deletion resolves', async () => {
     const harness = makeRestoreHarness();
@@ -2462,6 +2483,41 @@ describe('active-session lifecycle refresh', () => {
 
     expect(refreshRequests(harness)).toHaveLength(1);
     expect(harness.sessionFetch).toHaveBeenCalledTimes(4);
+    expect(harness.coordinator.state.sessionUsable).toBe(true);
+  });
+
+  it('refreshes instead of verifying an expired retained candidate', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 120_000);
+    // Short-lived candidate so it expires before the manual retry.
+    prepareSuccessfulRefresh(harness, { expiresInSeconds: 10 });
+    harness.sessionFetch
+      .mockResolvedValueOnce(response(500, { error: 'temporary' }))
+      .mockResolvedValueOnce(response(500, { error: 'temporary' }));
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(5_000);
+    // Candidate expired at NOW + 70_000; advance past it.
+    await vi.advanceTimersByTimeAsync(6_000);
+
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      errorCode: 'session_verification_failed',
+      retryAction: 'verify',
+    });
+    expect(harness.sessionStore.clearCalls).toBe(0);
+
+    // The retry must obtain a fresh candidate via the refresh grant, not
+    // send the expired ID token to /auth/session (which would 401 and
+    // trigger terminal cleanup of the still-valid durable token).
+    prepareSuccessfulRefresh(harness);
+    await harness.coordinator.retryCurrentOperation();
+
+    expect(refreshRequests(harness)).toHaveLength(2);
+    expect(harness.sessionStore.clearCalls).toBe(0);
+    expect(harness.sessionStore.refreshToken).toBe('SECRET-refresh-token');
     expect(harness.coordinator.state.sessionUsable).toBe(true);
   });
 

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -2521,6 +2521,95 @@ describe('active-session lifecycle refresh', () => {
     expect(harness.coordinator.state.sessionUsable).toBe(true);
   });
 
+  it('reissues an expired rotated refresh candidate with the durable R2, not active R1', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 120_000);
+    // First refresh returns a rotated R2 with a short-lived candidate so it
+    // expires before the manual retry. R2 is persisted before verification,
+    // while active still holds R1.
+    prepareSuccessfulRefresh(harness, {
+      rotatedRefreshToken: 'SECRET-rotated-refresh-token',
+      expiresInSeconds: 10,
+    });
+    harness.sessionFetch
+      .mockResolvedValueOnce(response(500, { error: 'temporary' }))
+      .mockResolvedValueOnce(response(500, { error: 'temporary' }));
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(5_000);
+    // Candidate expired at NOW + 70_000; advance past it.
+    await vi.advanceTimersByTimeAsync(6_000);
+
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      errorCode: 'session_verification_failed',
+      retryAction: 'verify',
+    });
+    expect(harness.sessionStore.clearCalls).toBe(0);
+    expect(harness.sessionStore.saveAttempts).toContain('SECRET-rotated-refresh-token');
+
+    // The retry must reissue the grant with the candidate's durable R2, not
+    // active.bundle.refreshToken (R1). Sending R1 would, once its rotation
+    // grace ends, elicit invalid_grant and terminally delete the valid R2.
+    prepareSuccessfulRefresh(harness, {
+      rotatedRefreshToken: 'SECRET-rotated-refresh-token',
+    });
+    await harness.coordinator.retryCurrentOperation();
+
+    const grants = refreshRequests(harness);
+    expect(grants).toHaveLength(2);
+    expect(grants[1]?.data).toContain('refresh_token=SECRET-rotated-refresh-token');
+    expect(grants[1]?.data).not.toContain('refresh_token=SECRET-refresh-token');
+    expect(harness.sessionStore.clearCalls).toBe(0);
+    expect(harness.coordinator.state.sessionUsable).toBe(true);
+  });
+
+  it('reissues when the candidate expires during the /auth/session round-trip', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 120_000);
+    // Candidate ID token expires at NOW + 62_000: valid when verification
+    // starts at NOW + 60_000 but expired by the time the response arrives.
+    prepareSuccessfulRefresh(harness, { expiresInSeconds: 2 });
+    const heldVerification = deferred<Response>();
+    harness.sessionFetch.mockImplementationOnce(async () => heldVerification.promise);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(harness.coordinator.state).toMatchObject({
+      operation: 'verifying',
+      sessionUsable: true,
+    });
+
+    // Advance past the candidate expiry while the response is still pending.
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(harness.coordinator.state.operation).toBe('verifying');
+
+    // Prepare the reissue grant, then release the held response. Without the
+    // pre-promotion recheck, enterAuthenticated() would trip the live-bundle
+    // invariant (applyState → assertMobileAuthState) after active had been
+    // replaced with the expired bundle and pendingCandidate cleared, leaving
+    // the coordinator stuck in 'verifying' with no recovery timer.
+    prepareSuccessfulRefresh(harness);
+    heldVerification.resolve(
+      response(200, {
+        authenticated: true,
+        user: { userId: 'user-123', email: 'person@example.com' },
+      }),
+    );
+    await harness.flush();
+
+    expect(refreshRequests(harness)).toHaveLength(2);
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      operation: 'idle',
+      sessionUsable: true,
+    });
+    expect(harness.sessionStore.clearCalls).toBe(0);
+  });
+
   it('replaces both old deadlines after successful promotion', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { watch } from 'vue';
 import {
   MOBILE_OAUTH_CALLBACK_URI,
   MOBILE_OAUTH_TRANSACTION_KEY,
@@ -16,6 +17,8 @@ import {
   createOAuthTransactionStore,
   type OAuthTransactionPreferences,
 } from '../auth/oauth-transaction-store';
+import type { MobileInstallationStore } from '../auth/mobile-installation-store';
+import type { MobileSessionStore } from '../auth/mobile-session-store';
 import { createMobileAuthCoordinator, MOBILE_AUTH_NETWORK_TIMEOUT_MS } from './mobile-auth';
 
 const NOW = 1_000_000;
@@ -94,9 +97,12 @@ class FakePreferences implements OAuthTransactionPreferences {
   setFailure: unknown;
   removeFailure: unknown;
 
+  constructor(private readonly order?: string[]) {}
+
   async get({ key }: { key: string }): Promise<{ value: string | null }> {
     expect(key).toBe(MOBILE_OAUTH_TRANSACTION_KEY);
     this.calls.push('preferences:get');
+    this.order?.push('preferences:get');
     if (this.getFailure) {
       throw this.getFailure;
     }
@@ -106,17 +112,20 @@ class FakePreferences implements OAuthTransactionPreferences {
   async set({ key, value }: { key: string; value: string }): Promise<void> {
     expect(key).toBe(MOBILE_OAUTH_TRANSACTION_KEY);
     this.calls.push('preferences:set:start');
+    this.order?.push('preferences:set:start');
     if (this.setFailure) {
       throw this.setFailure;
     }
     this.value = value;
     await this.setGate;
     this.calls.push('preferences:set:complete');
+    this.order?.push('preferences:set:complete');
   }
 
   async remove({ key }: { key: string }): Promise<void> {
     expect(key).toBe(MOBILE_OAUTH_TRANSACTION_KEY);
     this.calls.push('preferences:remove');
+    this.order?.push('preferences:remove');
     await this.removeGate;
     if (this.removeFailure) {
       throw this.removeFailure;
@@ -129,6 +138,63 @@ class FakePreferences implements OAuthTransactionPreferences {
       throw new Error('No persisted transaction');
     }
     return JSON.parse(this.value) as OAuthTransaction;
+  }
+}
+
+class FakeSessionStore implements MobileSessionStore {
+  refreshToken: string | null = null;
+  readonly saveAttempts: string[] = [];
+  clearCalls = 0;
+  saveGate: Promise<void> | undefined;
+  loadFailure: unknown;
+  saveFailure: unknown;
+  clearFailure: unknown;
+
+  constructor(private readonly order: string[]) {}
+
+  async loadRefreshToken(): Promise<string | null> {
+    this.order.push('session:load');
+    if (this.loadFailure) throw this.loadFailure;
+    return this.refreshToken;
+  }
+
+  async saveRefreshToken(refreshToken: string): Promise<void> {
+    this.order.push(`session:save:${refreshToken}`);
+    this.saveAttempts.push(refreshToken);
+    await this.saveGate;
+    if (this.saveFailure) throw this.saveFailure;
+    this.refreshToken = refreshToken;
+  }
+
+  async clearRefreshToken(): Promise<void> {
+    this.order.push('session:clear');
+    this.clearCalls += 1;
+    if (this.clearFailure) throw this.clearFailure;
+    this.refreshToken = null;
+  }
+}
+
+class FakeInstallationStore implements MobileInstallationStore {
+  marked = true;
+  readFailure: unknown;
+  markFailure: unknown;
+  readCalls = 0;
+  markCalls = 0;
+
+  constructor(private readonly order: string[]) {}
+
+  async isCurrentInstallationMarked(): Promise<boolean> {
+    this.order.push('installation:isMarked');
+    this.readCalls += 1;
+    if (this.readFailure) throw this.readFailure;
+    return this.marked;
+  }
+
+  async markCurrentInstallation(): Promise<void> {
+    this.order.push('installation:mark');
+    this.markCalls += 1;
+    if (this.markFailure) throw this.markFailure;
+    this.marked = true;
   }
 }
 
@@ -263,6 +329,9 @@ type HarnessOptions = {
   browser?: FakeBrowser;
   preferences?: FakePreferences;
   tokenTransport?: FakeTokenTransport;
+  sessionStore?: FakeSessionStore;
+  installationStore?: FakeInstallationStore;
+  isNativeIos?: boolean;
   crypto?: Crypto | undefined;
   isSecureContext?: boolean;
   authConfig?: MobileOAuthConfig;
@@ -273,13 +342,21 @@ function makeHarness(options: HarnessOptions = {}) {
   const order: string[] = [];
   const app = options.app ?? new FakeApp(order);
   const browser = options.browser ?? new FakeBrowser(order);
-  const preferences = options.preferences ?? new FakePreferences();
+  const preferences = options.preferences ?? new FakePreferences(order);
   const tokenTransport = options.tokenTransport ?? new FakeTokenTransport();
-  const sessionFetch = vi.fn().mockResolvedValue(
-    response(200, {
-      authenticated: true,
-      user: { userId: 'user-123', email: 'person@example.com' },
-    }),
+  const sessionStore = options.sessionStore ?? new FakeSessionStore(order);
+  const installationStore = options.installationStore ?? new FakeInstallationStore(order);
+  const sessionFetch = vi.fn(
+    async (
+      _input: Parameters<typeof fetch>[0],
+      _init?: Parameters<typeof fetch>[1],
+    ): Promise<Response> => {
+      order.push('fetch:/auth/session');
+      return response(200, {
+        authenticated: true,
+        user: { userId: 'user-123', email: 'person@example.com' },
+      });
+    },
   );
   const transactionStore = createOAuthTransactionStore(preferences, () => NOW);
   const crypto = Object.hasOwn(options, 'crypto') ? options.crypto : deterministicCrypto();
@@ -288,6 +365,9 @@ function makeHarness(options: HarnessOptions = {}) {
     browser,
     transactionStore,
     tokenTransport,
+    sessionStore,
+    installationStore,
+    isNativeIos: options.isNativeIos ?? true,
     crypto,
     isSecureContext: options.isSecureContext ?? true,
     fetch: sessionFetch as unknown as typeof fetch,
@@ -324,12 +404,25 @@ function makeHarness(options: HarnessOptions = {}) {
     coordinator,
     order,
     preferences,
+    sessionStore,
+    installationStore,
     sessionFetch,
     tokenTransport,
     persist,
     prepareSuccessfulExchange,
     flush,
   };
+}
+
+function expectOrderedCalls(order: string[], sequence: string[]): void {
+  let previousIndex = -1;
+  for (const item of sequence) {
+    const index = order.indexOf(item, previousIndex + 1);
+    expect(index, `${item} must follow ${order[previousIndex] ?? 'the start'}`).toBeGreaterThan(
+      previousIndex,
+    );
+    previousIndex = index;
+  }
 }
 
 function snapshot(state: Readonly<MobileAuthState>): string {
@@ -397,7 +490,9 @@ describe('mobile auth initialization', () => {
     expect(harness.order).toEqual([
       'app:add:appUrlOpen',
       'browser:add:browserFinished',
+      'installation:isMarked',
       'app:getLaunchUrl',
+      'preferences:get',
     ]);
     expect(harness.coordinator.state).toEqual({
       phase: 'signedOut',
@@ -408,6 +503,123 @@ describe('mobile auth initialization', () => {
       notice: null,
       user: null,
     });
+  });
+
+  it('stops before native stores and listeners on an unsupported runtime', async () => {
+    const harness = makeHarness({ isNativeIos: false });
+
+    await harness.coordinator.initialize();
+    await harness.coordinator.startSignIn();
+
+    expect(harness.order).toEqual([]);
+    expect(harness.preferences.calls).toEqual([]);
+    expect(harness.sessionStore.clearCalls).toBe(0);
+    expect(harness.installationStore.readCalls).toBe(0);
+    expect(harness.browser.openCalls).toEqual([]);
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'error',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: 'unsupported_platform',
+      retryAction: null,
+      notice: null,
+      user: null,
+    });
+  });
+
+  it('clears retained Keychain state before writing a missing install marker', async () => {
+    const harness = makeHarness();
+    harness.installationStore.marked = false;
+
+    await harness.coordinator.initialize();
+
+    expectOrderedCalls(harness.order, [
+      'installation:isMarked',
+      'session:clear',
+      'installation:mark',
+      'app:getLaunchUrl',
+    ]);
+    expect(harness.installationStore.marked).toBe(true);
+  });
+
+  it('fails closed when first-install cleanup cannot complete', async () => {
+    const harness = makeHarness();
+    harness.installationStore.marked = false;
+    harness.sessionStore.clearFailure = new Error('SECRET-keychain');
+
+    await harness.coordinator.initialize();
+
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'signedOut',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: 'session_cleanup_failed',
+      retryAction: 'cleanup',
+      notice: 'cleanup_incomplete',
+      user: null,
+    });
+    expect(harness.order).not.toContain('app:getLaunchUrl');
+    expect(harness.preferences.calls).toEqual([]);
+    expect(harness.installationStore.markCalls).toBe(0);
+  });
+
+  it('fails closed when the installation marker cannot be read', async () => {
+    const harness = makeHarness();
+    harness.installationStore.readFailure = new Error('SECRET-marker-read');
+
+    await harness.coordinator.initialize();
+
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'signedOut',
+      errorCode: 'session_cleanup_failed',
+      retryAction: 'cleanup',
+      notice: 'cleanup_incomplete',
+    });
+    expect(harness.sessionStore.clearCalls).toBe(0);
+    expect(harness.order).not.toContain('app:getLaunchUrl');
+    expect(harness.preferences.calls).toEqual([]);
+  });
+
+  it('fails closed when a cleared installation cannot be marked', async () => {
+    const harness = makeHarness();
+    harness.installationStore.marked = false;
+    harness.installationStore.markFailure = new Error('SECRET-marker-write');
+
+    await harness.coordinator.initialize();
+
+    expectOrderedCalls(harness.order, [
+      'installation:isMarked',
+      'session:clear',
+      'installation:mark',
+    ]);
+    expect(harness.sessionStore.clearCalls).toBe(1);
+    expect(harness.installationStore.marked).toBe(false);
+    expect(harness.order).not.toContain('app:getLaunchUrl');
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'signedOut',
+      errorCode: 'session_cleanup_failed',
+      retryAction: 'cleanup',
+      notice: 'cleanup_incomplete',
+    });
+  });
+
+  it('repeats clear-before-mark after a crash-safe installation reset failure', async () => {
+    const first = makeHarness();
+    first.installationStore.marked = false;
+    first.installationStore.markFailure = new Error('SECRET-first-mark');
+    await first.coordinator.initialize();
+
+    first.installationStore.markFailure = undefined;
+    const relaunched = makeHarness({
+      sessionStore: first.sessionStore,
+      installationStore: first.installationStore,
+    });
+    await relaunched.coordinator.initialize();
+
+    expect(first.sessionStore.clearCalls).toBe(2);
+    expect(first.installationStore.markCalls).toBe(2);
+    expect(first.installationStore.marked).toBe(true);
+    expect(relaunched.coordinator.state.phase).toBe('signedOut');
   });
 
   it.each([
@@ -632,7 +844,9 @@ describe('mobile auth initialization', () => {
     expect(harness.order).toEqual([
       'app:add:appUrlOpen',
       'browser:add:browserFinished',
+      'installation:isMarked',
       'app:getLaunchUrl',
+      'preferences:get',
     ]);
   });
 });
@@ -1072,6 +1286,102 @@ describe('callback completion and cleanup', () => {
     });
   });
 
+  it('persists the callback refresh token before transaction cleanup, API verification, and authenticated publication', async () => {
+    const harness = makeHarness();
+    await harness.persist(activeTransaction);
+    harness.prepareSuccessfulExchange(activeTransaction);
+    await harness.coordinator.initialize();
+    harness.order.length = 0;
+    harness.preferences.calls.length = 0;
+    const stop = watch(
+      () => [harness.coordinator.state.phase, harness.coordinator.state.sessionUsable] as const,
+      ([phase, sessionUsable]) => {
+        if (phase === 'authenticated' && sessionUsable) {
+          harness.order.push('state:authenticated');
+        }
+      },
+      { flush: 'sync' },
+    );
+
+    try {
+      await harness.coordinator.completeCallback(callback(activeTransaction));
+    } finally {
+      stop();
+    }
+
+    expectOrderedCalls(harness.order, [
+      'session:save:SECRET-refresh-token',
+      'preferences:remove',
+      'fetch:/auth/session',
+      'state:authenticated',
+    ]);
+  });
+
+  it('does not clear the transaction or verify while callback persistence is pending', async () => {
+    const persistence = deferred<void>();
+    const harness = makeHarness();
+    await harness.persist(activeTransaction);
+    harness.prepareSuccessfulExchange(activeTransaction);
+    harness.sessionStore.saveGate = persistence.promise;
+    await harness.coordinator.initialize();
+    harness.preferences.calls.length = 0;
+
+    const completing = harness.coordinator.completeCallback(callback(activeTransaction));
+    await vi.waitFor(() =>
+      expect(harness.sessionStore.saveAttempts).toEqual(['SECRET-refresh-token']),
+    );
+
+    expect(harness.preferences.value).not.toBeNull();
+    expect(harness.preferences.calls).not.toContain('preferences:remove');
+    expect(harness.sessionFetch).not.toHaveBeenCalled();
+    expect(harness.coordinator.state).toMatchObject({
+      operation: 'persisting',
+      sessionUsable: false,
+    });
+
+    persistence.resolve();
+    await completing;
+    expect(harness.coordinator.state.phase).toBe('authenticated');
+  });
+
+  it('retains the callback candidate and transaction after persistence failure', async () => {
+    const harness = makeHarness();
+    await harness.persist(activeTransaction);
+    harness.prepareSuccessfulExchange(activeTransaction);
+    harness.sessionStore.saveFailure = new Error('SECRET-keychain-save');
+    await harness.coordinator.initialize();
+
+    await harness.coordinator.completeCallback(callback(activeTransaction));
+
+    expect(harness.preferences.value).not.toBeNull();
+    expect(harness.sessionFetch).not.toHaveBeenCalled();
+    expect(harness.coordinator.state).toEqual({
+      phase: 'error',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: 'session_persistence_failed',
+      retryAction: 'persist',
+      notice: null,
+      user: null,
+    });
+
+    const preferencesBeforeRejectedStart = [...harness.preferences.calls];
+    await harness.coordinator.startSignIn();
+    expect(harness.preferences.calls).toEqual(preferencesBeforeRejectedStart);
+    expect(harness.browser.openCalls).toEqual([]);
+
+    harness.sessionStore.saveFailure = undefined;
+    await harness.coordinator.retrySessionVerification();
+
+    expect(harness.sessionStore.saveAttempts).toEqual([
+      'SECRET-refresh-token',
+      'SECRET-refresh-token',
+    ]);
+    expect(harness.tokenTransport.requests).toHaveLength(1);
+    expect(harness.preferences.value).toBeNull();
+    expect(harness.coordinator.state.phase).toBe('authenticated');
+  });
+
   it('proceeds to session verification when successful exchange cleanup fails', async () => {
     const harness = makeHarness();
     await harness.persist(activeTransaction);
@@ -1261,24 +1571,45 @@ describe('session verification', () => {
     expect(authorization).toBe(`Bearer ${idToken(activeTransaction)}`);
   });
 
-  it.each([401, 403])('clears the token bundle after API status %i', async (status) => {
+  it.each([401, 403])(
+    'clears the durable callback credential before publishing session_unusable after API status %i',
+    async (status) => {
+      const harness = await exchangedHarness();
+      harness.sessionFetch.mockResolvedValueOnce(response(status, { authenticated: false }));
+
+      await harness.coordinator.completeCallback(callback(activeTransaction));
+
+      expect(harness.sessionStore.clearCalls).toBe(1);
+      expect(harness.sessionStore.refreshToken).toBeNull();
+      expect(harness.coordinator.state).toEqual({
+        phase: 'signedOut',
+        operation: 'idle',
+        sessionUsable: false,
+        errorCode: null,
+        retryAction: null,
+        notice: 'session_unusable',
+        user: null,
+      });
+      expect(harness.sessionFetch).toHaveBeenCalledOnce();
+    },
+  );
+
+  it('fails closed when an API-rejected callback credential cannot be deleted', async () => {
     const harness = await exchangedHarness();
-    harness.sessionFetch.mockResolvedValueOnce(response(status, { authenticated: false }));
+    harness.sessionFetch.mockResolvedValueOnce(response(401, { authenticated: false }));
+    harness.sessionStore.clearFailure = new Error('SECRET-keychain-delete');
 
     await harness.coordinator.completeCallback(callback(activeTransaction));
-    harness.sessionFetch.mockResolvedValueOnce(
-      response(200, {
-        authenticated: true,
-        user: { userId: 'user-123', email: null },
-      }),
-    );
-    await harness.coordinator.retrySessionVerification();
 
-    expect(harness.coordinator.state).toMatchObject({
-      phase: 'error',
-      errorCode: 'session_unauthorized',
+    expect(harness.coordinator.state).toEqual({
+      phase: 'signedOut',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: 'session_cleanup_failed',
+      retryAction: 'cleanup',
+      notice: 'cleanup_incomplete',
+      user: null,
     });
-    expect(harness.sessionFetch).toHaveBeenCalledOnce();
   });
 
   it.each([
@@ -1348,7 +1679,7 @@ describe('session verification', () => {
     try {
       harness.sessionFetch.mockImplementationOnce(
         (_url, init) =>
-          new Promise<void>((_resolve, reject) => {
+          new Promise<Response>((_resolve, reject) => {
             init?.signal?.addEventListener('abort', () => {
               reject(new Error('aborted'));
             });
@@ -1483,6 +1814,31 @@ describe('serialization, disposal, and secret handling', () => {
       /SECRET-code|SECRET-verifier|SECRET-state|SECRET-nonce|SECRET-access|SECRET-refresh|SECRET-thrown/u,
     );
     expect(snapshot(harness.coordinator.state)).not.toMatch(/SECRET/u);
+    for (const spy of spies) {
+      spy.mockRestore();
+    }
+  });
+
+  it('never logs or exposes installation or Keychain failure sentinels', async () => {
+    const spies = (['debug', 'info', 'log', 'warn', 'error'] as const).map((method) =>
+      vi.spyOn(console, method).mockImplementation(() => undefined),
+    );
+    const cleanupHarness = makeHarness();
+    cleanupHarness.installationStore.marked = false;
+    cleanupHarness.sessionStore.clearFailure = new Error('SECRET-cleanup-object');
+    const persistenceHarness = makeHarness();
+    await persistenceHarness.persist(activeTransaction);
+    persistenceHarness.prepareSuccessfulExchange(activeTransaction);
+    persistenceHarness.sessionStore.saveFailure = new Error('SECRET-persistence-object');
+
+    await cleanupHarness.coordinator.initialize();
+    await persistenceHarness.coordinator.initialize();
+    await persistenceHarness.coordinator.completeCallback(callback(activeTransaction));
+
+    const output = spies.flatMap((spy) => spy.mock.calls.flat()).join(' ');
+    expect(output).not.toMatch(/SECRET-cleanup|SECRET-persistence/u);
+    expect(snapshot(cleanupHarness.coordinator.state)).not.toMatch(/SECRET/u);
+    expect(snapshot(persistenceHarness.coordinator.state)).not.toMatch(/SECRET/u);
     for (const spy of spies) {
       spy.mockRestore();
     }

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -807,6 +807,18 @@ describe('mobile auth initialization', () => {
       } satisfies MobileAuthState,
     },
     {
+      label: 'refresh failure during cold initialization',
+      value: {
+        phase: 'initializing',
+        operation: 'idle',
+        sessionUsable: false,
+        errorCode: 'session_refresh_failed',
+        retryAction: 'refresh',
+        notice: null,
+        user: null,
+      } satisfies MobileAuthState,
+    },
+    {
       label: 'sign-out work that already claims signed-out phase',
       value: {
         phase: 'signedOut',
@@ -861,6 +873,54 @@ describe('mobile auth initialization', () => {
         now: NOW,
       }),
     ).toThrow('invalid_mobile_auth_state');
+  });
+
+  const retryFailureState = (
+    phase: MobileAuthState['phase'],
+    errorCode: NonNullable<MobileAuthState['errorCode']>,
+    retryAction: NonNullable<MobileAuthState['retryAction']>,
+    user: MobileAuthState['user'] = null,
+  ): MobileAuthState => ({
+    phase,
+    operation: 'idle',
+    sessionUsable: false,
+    errorCode,
+    retryAction,
+    notice: null,
+    user,
+  });
+
+  it.each([
+    {
+      label: 'initializing restore failure',
+      value: retryFailureState('initializing', 'session_restore_failed', 'restore'),
+    },
+    {
+      label: 'initializing persistence failure',
+      value: retryFailureState('initializing', 'session_persistence_failed', 'persist'),
+    },
+    {
+      label: 'initializing verification failure',
+      value: retryFailureState('initializing', 'session_verification_failed', 'verify'),
+    },
+    {
+      label: 'authenticated refresh failure',
+      value: retryFailureState('authenticated', 'session_refresh_failed', 'refresh', {
+        userId: 'user-1',
+        email: null,
+      }),
+    },
+    {
+      label: 'refresh failure without an active session',
+      value: retryFailureState('error', 'session_refresh_failed', 'refresh'),
+    },
+  ])('accepts $label', ({ value }) => {
+    expect(() =>
+      assertMobileAuthState(value, {
+        activeBundle: null,
+        now: NOW,
+      }),
+    ).not.toThrow();
   });
 
   it('publishes the complete authenticated tuple after verification', async () => {

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { watch } from 'vue';
+import { toRaw, watch } from 'vue';
 import {
   MOBILE_OAUTH_CALLBACK_URI,
   MOBILE_OAUTH_TRANSACTION_KEY,
@@ -18,7 +18,7 @@ import {
   type OAuthTransactionPreferences,
 } from '../auth/oauth-transaction-store';
 import type { MobileInstallationStore } from '../auth/mobile-installation-store';
-import type { MobileSessionStore } from '../auth/mobile-session-store';
+import { MobileSessionStoreError, type MobileSessionStore } from '../auth/mobile-session-store';
 import { createMobileAuthCoordinator, MOBILE_AUTH_NETWORK_TIMEOUT_MS } from './mobile-auth';
 
 const NOW = 1_000_000;
@@ -74,6 +74,17 @@ function idToken(transaction: OAuthTransaction, overrides: Record<string, unknow
     ...overrides,
   };
   return `${base64UrlJson({ alg: 'none' })}.${base64UrlJson(claims)}.unsigned`;
+}
+
+function refreshedIdToken(overrides: Record<string, unknown> = {}): string {
+  return `${base64UrlJson({ alg: 'none' })}.${base64UrlJson({
+    token_use: 'id',
+    aud: config.mobileClientId,
+    iss: `https://cognito-idp.${config.region}.amazonaws.com/${config.userPoolId}`,
+    sub: 'user-123',
+    exp: 2_000,
+    ...overrides,
+  })}.unsigned`;
 }
 
 function callback(transaction: OAuthTransaction, code = 'authorization-code'): string {
@@ -315,8 +326,15 @@ class FakeTokenTransport implements MobileTokenTransportAdapter {
   failure: unknown;
   gate: Promise<{ status: number; data: unknown }> | undefined;
 
+  constructor(private readonly order: string[]) {}
+
   async request(options: MobileTokenRequest): Promise<{ status: number; data: unknown }> {
     this.requests.push(options);
+    this.order.push(
+      options.data.includes('grant_type=refresh_token')
+        ? 'token:refresh'
+        : 'token:authorizationCode',
+    );
     if (this.failure) {
       throw this.failure;
     }
@@ -343,7 +361,7 @@ function makeHarness(options: HarnessOptions = {}) {
   const app = options.app ?? new FakeApp(order);
   const browser = options.browser ?? new FakeBrowser(order);
   const preferences = options.preferences ?? new FakePreferences(order);
-  const tokenTransport = options.tokenTransport ?? new FakeTokenTransport();
+  const tokenTransport = options.tokenTransport ?? new FakeTokenTransport(order);
   const sessionStore = options.sessionStore ?? new FakeSessionStore(order);
   const installationStore = options.installationStore ?? new FakeInstallationStore(order);
   const sessionFetch = vi.fn(
@@ -425,6 +443,21 @@ function expectOrderedCalls(order: string[], sequence: string[]): void {
   }
 }
 
+function prepareSuccessfulRefresh(
+  harness: ReturnType<typeof makeHarness>,
+  options: { subject?: string; rotatedRefreshToken?: string } = {},
+): void {
+  harness.tokenTransport.result = {
+    status: 200,
+    data: {
+      access_token: 'SECRET-refreshed-access-token',
+      id_token: refreshedIdToken({ sub: options.subject ?? 'user-123' }),
+      expires_in: 3_600,
+      ...(options.rotatedRefreshToken ? { refresh_token: options.rotatedRefreshToken } : {}),
+    },
+  };
+}
+
 function snapshot(state: Readonly<MobileAuthState>): string {
   return JSON.stringify(state);
 }
@@ -491,6 +524,7 @@ describe('mobile auth initialization', () => {
       'app:add:appUrlOpen',
       'browser:add:browserFinished',
       'installation:isMarked',
+      'session:load',
       'app:getLaunchUrl',
       'preferences:get',
     ]);
@@ -530,6 +564,7 @@ describe('mobile auth initialization', () => {
   it('clears retained Keychain state before writing a missing install marker', async () => {
     const harness = makeHarness();
     harness.installationStore.marked = false;
+    harness.sessionStore.refreshToken = 'SECRET-reinstall-residue';
 
     await harness.coordinator.initialize();
 
@@ -540,6 +575,8 @@ describe('mobile auth initialization', () => {
       'app:getLaunchUrl',
     ]);
     expect(harness.installationStore.marked).toBe(true);
+    expect(harness.tokenTransport.requests).toHaveLength(0);
+    expect(harness.sessionStore.refreshToken).toBeNull();
   });
 
   it('fails closed when first-install cleanup cannot complete', async () => {
@@ -576,6 +613,7 @@ describe('mobile auth initialization', () => {
       notice: 'cleanup_incomplete',
     });
     expect(harness.sessionStore.clearCalls).toBe(0);
+    expect(harness.order).toContain('session:load');
     expect(harness.order).not.toContain('app:getLaunchUrl');
     expect(harness.preferences.calls).toEqual([]);
   });
@@ -845,9 +883,438 @@ describe('mobile auth initialization', () => {
       'app:add:appUrlOpen',
       'browser:add:browserFinished',
       'installation:isMarked',
+      'session:load',
       'app:getLaunchUrl',
       'preferences:get',
     ]);
+  });
+});
+
+describe('durable session restoration and cold-launch precedence', () => {
+  it('lets a matching callback win without starting a parallel restore', async () => {
+    const harness = makeHarness();
+    await harness.persist(activeTransaction);
+    harness.app.launchUrl = { url: callback(activeTransaction) };
+    harness.sessionStore.refreshToken = 'SECRET-durable-token';
+    harness.prepareSuccessfulExchange(activeTransaction);
+
+    await harness.coordinator.initialize();
+
+    expect(harness.tokenTransport.requests).toHaveLength(1);
+    expect(harness.tokenTransport.requests[0]?.data).toContain('grant_type=authorization_code');
+    expect(harness.tokenTransport.requests[0]?.data).not.toContain('grant_type=refresh_token');
+  });
+
+  it('lets a durable token outrank a residual transaction', async () => {
+    const harness = makeHarness();
+    await harness.persist(activeTransaction);
+    harness.sessionStore.refreshToken = 'SECRET-durable-token';
+    prepareSuccessfulRefresh(harness);
+
+    await harness.coordinator.initialize();
+
+    expect(harness.preferences.value).toBeNull();
+    expect(harness.tokenTransport.requests[0]?.data).toContain('grant_type=refresh_token');
+    expect(harness.coordinator.state.phase).toBe('authenticated');
+  });
+
+  it('restores and verifies before publishing a usable session', async () => {
+    const harness = makeHarness();
+    harness.sessionStore.refreshToken = 'SECRET-durable-token';
+    prepareSuccessfulRefresh(harness);
+    const stop = watch(
+      () => [harness.coordinator.state.phase, harness.coordinator.state.sessionUsable] as const,
+      ([phase, sessionUsable]) => {
+        if (phase === 'authenticated' && sessionUsable) {
+          harness.order.push('state:authenticated');
+        }
+      },
+      { flush: 'sync' },
+    );
+
+    try {
+      await harness.coordinator.initialize();
+    } finally {
+      stop();
+    }
+
+    expectOrderedCalls(harness.order, [
+      'session:load',
+      'token:refresh',
+      'fetch:/auth/session',
+      'state:authenticated',
+    ]);
+    expect(harness.coordinator.state.sessionUsable).toBe(true);
+  });
+
+  it('enters ordinary signed out when neither durable token nor transaction exists', async () => {
+    const harness = makeHarness();
+
+    await harness.coordinator.initialize();
+
+    expect(harness.order).toContain('session:load');
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'signedOut',
+      sessionUsable: false,
+      errorCode: null,
+      retryAction: null,
+      notice: null,
+    });
+  });
+
+  it('retains active transaction recovery when no durable token exists', async () => {
+    const harness = makeHarness();
+    await harness.persist(activeTransaction);
+
+    await harness.coordinator.initialize();
+
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'error',
+      errorCode: 'interrupted',
+    });
+    expect(harness.tokenTransport.requests).toHaveLength(0);
+  });
+
+  it('restores a durable token when transaction discovery rejects', async () => {
+    const harness = makeHarness();
+    harness.preferences.getFailure = new Error('SECRET-transaction-read');
+    harness.sessionStore.refreshToken = 'SECRET-durable-token';
+    prepareSuccessfulRefresh(harness);
+
+    await harness.coordinator.initialize();
+
+    expect(harness.tokenTransport.requests[0]?.data).toContain('grant_type=refresh_token');
+    expect(harness.coordinator.state.phase).toBe('authenticated');
+  });
+
+  it('keeps a Keychain operational failure retryable despite a residual transaction', async () => {
+    const harness = makeHarness();
+    await harness.persist(activeTransaction);
+    harness.sessionStore.loadFailure = new MobileSessionStoreError('unavailable');
+
+    await harness.coordinator.initialize();
+
+    expect(harness.installationStore.readCalls).toBe(1);
+    expect(harness.preferences.calls).toContain('preferences:get');
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'error',
+      errorCode: 'session_restore_failed',
+      retryAction: 'restore',
+    });
+  });
+
+  it('persists a rotated refresh token before API verification and promotion', async () => {
+    const harness = makeHarness();
+    harness.sessionStore.refreshToken = 'SECRET-old-refresh-token';
+    prepareSuccessfulRefresh(harness, {
+      rotatedRefreshToken: 'SECRET-rotated-refresh-token',
+    });
+
+    await harness.coordinator.initialize();
+
+    expectOrderedCalls(harness.order, [
+      'token:refresh',
+      'session:save:SECRET-rotated-refresh-token',
+      'fetch:/auth/session',
+    ]);
+    expect(harness.sessionStore.refreshToken).toBe('SECRET-rotated-refresh-token');
+    expect(harness.coordinator.state.phase).toBe('authenticated');
+  });
+
+  it('retains the previous durable refresh token when rotation is omitted', async () => {
+    const harness = makeHarness();
+    harness.sessionStore.refreshToken = 'SECRET-existing-refresh-token';
+    prepareSuccessfulRefresh(harness);
+
+    await harness.coordinator.initialize();
+
+    expect(harness.sessionStore.saveAttempts).toEqual([]);
+    expect(harness.sessionStore.refreshToken).toBe('SECRET-existing-refresh-token');
+    expect(harness.coordinator.state.phase).toBe('authenticated');
+  });
+
+  it('clears a refreshed subject that disagrees with the verified API user', async () => {
+    const harness = makeHarness();
+    harness.sessionStore.refreshToken = 'SECRET-durable-token';
+    prepareSuccessfulRefresh(harness, { subject: 'different-user' });
+
+    await harness.coordinator.initialize();
+
+    expect(harness.sessionStore.clearCalls).toBe(1);
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'signedOut',
+      sessionUsable: false,
+      errorCode: null,
+      retryAction: null,
+      notice: 'session_unusable',
+    });
+  });
+});
+
+describe('restore terminal and retryable classification', () => {
+  function makeRestoreHarness() {
+    const harness = makeHarness();
+    harness.sessionStore.refreshToken = 'SECRET-durable-token';
+    return harness;
+  }
+
+  it.each([
+    [400, { error: 'invalid_grant' }],
+    [401, { error: 'unauthorized' }],
+    [403, { error: 'forbidden' }],
+  ] as const)('clears terminal refresh failures with status %s', async (status, data) => {
+    const harness = makeRestoreHarness();
+    harness.tokenTransport.result = { status, data };
+
+    await harness.coordinator.initialize();
+
+    expect(harness.sessionStore.clearCalls).toBe(1);
+    expect(harness.coordinator.state.notice).toBe('session_unusable');
+  });
+
+  it.each([429, 500, 503])(
+    'preserves the durable token for retryable status %s',
+    async (status) => {
+      const harness = makeRestoreHarness();
+      harness.tokenTransport.result = { status, data: {} };
+
+      await harness.coordinator.initialize();
+
+      expect(harness.sessionStore.clearCalls).toBe(0);
+      expect(harness.sessionStore.refreshToken).toBe('SECRET-durable-token');
+      expect(harness.coordinator.state).toMatchObject({
+        errorCode: 'session_restore_failed',
+        retryAction: 'restore',
+      });
+    },
+  );
+
+  it('preserves the durable token after a refresh network rejection', async () => {
+    const harness = makeRestoreHarness();
+    harness.tokenTransport.failure = new Error('SECRET-refresh-network');
+
+    await harness.coordinator.initialize();
+
+    expect(harness.sessionStore.clearCalls).toBe(0);
+    expect(harness.coordinator.state).toMatchObject({
+      errorCode: 'session_restore_failed',
+      retryAction: 'restore',
+    });
+  });
+
+  it('clears a malformed successful refresh response', async () => {
+    const harness = makeRestoreHarness();
+    harness.tokenTransport.result = {
+      status: 200,
+      data: {
+        access_token: 'SECRET-access-token',
+        expires_in: 3_600,
+      },
+    };
+
+    await harness.coordinator.initialize();
+
+    expect(harness.sessionStore.clearCalls).toBe(1);
+    expect(harness.coordinator.state.notice).toBe('session_unusable');
+  });
+
+  it('clears a refresh response whose ID-token claims are invalid', async () => {
+    const harness = makeRestoreHarness();
+    prepareSuccessfulRefresh(harness, { subject: '' });
+
+    await harness.coordinator.initialize();
+
+    expect(harness.sessionStore.clearCalls).toBe(1);
+    expect(harness.coordinator.state.notice).toBe('session_unusable');
+  });
+
+  it('clears a corrupt local token before showing the terminal notice', async () => {
+    const harness = makeHarness();
+    harness.sessionStore.loadFailure = new MobileSessionStoreError('corrupt');
+
+    await harness.coordinator.initialize();
+
+    expect(harness.sessionStore.clearCalls).toBe(1);
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'signedOut',
+      sessionUsable: false,
+      errorCode: null,
+      retryAction: null,
+      notice: 'session_unusable',
+    });
+  });
+
+  it('fails closed when corrupt local token deletion is unavailable', async () => {
+    const harness = makeHarness();
+    harness.sessionStore.loadFailure = new MobileSessionStoreError('corrupt');
+    harness.sessionStore.clearFailure = new Error('SECRET-corrupt-delete');
+
+    await harness.coordinator.initialize();
+
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'signedOut',
+      errorCode: 'session_cleanup_failed',
+      retryAction: 'cleanup',
+      notice: 'cleanup_incomplete',
+    });
+  });
+
+  it.each([401, 403])(
+    'clears the durable token after restored API verification status %s',
+    async (status) => {
+      const harness = makeRestoreHarness();
+      prepareSuccessfulRefresh(harness);
+      harness.sessionFetch.mockResolvedValueOnce(response(status, { authenticated: false }));
+
+      await harness.coordinator.initialize();
+
+      expect(harness.sessionStore.clearCalls).toBe(1);
+      expect(harness.coordinator.state.notice).toBe('session_unusable');
+    },
+  );
+
+  it.each([429, 500, 503])(
+    'retains the verified candidate for API retry after status %s',
+    async (status) => {
+      const harness = makeRestoreHarness();
+      prepareSuccessfulRefresh(harness);
+      harness.sessionFetch.mockResolvedValueOnce(response(status, { error: 'temporary' }));
+
+      await harness.coordinator.initialize();
+
+      expect(harness.sessionStore.clearCalls).toBe(0);
+      expect(harness.coordinator.state).toMatchObject({
+        errorCode: 'session_verification_failed',
+        retryAction: 'verify',
+      });
+    },
+  );
+
+  it('retains the verified candidate after an API network rejection', async () => {
+    const harness = makeRestoreHarness();
+    prepareSuccessfulRefresh(harness);
+    harness.sessionFetch.mockRejectedValueOnce(new Error('SECRET-api-network'));
+
+    await harness.coordinator.initialize();
+
+    expect(harness.sessionStore.clearCalls).toBe(0);
+    expect(harness.coordinator.state).toMatchObject({
+      errorCode: 'session_verification_failed',
+      retryAction: 'verify',
+    });
+  });
+});
+
+describe('generalized retry dispatch', () => {
+  it('retries restore from the refresh grant', async () => {
+    const harness = makeHarness();
+    harness.sessionStore.refreshToken = 'SECRET-durable-token';
+    harness.tokenTransport.result = { status: 503, data: {} };
+    await harness.coordinator.initialize();
+    prepareSuccessfulRefresh(harness);
+
+    await harness.coordinator.retryCurrentOperation();
+
+    expect(harness.tokenTransport.requests).toHaveLength(2);
+    expect(harness.tokenTransport.requests[1]?.data).toContain('grant_type=refresh_token');
+    expect(harness.coordinator.state.phase).toBe('authenticated');
+  });
+
+  it('retries active-session refresh through the candidate pipeline', async () => {
+    const harness = makeHarness();
+    harness.sessionStore.refreshToken = 'SECRET-durable-token';
+    prepareSuccessfulRefresh(harness);
+    await harness.coordinator.initialize();
+    Object.assign(toRaw(harness.coordinator.state) as MobileAuthState, {
+      phase: 'error',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: 'session_refresh_failed',
+      retryAction: 'refresh',
+      notice: null,
+      user: null,
+    });
+    prepareSuccessfulRefresh(harness, {
+      rotatedRefreshToken: 'SECRET-refreshed-again-token',
+    });
+
+    await harness.coordinator.retryCurrentOperation();
+
+    expect(harness.tokenTransport.requests).toHaveLength(2);
+    expect(harness.sessionStore.refreshToken).toBe('SECRET-refreshed-again-token');
+    expect(harness.coordinator.state.phase).toBe('authenticated');
+  });
+
+  it('retries persistence without repeating refresh or API verification', async () => {
+    const harness = makeHarness();
+    harness.sessionStore.refreshToken = 'SECRET-old-token';
+    prepareSuccessfulRefresh(harness, { rotatedRefreshToken: 'SECRET-rotated-token' });
+    harness.sessionStore.saveFailure = new Error('SECRET-save');
+    await harness.coordinator.initialize();
+
+    expect(harness.coordinator.state.retryAction).toBe('persist');
+    harness.sessionStore.saveFailure = undefined;
+    await harness.coordinator.retryCurrentOperation();
+
+    expect(harness.tokenTransport.requests).toHaveLength(1);
+    expect(harness.sessionFetch).toHaveBeenCalledOnce();
+    expect(harness.sessionStore.saveAttempts).toEqual([
+      'SECRET-rotated-token',
+      'SECRET-rotated-token',
+    ]);
+  });
+
+  it('retries API verification without repeating refresh or Keychain persistence', async () => {
+    const harness = makeHarness();
+    harness.sessionStore.refreshToken = 'SECRET-durable-token';
+    prepareSuccessfulRefresh(harness);
+    harness.sessionFetch.mockResolvedValueOnce(response(500, { error: 'temporary' }));
+    await harness.coordinator.initialize();
+    harness.sessionFetch.mockResolvedValueOnce(
+      response(200, {
+        authenticated: true,
+        user: { userId: 'user-123', email: null },
+      }),
+    );
+
+    await harness.coordinator.retryCurrentOperation();
+
+    expect(harness.tokenTransport.requests).toHaveLength(1);
+    expect(harness.sessionStore.saveAttempts).toEqual([]);
+    expect(harness.sessionFetch).toHaveBeenCalledTimes(2);
+    expect(harness.coordinator.state.phase).toBe('authenticated');
+  });
+
+  it('retries terminal cleanup without repeating token or API requests', async () => {
+    const harness = makeHarness();
+    harness.sessionStore.refreshToken = 'SECRET-durable-token';
+    harness.tokenTransport.result = { status: 400, data: { error: 'invalid_grant' } };
+    harness.sessionStore.clearFailure = new Error('SECRET-clear');
+    await harness.coordinator.initialize();
+
+    expect(harness.coordinator.state.retryAction).toBe('cleanup');
+    harness.sessionStore.clearFailure = undefined;
+    await harness.coordinator.retryCurrentOperation();
+
+    expect(harness.tokenTransport.requests).toHaveLength(1);
+    expect(harness.sessionFetch).not.toHaveBeenCalled();
+    expect(harness.sessionStore.clearCalls).toBe(2);
+    expect(harness.coordinator.state.notice).toBe('session_unusable');
+  });
+
+  it('retries installation cleanup by clearing before marking and resuming initialization', async () => {
+    const harness = makeHarness();
+    harness.installationStore.marked = false;
+    harness.sessionStore.clearFailure = new Error('SECRET-clear');
+    await harness.coordinator.initialize();
+
+    harness.sessionStore.clearFailure = undefined;
+    await harness.coordinator.retryCurrentOperation();
+
+    expectOrderedCalls(harness.order, ['session:clear', 'session:clear', 'installation:mark']);
+    expect(harness.tokenTransport.requests).toHaveLength(0);
+    expect(harness.sessionFetch).not.toHaveBeenCalled();
+    expect(harness.coordinator.state.phase).toBe('signedOut');
   });
 });
 
@@ -1371,7 +1838,7 @@ describe('callback completion and cleanup', () => {
     expect(harness.browser.openCalls).toEqual([]);
 
     harness.sessionStore.saveFailure = undefined;
-    await harness.coordinator.retrySessionVerification();
+    await harness.coordinator.retryCurrentOperation();
 
     expect(harness.sessionStore.saveAttempts).toEqual([
       'SECRET-refresh-token',
@@ -1533,7 +2000,7 @@ describe('callback completion and cleanup', () => {
         user: { userId: 'retry-user', email: null },
       }),
     );
-    await harness.coordinator.retrySessionVerification();
+    await harness.coordinator.retryCurrentOperation();
 
     expect(harness.tokenTransport.requests).toHaveLength(1);
     expect(harness.coordinator.state.phase).toBe('authenticated');
@@ -1639,7 +2106,7 @@ describe('session verification', () => {
           user: { userId: 'retry-user', email: null },
         }),
       );
-      await harness.coordinator.retrySessionVerification();
+      await harness.coordinator.retryCurrentOperation();
 
       expect(harness.tokenTransport.requests).toHaveLength(1);
       expect(harness.sessionFetch).toHaveBeenCalledTimes(2);

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { toRaw, watch } from 'vue';
+import { watch } from 'vue';
 import {
   MOBILE_OAUTH_CALLBACK_URI,
   MOBILE_OAUTH_TRANSACTION_KEY,
@@ -23,126 +23,13 @@ import {
 } from '../auth/mobile-installation-store';
 import { MobileSessionStoreError, type MobileSessionStore } from '../auth/mobile-session-store';
 import { createMobileAuthCoordinator, MOBILE_AUTH_NETWORK_TIMEOUT_MS } from './mobile-auth';
+import {
+  captureConsoleCalls as createConsoleCapture,
+  createSecretLeakAssertions,
+  searchable,
+} from '../test/secret-leak-helpers';
 
 const NOW = 1_000_000;
-
-const SECRET_SENTINELS = [
-  'SECRET-access-token',
-  'SECRET-id-token',
-  'SECRET-refresh-token',
-  'SECRET-rotated-refresh-token',
-] as const;
-
-const LOG_AND_DOM_SENTINELS = [
-  ...SECRET_SENTINELS,
-  'SECRET-authorization-url',
-  'SECRET-callback-code',
-  'SECRET-code-verifier',
-  'SECRET-nonce',
-  'SECRET-claim-email',
-] as const;
-
-const NON_SCHEMA_STORAGE_SENTINELS = [
-  'SECRET-callback-code',
-  'SECRET-claim-email',
-  'SECRET-raw-request',
-  'SECRET-raw-response',
-  'SECRET-native-exception',
-] as const;
-
-function searchable(value: unknown): string {
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
-}
-
-function storageSnapshot(storage: Storage): string {
-  return Array.from({ length: storage.length }, (_, index) => {
-    const key = storage.key(index) ?? '';
-    return `${key}=${storage.getItem(key) ?? ''}`;
-  }).join('\n');
-}
-
-function expectApprovedPreferenceWrites(preferenceCalls: unknown[][]): void {
-  const installationKey = createMobileInstallationKey(config);
-
-  for (const call of preferenceCalls) {
-    expect(call).toHaveLength(1);
-    const options = call[0];
-    expect(options).toEqual(
-      expect.objectContaining({
-        key: expect.any(String),
-        value: expect.any(String),
-      }),
-    );
-    const { key, value } = options as { key: string; value: string };
-    expect(Object.keys(options as object).sort()).toEqual(['key', 'value']);
-
-    if (key === MOBILE_OAUTH_TRANSACTION_KEY) {
-      let parsed: unknown = null;
-      try {
-        parsed = JSON.parse(value);
-      } catch {
-        expect.fail('OAuth transaction Preferences value must be valid JSON');
-      }
-      expect(parsed).toEqual(
-        expect.objectContaining({
-          state: expect.any(String),
-          codeVerifier: expect.any(String),
-          nonce: expect.any(String),
-          createdAt: expect.any(Number),
-        }),
-      );
-      const transaction = parsed as Record<string, unknown>;
-      expect(Object.keys(transaction).sort()).toEqual([
-        'codeVerifier',
-        'createdAt',
-        'nonce',
-        'state',
-      ]);
-      expect((transaction.state as string).length).toBeGreaterThan(0);
-      expect((transaction.codeVerifier as string).length).toBeGreaterThan(0);
-      expect((transaction.nonce as string).length).toBeGreaterThan(0);
-      expect(Number.isFinite(transaction.createdAt)).toBe(true);
-      continue;
-    }
-
-    expect(key).toBe(installationKey);
-    expect(value).toBe('1');
-  }
-}
-
-function expectNoSecretLeak(input: {
-  consoleCalls: unknown[][];
-  preferenceCalls: unknown[][];
-  renderedText?: string;
-}): void {
-  const logsAndDom = [
-    searchable(input.consoleCalls),
-    input.renderedText ?? document.body.textContent ?? '',
-  ].join('\n');
-  const browserAndPreferenceStorage = [
-    searchable(input.preferenceCalls),
-    storageSnapshot(window.localStorage),
-    storageSnapshot(window.sessionStorage),
-  ].join('\n');
-
-  for (const secret of LOG_AND_DOM_SENTINELS) {
-    expect(logsAndDom).not.toContain(secret);
-  }
-  expect(logsAndDom).not.toContain('SECRET-');
-  for (const secret of SECRET_SENTINELS) {
-    expect(browserAndPreferenceStorage).not.toContain(secret);
-  }
-  for (const secret of NON_SCHEMA_STORAGE_SENTINELS) {
-    expect(browserAndPreferenceStorage).not.toContain(secret);
-  }
-  expectApprovedPreferenceWrites(input.preferenceCalls);
-  expect(storageSnapshot(window.localStorage)).toBe('');
-  expect(storageSnapshot(window.sessionStorage)).toBe('');
-}
 
 const config: MobileOAuthConfig = {
   apiUrl: 'https://vela.example/api/',
@@ -152,6 +39,10 @@ const config: MobileOAuthConfig = {
   region: 'us-east-1',
   callbackUri: MOBILE_OAUTH_CALLBACK_URI,
 };
+
+const { expectNoSecretLeak } = createSecretLeakAssertions({
+  installationKey: createMobileInstallationKey(config),
+});
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -719,19 +610,7 @@ const securityTransaction: OAuthTransaction = {
 function captureConsoleCalls(): {
   calls: () => unknown[][];
 } {
-  const spies = (['debug', 'info', 'log', 'warn', 'error'] as const).map((method) =>
-    vi.spyOn(console, method).mockImplementation(() => undefined),
-  );
-  return {
-    calls: () =>
-      spies.flatMap((spy) =>
-        spy.mock.calls.map((call) =>
-          call.map((value) =>
-            value instanceof Error ? { ...value, name: value.name, message: value.message } : value,
-          ),
-        ),
-      ),
-  };
+  return createConsoleCapture();
 }
 
 function prepareSentinelExchange(harness: ReturnType<typeof makeHarness>): void {
@@ -930,7 +809,7 @@ describe('mobile auth initialization', () => {
     harness.sessionFetch.mockResolvedValueOnce(
       response(200, {
         authenticated: true,
-        user: { userId: 'user-1', email: null },
+        user: { userId: 'user-123', email: null },
       }),
     );
     await harness.coordinator.initialize();
@@ -944,7 +823,7 @@ describe('mobile auth initialization', () => {
       errorCode: null,
       retryAction: null,
       notice: null,
-      user: { userId: 'user-1', email: null },
+      user: { userId: 'user-123', email: null },
     });
   });
 
@@ -1725,26 +1604,18 @@ describe('generalized retry dispatch', () => {
   });
 
   it('retries active-session refresh through the candidate pipeline', async () => {
-    const harness = makeHarness();
-    harness.sessionStore.refreshToken = 'SECRET-durable-token';
-    prepareSuccessfulRefresh(harness);
-    await harness.coordinator.initialize();
-    Object.assign(toRaw(harness.coordinator.state) as MobileAuthState, {
-      phase: 'error',
-      operation: 'idle',
-      sessionUsable: false,
-      errorCode: 'session_refresh_failed',
-      retryAction: 'refresh',
-      notice: null,
-      user: null,
-    });
+    const harness = await arrangeBlockingRetry('refresh');
+    harness.tokenTransport.failure = undefined;
     prepareSuccessfulRefresh(harness, {
       rotatedRefreshToken: 'SECRET-refreshed-again-token',
+      claimExpirySeconds: 10_000,
     });
 
     await harness.coordinator.retryCurrentOperation();
 
-    expect(harness.tokenTransport.requests).toHaveLength(2);
+    const refreshes = refreshRequests(harness);
+    expect(refreshes).toHaveLength(2);
+    expect(refreshes[1]?.data).toContain('grant_type=refresh_token');
     expect(harness.sessionStore.refreshToken).toBe('SECRET-refreshed-again-token');
     expect(harness.coordinator.state.phase).toBe('authenticated');
   });
@@ -3304,7 +3175,7 @@ describe('callback completion and cleanup', () => {
     harness.sessionFetch.mockResolvedValueOnce(
       response(200, {
         authenticated: true,
-        user: { userId: 'retry-user', email: null },
+        user: { userId: 'user-123', email: null },
       }),
     );
     await harness.coordinator.retryCurrentOperation();
@@ -3410,7 +3281,7 @@ describe('session verification', () => {
       harness.sessionFetch.mockResolvedValueOnce(
         response(200, {
           authenticated: true,
-          user: { userId: 'retry-user', email: null },
+          user: { userId: 'user-123', email: null },
         }),
       );
       await harness.coordinator.retryCurrentOperation();
@@ -3424,7 +3295,7 @@ describe('session verification', () => {
         errorCode: null,
         retryAction: null,
         notice: null,
-        user: { userId: 'retry-user', email: null },
+        user: { userId: 'user-123', email: null },
       });
     },
   );

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -64,6 +64,7 @@ function idToken(transaction: OAuthTransaction, overrides: Record<string, unknow
     token_use: 'id',
     aud: config.mobileClientId,
     iss: `https://cognito-idp.${config.region}.amazonaws.com/${config.userPoolId}`,
+    sub: 'user-123',
     nonce: transaction.nonce,
     exp: 2_000,
     ...overrides,
@@ -911,12 +912,12 @@ describe('callback completion and cleanup', () => {
       null,
       'code_exchange_failed',
     ],
-    ['invalid JSON', { status: 200, data: '{not-json' }, null, 'code_exchange_failed'],
+    ['invalid JSON', { status: 200, data: '{not-json' }, null, 'token_validation_failed'],
     [
       'invalid shape',
       { status: 200, data: { id_token: 'SECRET-id' } },
       null,
-      'code_exchange_failed',
+      'token_validation_failed',
     ],
   ] as const)(
     'maps %s safely and clears the transaction',
@@ -945,6 +946,7 @@ describe('callback completion and cleanup', () => {
       data: {
         access_token: 'SECRET-access-token',
         id_token: idToken(activeTransaction, { nonce: 'SECRET-wrong-nonce' }),
+        refresh_token: 'SECRET-refresh-token',
         expires_in: 3_600,
       },
     };
@@ -958,6 +960,25 @@ describe('callback completion and cleanup', () => {
       errorCode: 'token_validation_failed',
     });
     expect(harness.sessionFetch).not.toHaveBeenCalled();
+  });
+
+  it('maps a successful callback response without a refresh token to token validation failure', async () => {
+    const harness = makeHarness();
+    await harness.coordinator.initialize();
+    await harness.coordinator.startSignIn();
+    const transaction = harness.preferences.transaction();
+    harness.tokenTransport.result = {
+      status: 200,
+      data: {
+        access_token: 'access',
+        id_token: idToken(transaction),
+        expires_in: 3_600,
+      },
+    };
+
+    harness.app.emit(callback(transaction));
+    await harness.flush();
+    expect(harness.coordinator.state.errorCode).toBe('token_validation_failed');
   });
 
   it('maps transaction-load failure safely without exchanging the code', async () => {
@@ -1319,6 +1340,7 @@ describe('serialization, disposal, and secret handling', () => {
       data: {
         access_token: 'SECRET-access-token',
         id_token: idToken(activeTransaction),
+        refresh_token: 'SECRET-refresh-token',
         expires_in: 3_600,
       },
     });

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -793,6 +793,76 @@ describe('mobile auth initialization', () => {
     ).toThrow('invalid_mobile_auth_state');
   });
 
+  it.each([
+    {
+      label: 'restore failure outside initialization',
+      value: {
+        phase: 'error',
+        operation: 'idle',
+        sessionUsable: false,
+        errorCode: 'session_restore_failed',
+        retryAction: 'restore',
+        notice: null,
+        user: null,
+      } satisfies MobileAuthState,
+    },
+    {
+      label: 'sign-out work that already claims signed-out phase',
+      value: {
+        phase: 'signedOut',
+        operation: 'signingOut',
+        sessionUsable: false,
+        errorCode: null,
+        retryAction: null,
+        notice: null,
+        user: null,
+      } satisfies MobileAuthState,
+    },
+    {
+      label: 'authenticated sign-out work without its originating user',
+      value: {
+        phase: 'authenticated',
+        operation: 'signingOut',
+        sessionUsable: false,
+        errorCode: null,
+        retryAction: null,
+        notice: null,
+        user: null,
+      } satisfies MobileAuthState,
+    },
+    {
+      label: 'initialization cleanup carrying an authenticated user',
+      value: {
+        phase: 'initializing',
+        operation: 'cleaningUp',
+        sessionUsable: false,
+        errorCode: null,
+        retryAction: null,
+        notice: null,
+        user: { userId: 'user-1', email: null },
+      } satisfies MobileAuthState,
+    },
+    {
+      label: 'authenticated cleanup without its originating user',
+      value: {
+        phase: 'authenticated',
+        operation: 'cleaningUp',
+        sessionUsable: false,
+        errorCode: null,
+        retryAction: null,
+        notice: null,
+        user: null,
+      } satisfies MobileAuthState,
+    },
+  ])('rejects $label', ({ value }) => {
+    expect(() =>
+      assertMobileAuthState(value, {
+        activeBundle: null,
+        now: NOW,
+      }),
+    ).toThrow('invalid_mobile_auth_state');
+  });
+
   it('publishes the complete authenticated tuple after verification', async () => {
     const harness = makeHarness();
     await harness.persist(activeTransaction);
@@ -881,6 +951,27 @@ describe('mobile auth initialization', () => {
     expect(harness.installationStore.marked).toBe(true);
     expect(harness.tokenTransport.requests).toHaveLength(0);
     expect(harness.sessionStore.refreshToken).toBeNull();
+    expect(harness.order).not.toContain('session:load');
+  });
+
+  it('does not let a slow Keychain load delay first-install reset', async () => {
+    const harness = makeHarness();
+    const loadGate = deferred<void>();
+    harness.installationStore.marked = false;
+    harness.sessionStore.refreshToken = 'SECRET-reinstall-residue';
+    harness.sessionStore.loadGate = loadGate.promise;
+
+    const initialization = harness.coordinator.initialize();
+    try {
+      await vi.waitFor(() => expect(harness.installationStore.markCalls).toBe(1), {
+        timeout: 100,
+      });
+      expect(harness.order).not.toContain('session:load');
+      await initialization;
+    } finally {
+      loadGate.resolve();
+      await initialization;
+    }
   });
 
   it('fails closed when first-install cleanup cannot complete', async () => {
@@ -900,6 +991,7 @@ describe('mobile auth initialization', () => {
       user: null,
     });
     expect(harness.order).not.toContain('app:getLaunchUrl');
+    expect(harness.order).not.toContain('session:load');
     expect(harness.preferences.calls).toEqual([]);
     expect(harness.installationStore.markCalls).toBe(0);
   });
@@ -917,7 +1009,7 @@ describe('mobile auth initialization', () => {
       notice: 'cleanup_incomplete',
     });
     expect(harness.sessionStore.clearCalls).toBe(0);
-    expect(harness.order).toContain('session:load');
+    expect(harness.order).not.toContain('session:load');
     expect(harness.order).not.toContain('app:getLaunchUrl');
     expect(harness.preferences.calls).toEqual([]);
   });
@@ -936,6 +1028,7 @@ describe('mobile auth initialization', () => {
     ]);
     expect(harness.sessionStore.clearCalls).toBe(1);
     expect(harness.installationStore.marked).toBe(false);
+    expect(harness.order).not.toContain('session:load');
     expect(harness.order).not.toContain('app:getLaunchUrl');
     expect(harness.coordinator.state).toMatchObject({
       phase: 'signedOut',
@@ -1223,6 +1316,24 @@ describe('durable session restoration and cold-launch precedence', () => {
     expect(harness.coordinator.state.phase).toBe('authenticated');
   });
 
+  it('restores a durable token when cold-launch URL discovery fails', async () => {
+    const harness = makeHarness();
+    harness.app.failLaunch = true;
+    harness.sessionStore.refreshToken = 'SECRET-durable-token';
+    prepareSuccessfulRefresh(harness);
+
+    await harness.coordinator.initialize();
+
+    expect(harness.tokenTransport.requests).toHaveLength(1);
+    expect(harness.tokenTransport.requests[0]?.data).toContain('grant_type=refresh_token');
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      operation: 'idle',
+      sessionUsable: true,
+      errorCode: null,
+    });
+  });
+
   it('restores and verifies before publishing a usable session', async () => {
     const harness = makeHarness();
     harness.sessionStore.refreshToken = 'SECRET-durable-token';
@@ -1302,7 +1413,7 @@ describe('durable session restoration and cold-launch precedence', () => {
     expect(harness.installationStore.readCalls).toBe(1);
     expect(harness.preferences.calls).toContain('preferences:get');
     expect(harness.coordinator.state).toMatchObject({
-      phase: 'error',
+      phase: 'initializing',
       errorCode: 'session_restore_failed',
       retryAction: 'restore',
     });
@@ -1377,6 +1488,26 @@ describe('restore terminal and retryable classification', () => {
     expect(harness.coordinator.state.notice).toBe('session_unusable');
   });
 
+  it('keeps terminal restore cleanup in initializing until deletion resolves', async () => {
+    const harness = makeRestoreHarness();
+    const clearGate = deferred<void>();
+    harness.tokenTransport.result = { status: 400, data: { error: 'invalid_grant' } };
+    harness.sessionStore.clearGate = clearGate.promise;
+
+    const initialization = harness.coordinator.initialize();
+    try {
+      await vi.waitFor(() => expect(harness.sessionStore.clearCalls).toBe(1));
+      expect(harness.coordinator.state).toMatchObject({
+        phase: 'initializing',
+        operation: 'cleaningUp',
+        sessionUsable: false,
+      });
+    } finally {
+      clearGate.resolve();
+      await initialization;
+    }
+  });
+
   it.each([429, 500, 503])(
     'preserves the durable token for retryable status %s',
     async (status) => {
@@ -1407,7 +1538,7 @@ describe('restore terminal and retryable classification', () => {
     });
   });
 
-  it('clears a malformed successful refresh response', async () => {
+  it('preserves the durable token after a malformed successful refresh response', async () => {
     const harness = makeRestoreHarness();
     harness.tokenTransport.result = {
       status: 200,
@@ -1419,8 +1550,16 @@ describe('restore terminal and retryable classification', () => {
 
     await harness.coordinator.initialize();
 
-    expect(harness.sessionStore.clearCalls).toBe(1);
-    expect(harness.coordinator.state.notice).toBe('session_unusable');
+    expect(harness.sessionStore.clearCalls).toBe(0);
+    expect(harness.sessionStore.refreshToken).toBe('SECRET-durable-token');
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'initializing',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: 'session_restore_failed',
+      retryAction: 'restore',
+      notice: null,
+    });
   });
 
   it('clears a refresh response whose ID-token claims are invalid', async () => {
@@ -1621,6 +1760,29 @@ describe('generalized retry dispatch', () => {
     expect(harness.sessionFetch).not.toHaveBeenCalled();
     expect(harness.coordinator.state.phase).toBe('signedOut');
   });
+
+  it('retains signedOut while installation cleanup retry is unresolved', async () => {
+    const harness = makeHarness();
+    const markGate = deferred<void>();
+    harness.installationStore.marked = false;
+    harness.sessionStore.clearFailure = new Error('SECRET-clear');
+    await harness.coordinator.initialize();
+
+    harness.sessionStore.clearFailure = undefined;
+    harness.installationStore.markGate = markGate.promise;
+    const retry = harness.coordinator.retryCurrentOperation();
+    try {
+      await vi.waitFor(() => expect(harness.installationStore.markCalls).toBe(1));
+      expect(harness.coordinator.state).toMatchObject({
+        phase: 'signedOut',
+        operation: 'cleaningUp',
+        sessionUsable: false,
+      });
+    } finally {
+      markGate.resolve();
+      await retry;
+    }
+  });
 });
 
 describe('local sign-out and cleanup retry', () => {
@@ -1638,8 +1800,10 @@ describe('local sign-out and cleanup retry', () => {
     const result = harness.coordinator.signOut();
 
     expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
       operation: 'signingOut',
       sessionUsable: false,
+      user: { userId: 'user-123', email: 'person@example.com' },
     });
     await vi.waitFor(() => expect(harness.sessionStore.clearCalls).toBe(1));
     expect(harness.preferences.value).not.toBeNull();
@@ -1683,7 +1847,27 @@ describe('local sign-out and cleanup retry', () => {
     },
   );
 
-  it('reports incomplete Keychain cleanup without claiming sign-out success', async () => {
+  it('retains initializing while start-over cleanup is unresolved', async () => {
+    const harness = await arrangeBlockingRetry('restore');
+    const clearGate = deferred<void>();
+    harness.sessionStore.clearGate = clearGate.promise;
+
+    const signOut = harness.coordinator.signOut();
+    try {
+      await vi.waitFor(() => expect(harness.sessionStore.clearCalls).toBe(1));
+      expect(harness.coordinator.state).toMatchObject({
+        phase: 'initializing',
+        operation: 'signingOut',
+        sessionUsable: false,
+        user: null,
+      });
+    } finally {
+      clearGate.resolve();
+      await signOut;
+    }
+  });
+
+  it('clears PKCE state when Keychain cleanup fails without claiming sign-out success', async () => {
     const harness = makeHarness();
     await authenticate(harness);
     await harness.persist(activeTransaction);
@@ -1700,7 +1884,8 @@ describe('local sign-out and cleanup retry', () => {
       notice: 'cleanup_incomplete',
       user: null,
     });
-    expect(harness.preferences.value).not.toBeNull();
+    expect(harness.preferences.value).toBeNull();
+    expect(harness.preferences.calls).toContain('preferences:remove');
     expect(snapshot(harness.coordinator.state)).not.toContain('SECRET');
   });
 
@@ -1938,6 +2123,62 @@ describe('active-session lifecycle refresh', () => {
     await vi.advanceTimersByTimeAsync(1);
 
     expect(refreshRequests(harness)).toHaveLength(1);
+  });
+
+  it('preserves the active durable token after a malformed successful refresh response', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 61_000);
+    const durableRefreshToken = harness.sessionStore.refreshToken;
+    harness.tokenTransport.result = {
+      status: 200,
+      data: {
+        access_token: 'SECRET-malformed-access-token',
+        expires_in: 3_600,
+      },
+    };
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(harness.sessionStore.clearCalls).toBe(0);
+    expect(harness.sessionStore.refreshToken).toBe(durableRefreshToken);
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      operation: 'idle',
+      sessionUsable: true,
+      errorCode: 'session_refresh_failed',
+      retryAction: 'refresh',
+      notice: null,
+      user: { userId: 'user-123', email: 'person@example.com' },
+    });
+  });
+
+  it('keeps terminal active-session cleanup authenticated until deletion resolves', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 61_000);
+    const clearGate = deferred<void>();
+    harness.tokenTransport.result = {
+      status: 400,
+      data: { error: 'invalid_grant' },
+    };
+    harness.sessionStore.clearGate = clearGate.promise;
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    try {
+      await vi.waitFor(() => expect(harness.sessionStore.clearCalls).toBe(1));
+      expect(harness.coordinator.state).toMatchObject({
+        phase: 'authenticated',
+        operation: 'cleaningUp',
+        sessionUsable: false,
+        user: { userId: 'user-123', email: 'person@example.com' },
+      });
+    } finally {
+      clearGate.resolve();
+      await harness.flush();
+    }
   });
 
   it('cancels the foreground timer while inactive and rechecks on resume', async () => {

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -157,6 +157,7 @@ class FakeSessionStore implements MobileSessionStore {
   readonly saveAttempts: string[] = [];
   clearCalls = 0;
   saveGate: Promise<void> | undefined;
+  clearGate: Promise<void> | undefined;
   loadFailure: unknown;
   saveFailure: unknown;
   clearFailure: unknown;
@@ -180,6 +181,7 @@ class FakeSessionStore implements MobileSessionStore {
   async clearRefreshToken(): Promise<void> {
     this.order.push('session:clear');
     this.clearCalls += 1;
+    await this.clearGate;
     if (this.clearFailure) throw this.clearFailure;
     this.refreshToken = null;
   }
@@ -506,6 +508,49 @@ async function authenticateWithExpiry(
   };
   await harness.coordinator.initialize();
   await harness.coordinator.completeCallback(callback(activeTransaction));
+}
+
+async function authenticate(harness: ReturnType<typeof makeHarness>): Promise<void> {
+  await harness.persist(activeTransaction);
+  harness.prepareSuccessfulExchange(activeTransaction);
+  await harness.coordinator.initialize();
+  await harness.coordinator.completeCallback(callback(activeTransaction));
+}
+
+async function arrangeBlockingRetry(
+  retryAction: 'restore' | 'refresh' | 'persist' | 'verify',
+): Promise<ReturnType<typeof makeHarness>> {
+  if (retryAction === 'restore') {
+    const harness = makeHarness();
+    harness.sessionStore.refreshToken = 'SECRET-durable-token';
+    harness.tokenTransport.result = { status: 503, data: {} };
+    await harness.coordinator.initialize();
+    return harness;
+  }
+
+  if (retryAction === 'refresh') {
+    let currentNow = NOW;
+    const harness = makeHarness({ now: () => currentNow });
+    await authenticate(harness);
+    harness.tokenTransport.failure = new Error('SECRET-refresh-network');
+    currentNow += 3_541_000;
+    harness.app.emitState(true);
+    await harness.flush();
+    return harness;
+  }
+
+  const harness = makeHarness();
+  harness.sessionStore.refreshToken = 'SECRET-durable-token';
+  prepareSuccessfulRefresh(harness, {
+    ...(retryAction === 'persist' ? { rotatedRefreshToken: 'SECRET-rotated-refresh-token' } : {}),
+  });
+  if (retryAction === 'persist') {
+    harness.sessionStore.saveFailure = new Error('SECRET-persist');
+  } else {
+    harness.sessionFetch.mockResolvedValueOnce(response(503, { error: 'temporary' }));
+  }
+  await harness.coordinator.initialize();
+  return harness;
 }
 
 function refreshRequests(harness: ReturnType<typeof makeHarness>): MobileTokenRequest[] {
@@ -1373,6 +1418,304 @@ describe('generalized retry dispatch', () => {
     expect(harness.tokenTransport.requests).toHaveLength(0);
     expect(harness.sessionFetch).not.toHaveBeenCalled();
     expect(harness.coordinator.state.phase).toBe('signedOut');
+  });
+});
+
+describe('local sign-out and cleanup retry', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('hides content before asynchronous durable cleanup and preserves cleanup ordering', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    await harness.persist(activeTransaction);
+    const clearGate = deferred<void>();
+    harness.sessionStore.clearGate = clearGate.promise;
+
+    const result = harness.coordinator.signOut();
+
+    expect(harness.coordinator.state).toMatchObject({
+      operation: 'signingOut',
+      sessionUsable: false,
+    });
+    await vi.waitFor(() => expect(harness.sessionStore.clearCalls).toBe(1));
+    expect(harness.preferences.value).not.toBeNull();
+    expect(harness.preferences.calls.at(-1)).not.toBe('preferences:remove');
+
+    clearGate.resolve();
+    await result;
+
+    expectOrderedCalls(harness.order, ['session:clear', 'preferences:remove']);
+    expect(harness.coordinator.state).toEqual({
+      phase: 'signedOut',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: null,
+      retryAction: null,
+      notice: null,
+      user: null,
+    });
+  });
+
+  it.each(['restore', 'refresh', 'persist', 'verify'] as const)(
+    'allows start-over cleanup from blocking %s recovery',
+    async (retryAction) => {
+      const harness = await arrangeBlockingRetry(retryAction);
+      expect(harness.coordinator.state.retryAction).toBe(retryAction);
+      await harness.persist(activeTransaction);
+
+      await harness.coordinator.signOut();
+
+      expect(harness.sessionStore.clearCalls).toBe(1);
+      expect(harness.preferences.value).toBeNull();
+      expect(harness.coordinator.state).toEqual({
+        phase: 'signedOut',
+        operation: 'idle',
+        sessionUsable: false,
+        errorCode: null,
+        retryAction: null,
+        notice: null,
+        user: null,
+      });
+    },
+  );
+
+  it('reports incomplete Keychain cleanup without claiming sign-out success', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    await harness.persist(activeTransaction);
+    harness.sessionStore.clearFailure = new Error('SECRET-delete-failure');
+
+    await harness.coordinator.signOut();
+
+    expect(harness.coordinator.state).toEqual({
+      phase: 'signedOut',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: 'session_cleanup_failed',
+      retryAction: 'cleanup',
+      notice: 'cleanup_incomplete',
+      user: null,
+    });
+    expect(harness.preferences.value).not.toBeNull();
+    expect(snapshot(harness.coordinator.state)).not.toContain('SECRET');
+  });
+
+  it('reports incomplete transaction cleanup after deleting the Keychain token', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    await harness.persist(activeTransaction);
+    harness.preferences.removeFailure = new Error('SECRET-transaction-delete');
+
+    await harness.coordinator.signOut();
+
+    expect(harness.sessionStore.refreshToken).toBeNull();
+    expect(harness.preferences.value).not.toBeNull();
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'signedOut',
+      sessionUsable: false,
+      errorCode: 'session_cleanup_failed',
+      retryAction: 'cleanup',
+      notice: 'cleanup_incomplete',
+    });
+    expect(snapshot(harness.coordinator.state)).not.toContain('SECRET');
+  });
+
+  it('retries sign-out cleanup to ordinary signed out', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    await harness.persist(activeTransaction);
+    harness.sessionStore.clearFailure = new Error('SECRET-delete-failure');
+    await harness.coordinator.signOut();
+
+    harness.sessionStore.clearFailure = undefined;
+    await harness.coordinator.retryCurrentOperation();
+
+    expect(harness.sessionStore.clearCalls).toBe(2);
+    expect(harness.preferences.value).toBeNull();
+    expect(harness.coordinator.state).toEqual({
+      phase: 'signedOut',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: null,
+      retryAction: null,
+      notice: null,
+      user: null,
+    });
+  });
+
+  it('keeps failed sign-out cleanup retryable until all cleanup succeeds', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    harness.sessionStore.clearFailure = new Error('SECRET-delete-failure');
+    await harness.coordinator.signOut();
+
+    await harness.coordinator.retryCurrentOperation();
+
+    expect(harness.sessionStore.clearCalls).toBe(2);
+    expect(harness.coordinator.state).toMatchObject({
+      errorCode: 'session_cleanup_failed',
+      retryAction: 'cleanup',
+      notice: 'cleanup_incomplete',
+    });
+  });
+
+  it('coalesces duplicate sign-out calls into one cleanup flight', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    const clearGate = deferred<void>();
+    harness.sessionStore.clearGate = clearGate.promise;
+
+    const first = harness.coordinator.signOut();
+    const second = harness.coordinator.signOut();
+
+    expect(second).toBe(first);
+    await vi.waitFor(() => expect(harness.sessionStore.clearCalls).toBe(1));
+    clearGate.resolve();
+    await Promise.all([first, second]);
+    expect(harness.sessionStore.clearCalls).toBe(1);
+  });
+
+  it('cancels proactive refresh and access-expiry timers', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 120_000);
+
+    await harness.coordinator.signOut();
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(refreshRequests(harness)).toHaveLength(0);
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'signedOut',
+      sessionUsable: false,
+      notice: null,
+    });
+  });
+
+  it('cancels a queued automatic refresh retry', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 61_000);
+    harness.tokenTransport.queuedFailures.push(new Error('SECRET-refresh-network'));
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(refreshRequests(harness)).toHaveLength(1);
+
+    await harness.coordinator.signOut();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(refreshRequests(harness)).toHaveLength(1);
+    expect(harness.coordinator.state.phase).toBe('signedOut');
+  });
+
+  it('prevents an in-flight refresh from republishing session capability', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 61_000);
+    const heldRefresh = deferred<{ status: number; data: unknown }>();
+    harness.tokenTransport.gate = heldRefresh.promise;
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(harness.coordinator.state.operation).toBe('refreshing');
+    const clearGate = deferred<void>();
+    harness.sessionStore.clearGate = clearGate.promise;
+
+    const signOut = harness.coordinator.signOut();
+    heldRefresh.resolve({
+      status: 200,
+      data: {
+        access_token: 'SECRET-late-access-token',
+        id_token: refreshedIdToken({ exp: 10_000 }),
+        expires_in: 3_600,
+      },
+    });
+    await vi.waitFor(() => expect(harness.sessionStore.clearCalls).toBe(1));
+
+    expect(harness.sessionFetch).toHaveBeenCalledOnce();
+    expect(harness.coordinator.state).toMatchObject({
+      operation: 'signingOut',
+      sessionUsable: false,
+    });
+    clearGate.resolve();
+    await signOut;
+    expect(harness.coordinator.state.phase).toBe('signedOut');
+  });
+
+  it('erases a failed pending candidate before the next sign-in', async () => {
+    const harness = await arrangeBlockingRetry('persist');
+    expect(harness.coordinator.state.retryAction).toBe('persist');
+    harness.sessionStore.saveFailure = undefined;
+
+    await harness.coordinator.signOut();
+    await harness.coordinator.startSignIn();
+    const replacement = harness.preferences.transaction();
+    harness.prepareSuccessfulExchange(replacement);
+    await harness.coordinator.completeCallback(callback(replacement));
+
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      sessionUsable: true,
+      errorCode: null,
+    });
+  });
+
+  it('retains the installation marker and makes no remote logout or browser request', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    const tokenRequestCount = harness.tokenTransport.requests.length;
+    const sessionRequestCount = harness.sessionFetch.mock.calls.length;
+    const browserOpenCount = harness.browser.openCalls.length;
+
+    await harness.coordinator.signOut();
+
+    expect(harness.installationStore.marked).toBe(true);
+    expect(harness.installationStore.markCalls).toBe(0);
+    expect(harness.tokenTransport.requests).toHaveLength(tokenRequestCount);
+    expect(harness.sessionFetch).toHaveBeenCalledTimes(sessionRequestCount);
+    expect(harness.browser.openCalls).toHaveLength(browserOpenCount);
+  });
+
+  it('dispose waits behind sign-out but never deletes durable state itself', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    const clearGate = deferred<void>();
+    harness.sessionStore.clearGate = clearGate.promise;
+
+    const signOut = harness.coordinator.signOut();
+    const dispose = harness.coordinator.dispose();
+    await vi.waitFor(() => expect(harness.sessionStore.clearCalls).toBe(1));
+    clearGate.resolve();
+    await signOut;
+    await dispose;
+
+    expect(harness.sessionStore.clearCalls).toBe(1);
+    expect(harness.preferences.value).toBeNull();
+  });
+
+  it('makes every public operation a no-op after disposal', async () => {
+    const harness = makeHarness();
+    harness.sessionStore.refreshToken = 'SECRET-durable-token';
+    await harness.coordinator.dispose();
+    const before = {
+      clearCalls: harness.sessionStore.clearCalls,
+      tokenRequests: harness.tokenTransport.requests.length,
+      browserOpens: harness.browser.openCalls.length,
+      preferenceCalls: harness.preferences.calls.length,
+    };
+
+    await harness.coordinator.initialize();
+    await harness.coordinator.startSignIn();
+    await harness.coordinator.completeCallback(callback(activeTransaction));
+    await harness.coordinator.retryCurrentOperation();
+    await harness.coordinator.signOut();
+
+    expect(harness.sessionStore.clearCalls).toBe(before.clearCalls);
+    expect(harness.tokenTransport.requests).toHaveLength(before.tokenRequests);
+    expect(harness.browser.openCalls).toHaveLength(before.browserOpens);
+    expect(harness.preferences.calls).toHaveLength(before.preferenceCalls);
+    expect(harness.sessionStore.refreshToken).toBe('SECRET-durable-token');
   });
 });
 

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -1567,6 +1567,107 @@ describe('active-session lifecycle refresh', () => {
     });
   });
 
+  it('closes capability at exact expiry while the refresh grant is still pending', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 61_000);
+    const heldRefresh = deferred<{ status: number; data: unknown }>();
+    harness.tokenTransport.gate = heldRefresh.promise;
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(harness.coordinator.state).toMatchObject({
+      operation: 'refreshing',
+      sessionUsable: true,
+    });
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(harness.coordinator.state.sessionUsable).toBe(true);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      operation: 'refreshing',
+      sessionUsable: false,
+      user: { userId: 'user-123', email: 'person@example.com' },
+    });
+    heldRefresh.reject(new Error('SECRET-late-refresh-failure'));
+    await harness.flush();
+    expect(harness.coordinator.state).toMatchObject({
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: 'session_refresh_failed',
+      retryAction: 'refresh',
+    });
+  });
+
+  it('closes capability at exact expiry while rotated-token persistence is pending', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 61_000);
+    prepareSuccessfulRefresh(harness, {
+      rotatedRefreshToken: 'SECRET-rotated-refresh-token',
+      claimExpirySeconds: 10_000,
+    });
+    const heldPersistence = deferred<void>();
+    harness.sessionStore.saveGate = heldPersistence.promise;
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(harness.coordinator.state).toMatchObject({
+      operation: 'persisting',
+      sessionUsable: true,
+    });
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      operation: 'persisting',
+      sessionUsable: false,
+    });
+    heldPersistence.resolve();
+    await harness.flush();
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      operation: 'idle',
+      sessionUsable: true,
+    });
+  });
+
+  it('closes capability at exact expiry while candidate verification is pending', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 61_000);
+    prepareSuccessfulRefresh(harness, { claimExpirySeconds: 10_000 });
+    const heldVerification = deferred<Response>();
+    harness.sessionFetch.mockImplementationOnce(async () => heldVerification.promise);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(harness.coordinator.state).toMatchObject({
+      operation: 'verifying',
+      sessionUsable: true,
+    });
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      operation: 'verifying',
+      sessionUsable: false,
+    });
+    heldVerification.resolve(
+      response(200, {
+        authenticated: true,
+        user: { userId: 'user-123', email: 'person@example.com' },
+      }),
+    );
+    await harness.flush();
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      operation: 'idle',
+      sessionUsable: true,
+    });
+  });
+
   it('retries rotated-candidate persistence without issuing another grant', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { toRaw, watch } from 'vue';
 import {
   MOBILE_OAUTH_CALLBACK_URI,
@@ -212,7 +212,8 @@ class FakeInstallationStore implements MobileInstallationStore {
 class FakeApp implements MobileAppAdapter {
   readonly order: string[];
   launchUrl: { url: string } | undefined;
-  listener: ((event: { url: string }) => void) | undefined;
+  urlListener: ((event: { url: string }) => void) | undefined;
+  stateListener: ((event: { isActive: boolean }) => void) | undefined;
   failAdd = false;
   failLaunch = false;
   removeCalls = 0;
@@ -231,7 +232,9 @@ class FakeApp implements MobileAppAdapter {
       throw new Error('SECRET-app-plugin-failure');
     }
     if (eventName === 'appUrlOpen') {
-      this.listener = listener as (event: { url: string }) => void;
+      this.urlListener = listener as (event: { url: string }) => void;
+    } else {
+      this.stateListener = listener as (event: { isActive: boolean }) => void;
     }
     return {
       remove: async () => {
@@ -239,7 +242,11 @@ class FakeApp implements MobileAppAdapter {
         if (this.failRemove) {
           throw new Error('SECRET-app-remove-failure');
         }
-        this.listener = undefined;
+        if (eventName === 'appUrlOpen') {
+          this.urlListener = undefined;
+        } else {
+          this.stateListener = undefined;
+        }
       },
     };
   }
@@ -253,7 +260,11 @@ class FakeApp implements MobileAppAdapter {
   }
 
   emit(url: string): void {
-    this.listener?.({ url });
+    this.urlListener?.({ url });
+  }
+
+  emitState(isActive: boolean): void {
+    this.stateListener?.({ isActive });
   }
 }
 
@@ -322,6 +333,7 @@ class FakeBrowser implements MobileBrowserAdapter {
 
 class FakeTokenTransport implements MobileTokenTransportAdapter {
   readonly requests: MobileTokenRequest[] = [];
+  readonly queuedFailures: unknown[] = [];
   result: { status: number; data: unknown } = { status: 500, data: {} };
   failure: unknown;
   gate: Promise<{ status: number; data: unknown }> | undefined;
@@ -335,6 +347,9 @@ class FakeTokenTransport implements MobileTokenTransportAdapter {
         ? 'token:refresh'
         : 'token:authorizationCode',
     );
+    if (this.queuedFailures.length > 0) {
+      throw this.queuedFailures.shift();
+    }
     if (this.failure) {
       throw this.failure;
     }
@@ -354,6 +369,7 @@ type HarnessOptions = {
   isSecureContext?: boolean;
   authConfig?: MobileOAuthConfig;
   isDevelopment?: boolean;
+  now?: () => number;
 };
 
 function makeHarness(options: HarnessOptions = {}) {
@@ -389,7 +405,7 @@ function makeHarness(options: HarnessOptions = {}) {
     crypto,
     isSecureContext: options.isSecureContext ?? true,
     fetch: sessionFetch as unknown as typeof fetch,
-    now: () => NOW,
+    now: options.now ?? (() => NOW),
     config: options.authConfig ?? config,
     isDevelopment: options.isDevelopment ?? false,
   });
@@ -445,17 +461,57 @@ function expectOrderedCalls(order: string[], sequence: string[]): void {
 
 function prepareSuccessfulRefresh(
   harness: ReturnType<typeof makeHarness>,
-  options: { subject?: string; rotatedRefreshToken?: string } = {},
+  options: {
+    subject?: string;
+    rotatedRefreshToken?: string;
+    expiresInSeconds?: number;
+    claimExpirySeconds?: number;
+  } = {},
 ): void {
   harness.tokenTransport.result = {
     status: 200,
     data: {
       access_token: 'SECRET-refreshed-access-token',
-      id_token: refreshedIdToken({ sub: options.subject ?? 'user-123' }),
-      expires_in: 3_600,
+      id_token: refreshedIdToken({
+        sub: options.subject ?? 'user-123',
+        ...(options.claimExpirySeconds === undefined ? {} : { exp: options.claimExpirySeconds }),
+      }),
+      expires_in: options.expiresInSeconds ?? 3_600,
       ...(options.rotatedRefreshToken ? { refresh_token: options.rotatedRefreshToken } : {}),
     },
   };
+}
+
+async function authenticateWithExpiry(
+  harness: ReturnType<typeof makeHarness>,
+  expiresAt: number,
+  clockNow = Date.now(),
+): Promise<void> {
+  const expiresInSeconds = (expiresAt - clockNow) / 1_000;
+  if (!Number.isInteger(expiresInSeconds) || expiresInSeconds <= 0) {
+    throw new Error('Test expiry must be a positive whole number of seconds');
+  }
+
+  await harness.persist(activeTransaction);
+  harness.tokenTransport.result = {
+    status: 200,
+    data: {
+      access_token: 'SECRET-access-token',
+      id_token: idToken(activeTransaction, {
+        exp: Math.ceil((expiresAt + 3_600_000) / 1_000),
+      }),
+      refresh_token: 'SECRET-refresh-token',
+      expires_in: expiresInSeconds,
+    },
+  };
+  await harness.coordinator.initialize();
+  await harness.coordinator.completeCallback(callback(activeTransaction));
+}
+
+function refreshRequests(harness: ReturnType<typeof makeHarness>): MobileTokenRequest[] {
+  return harness.tokenTransport.requests.filter((request) =>
+    request.data.includes('grant_type=refresh_token'),
+  );
 }
 
 function snapshot(state: Readonly<MobileAuthState>): string {
@@ -522,6 +578,7 @@ describe('mobile auth initialization', () => {
 
     expect(harness.order).toEqual([
       'app:add:appUrlOpen',
+      'app:add:appStateChange',
       'browser:add:browserFinished',
       'installation:isMarked',
       'session:load',
@@ -881,6 +938,7 @@ describe('mobile auth initialization', () => {
 
     expect(harness.order).toEqual([
       'app:add:appUrlOpen',
+      'app:add:appStateChange',
       'browser:add:browserFinished',
       'installation:isMarked',
       'session:load',
@@ -1315,6 +1373,308 @@ describe('generalized retry dispatch', () => {
     expect(harness.tokenTransport.requests).toHaveLength(0);
     expect(harness.sessionFetch).not.toHaveBeenCalled();
     expect(harness.coordinator.state.phase).toBe('signedOut');
+  });
+});
+
+describe('active-session lifecycle refresh', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('refreshes exactly 60 seconds before access expiry', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 3_600_000);
+    harness.tokenTransport.queuedFailures.push(new Error('SECRET-refresh-network'));
+
+    await vi.advanceTimersByTimeAsync(3_539_999);
+    expect(refreshRequests(harness)).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(refreshRequests(harness)).toHaveLength(1);
+  });
+
+  it('cancels the foreground timer while inactive and rechecks on resume', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 120_000);
+
+    harness.app.emitState(false);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(refreshRequests(harness)).toHaveLength(0);
+    harness.app.emitState(true);
+    await harness.flush();
+    expect(refreshRequests(harness)).toHaveLength(1);
+  });
+
+  it('reschedules from the absolute expiry when the app becomes active', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 180_000);
+    harness.app.emitState(false);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    harness.app.emitState(true);
+    await vi.advanceTimersByTimeAsync(89_999);
+    expect(refreshRequests(harness)).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(refreshRequests(harness)).toHaveLength(1);
+  });
+
+  it('refreshes immediately on resume inside the lead window', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 120_000);
+    harness.app.emitState(false);
+    await vi.advanceTimersByTimeAsync(70_000);
+    harness.tokenTransport.queuedFailures.push(new Error('SECRET-refresh-network'));
+
+    harness.app.emitState(true);
+    await harness.flush();
+
+    expect(refreshRequests(harness)).toHaveLength(1);
+  });
+
+  it('coalesces resume, automatic timer, and manual retry into one grant', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 120_000);
+    harness.tokenTransport.queuedFailures.push(new Error('SECRET-refresh-network'));
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    const heldRefresh = deferred<{ status: number; data: unknown }>();
+    harness.tokenTransport.gate = heldRefresh.promise;
+    const manualRetry = harness.coordinator.retryCurrentOperation();
+    await Promise.resolve();
+    await Promise.resolve();
+    harness.app.emitState(true);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(refreshRequests(harness)).toHaveLength(2);
+    heldRefresh.resolve({
+      status: 200,
+      data: {
+        access_token: 'SECRET-refreshed-access-token',
+        id_token: refreshedIdToken({ exp: 10_000 }),
+        expires_in: 3_600,
+      },
+    });
+    await manualRetry;
+  });
+
+  it('rechecks app activity at the serialized refresh queue head', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 61_000);
+    prepareSuccessfulRefresh(harness, { claimExpirySeconds: 10_000 });
+    harness.sessionFetch.mockResolvedValueOnce(response(500, { error: 'temporary' }));
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    const heldVerification = deferred<Response>();
+    harness.sessionFetch.mockImplementationOnce(async () => heldVerification.promise);
+    const manualRetry = harness.coordinator.retryCurrentOperation();
+    await Promise.resolve();
+    await Promise.resolve();
+    harness.app.emitState(true);
+    harness.app.emitState(false);
+    heldVerification.resolve(response(500, { error: 'temporary' }));
+    await manualRetry;
+    await harness.flush();
+
+    expect(refreshRequests(harness)).toHaveLength(1);
+  });
+
+  it('retries one soft failure after five seconds with enough lifetime', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 61_000);
+    harness.tokenTransport.queuedFailures.push(
+      new Error('SECRET-refresh-network-1'),
+      new Error('SECRET-refresh-network-2'),
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(harness.coordinator.state.sessionUsable).toBe(true);
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(refreshRequests(harness)).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refreshRequests(harness)).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(refreshRequests(harness)).toHaveLength(2);
+  });
+
+  it('does not retry automatically at the exact 20-second lifetime budget', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 20_000);
+    harness.tokenTransport.queuedFailures.push(new Error('SECRET-refresh-network'));
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(refreshRequests(harness)).toHaveLength(1);
+  });
+
+  it('cancels a pending automatic retry when the user retries manually', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 61_000);
+    harness.tokenTransport.queuedFailures.push(new Error('SECRET-refresh-network'));
+    await vi.advanceTimersByTimeAsync(1_000);
+    prepareSuccessfulRefresh(harness, { claimExpirySeconds: 10_000 });
+
+    await harness.coordinator.retryCurrentOperation();
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(refreshRequests(harness)).toHaveLength(2);
+  });
+
+  it('closes the gate at exact old-token expiry after a soft failure', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 61_000);
+    harness.tokenTransport.queuedFailures.push(
+      new Error('SECRET-refresh-network-1'),
+      new Error('SECRET-refresh-network-2'),
+    );
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await vi.advanceTimersByTimeAsync(54_999);
+    expect(harness.coordinator.state.sessionUsable).toBe(true);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: 'session_refresh_failed',
+      retryAction: 'refresh',
+      user: { userId: 'user-123', email: 'person@example.com' },
+    });
+  });
+
+  it('retries rotated-candidate persistence without issuing another grant', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 120_000);
+    prepareSuccessfulRefresh(harness, {
+      rotatedRefreshToken: 'SECRET-rotated-refresh-token',
+      claimExpirySeconds: 10_000,
+    });
+    harness.sessionStore.saveFailure = new Error('SECRET-save');
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      sessionUsable: true,
+      errorCode: 'session_persistence_failed',
+      retryAction: 'persist',
+    });
+    harness.sessionStore.saveFailure = undefined;
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(refreshRequests(harness)).toHaveLength(1);
+    expect(harness.sessionStore.saveAttempts).toEqual([
+      'SECRET-refresh-token',
+      'SECRET-rotated-refresh-token',
+      'SECRET-rotated-refresh-token',
+    ]);
+    expect(harness.sessionFetch).toHaveBeenCalledTimes(2);
+    expect(harness.coordinator.state.sessionUsable).toBe(true);
+  });
+
+  it('retries candidate verification without issuing another grant', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 120_000);
+    prepareSuccessfulRefresh(harness, { claimExpirySeconds: 10_000 });
+    harness.sessionFetch.mockResolvedValueOnce(response(500, { error: 'temporary' }));
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      sessionUsable: true,
+      errorCode: 'session_verification_failed',
+      retryAction: 'verify',
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(refreshRequests(harness)).toHaveLength(1);
+    expect(harness.sessionStore.saveAttempts).toEqual(['SECRET-refresh-token']);
+    expect(harness.sessionFetch).toHaveBeenCalledTimes(3);
+    expect(harness.coordinator.state.sessionUsable).toBe(true);
+  });
+
+  it('retains an expired candidate for manual verification retry', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 61_000);
+    prepareSuccessfulRefresh(harness, { claimExpirySeconds: 10_000 });
+    harness.sessionFetch
+      .mockResolvedValueOnce(response(500, { error: 'temporary' }))
+      .mockResolvedValueOnce(response(500, { error: 'temporary' }));
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await vi.advanceTimersByTimeAsync(55_000);
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      sessionUsable: false,
+      errorCode: 'session_verification_failed',
+      retryAction: 'verify',
+    });
+    await harness.coordinator.retryCurrentOperation();
+
+    expect(refreshRequests(harness)).toHaveLength(1);
+    expect(harness.sessionFetch).toHaveBeenCalledTimes(4);
+    expect(harness.coordinator.state.sessionUsable).toBe(true);
+  });
+
+  it('replaces both old deadlines after successful promotion', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const harness = makeHarness({ now: () => Date.now() });
+    await authenticateWithExpiry(harness, NOW + 120_000);
+    prepareSuccessfulRefresh(harness, { claimExpirySeconds: 10_000 });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(refreshRequests(harness)).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(harness.coordinator.state.sessionUsable).toBe(true);
+    await vi.advanceTimersByTimeAsync(3_479_999);
+    expect(refreshRequests(harness)).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(refreshRequests(harness)).toHaveLength(2);
+  });
+
+  it('uses only the injected clock for lifecycle delay decisions', async () => {
+    const injectedNow = 2_000_000_000_000;
+    const harness = makeHarness({ now: () => injectedNow });
+
+    await authenticateWithExpiry(harness, injectedNow + 60_000, injectedNow);
+    prepareSuccessfulRefresh(harness, {
+      claimExpirySeconds: Math.ceil((injectedNow + 7_200_000) / 1_000),
+    });
+    await vi.waitFor(() => expect(refreshRequests(harness)).toHaveLength(1));
+    await harness.coordinator.dispose();
   });
 });
 
@@ -2235,7 +2595,7 @@ describe('serialization, disposal, and secret handling', () => {
 
     await harness.coordinator.dispose();
 
-    expect(harness.app.removeCalls).toBe(1);
+    expect(harness.app.removeCalls).toBe(2);
     expect(harness.browser.removeCalls).toBe(1);
     expect(harness.preferences.value).not.toBeNull();
     expect(harness.coordinator.state).toEqual({
@@ -2258,7 +2618,7 @@ describe('serialization, disposal, and secret handling', () => {
     await harness.coordinator.dispose();
     await harness.coordinator.dispose();
 
-    expect(harness.app.removeCalls).toBe(1);
+    expect(harness.app.removeCalls).toBe(2);
     expect(harness.browser.removeCalls).toBe(1);
     expect(harness.coordinator.state.phase).toBe('signedOut');
   });

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -17,7 +17,10 @@ import {
   createOAuthTransactionStore,
   type OAuthTransactionPreferences,
 } from '../auth/oauth-transaction-store';
-import type { MobileInstallationStore } from '../auth/mobile-installation-store';
+import {
+  createMobileInstallationKey,
+  type MobileInstallationStore,
+} from '../auth/mobile-installation-store';
 import { MobileSessionStoreError, type MobileSessionStore } from '../auth/mobile-session-store';
 import { createMobileAuthCoordinator, MOBILE_AUTH_NETWORK_TIMEOUT_MS } from './mobile-auth';
 
@@ -39,6 +42,14 @@ const LOG_AND_DOM_SENTINELS = [
   'SECRET-claim-email',
 ] as const;
 
+const NON_SCHEMA_STORAGE_SENTINELS = [
+  'SECRET-callback-code',
+  'SECRET-claim-email',
+  'SECRET-raw-request',
+  'SECRET-raw-response',
+  'SECRET-native-exception',
+] as const;
+
 function searchable(value: unknown): string {
   try {
     return JSON.stringify(value);
@@ -52,6 +63,55 @@ function storageSnapshot(storage: Storage): string {
     const key = storage.key(index) ?? '';
     return `${key}=${storage.getItem(key) ?? ''}`;
   }).join('\n');
+}
+
+function expectApprovedPreferenceWrites(preferenceCalls: unknown[][]): void {
+  const installationKey = createMobileInstallationKey(config);
+
+  for (const call of preferenceCalls) {
+    expect(call).toHaveLength(1);
+    const options = call[0];
+    expect(options).toEqual(
+      expect.objectContaining({
+        key: expect.any(String),
+        value: expect.any(String),
+      }),
+    );
+    const { key, value } = options as { key: string; value: string };
+    expect(Object.keys(options as object).sort()).toEqual(['key', 'value']);
+
+    if (key === MOBILE_OAUTH_TRANSACTION_KEY) {
+      let parsed: unknown = null;
+      try {
+        parsed = JSON.parse(value);
+      } catch {
+        expect.fail('OAuth transaction Preferences value must be valid JSON');
+      }
+      expect(parsed).toEqual(
+        expect.objectContaining({
+          state: expect.any(String),
+          codeVerifier: expect.any(String),
+          nonce: expect.any(String),
+          createdAt: expect.any(Number),
+        }),
+      );
+      const transaction = parsed as Record<string, unknown>;
+      expect(Object.keys(transaction).sort()).toEqual([
+        'codeVerifier',
+        'createdAt',
+        'nonce',
+        'state',
+      ]);
+      expect((transaction.state as string).length).toBeGreaterThan(0);
+      expect((transaction.codeVerifier as string).length).toBeGreaterThan(0);
+      expect((transaction.nonce as string).length).toBeGreaterThan(0);
+      expect(Number.isFinite(transaction.createdAt)).toBe(true);
+      continue;
+    }
+
+    expect(key).toBe(installationKey);
+    expect(value).toBe('1');
+  }
 }
 
 function expectNoSecretLeak(input: {
@@ -72,9 +132,16 @@ function expectNoSecretLeak(input: {
   for (const secret of LOG_AND_DOM_SENTINELS) {
     expect(logsAndDom).not.toContain(secret);
   }
+  expect(logsAndDom).not.toContain('SECRET-');
   for (const secret of SECRET_SENTINELS) {
     expect(browserAndPreferenceStorage).not.toContain(secret);
   }
+  for (const secret of NON_SCHEMA_STORAGE_SENTINELS) {
+    expect(browserAndPreferenceStorage).not.toContain(secret);
+  }
+  expectApprovedPreferenceWrites(input.preferenceCalls);
+  expect(storageSnapshot(window.localStorage)).toBe('');
+  expect(storageSnapshot(window.sessionStorage)).toBe('');
 }
 
 const config: MobileOAuthConfig = {
@@ -3264,6 +3331,80 @@ describe('cross-boundary secret leakage regressions', () => {
     window.sessionStorage.clear();
   });
 
+  it('rejects a Preferences write with callback, claim, and raw transport fields outside the transaction schema', () => {
+    const transactionWithRogueFields = JSON.stringify({
+      ...securityTransaction,
+      callbackCode: 'SECRET-callback-code',
+      decodedClaimEmail: 'SECRET-claim-email',
+      rawRequest: 'SECRET-raw-request',
+      rawResponse: 'SECRET-raw-response',
+    });
+
+    expect(() =>
+      expectNoSecretLeak({
+        consoleCalls: [],
+        preferenceCalls: [
+          [
+            {
+              key: MOBILE_OAUTH_TRANSACTION_KEY,
+              value: transactionWithRogueFields,
+            },
+          ],
+        ],
+        renderedText: '',
+      }),
+    ).toThrow();
+  });
+
+  it('rejects unenumerated native removal failures from captured logs and errors', () => {
+    expect(() =>
+      expectNoSecretLeak({
+        consoleCalls: [
+          [new Error('SECRET-app-remove-failure')],
+          [{ cause: 'SECRET-browser-remove-failure' }],
+        ],
+        preferenceCalls: [],
+        renderedText: '',
+      }),
+    ).toThrow();
+  });
+
+  it('rejects raw transport values from browser storage', () => {
+    window.localStorage.setItem('rogue-request', 'SECRET-raw-request');
+    window.sessionStorage.setItem('rogue-response', 'SECRET-raw-response');
+
+    expect(() =>
+      expectNoSecretLeak({
+        consoleCalls: [],
+        preferenceCalls: [],
+        renderedText: '',
+      }),
+    ).toThrow();
+  });
+
+  it('allows only the exact token-free transaction and installation-marker Preferences schemas', () => {
+    expect(() =>
+      expectNoSecretLeak({
+        consoleCalls: [],
+        preferenceCalls: [
+          [
+            {
+              key: MOBILE_OAUTH_TRANSACTION_KEY,
+              value: JSON.stringify(securityTransaction),
+            },
+          ],
+          [
+            {
+              key: createMobileInstallationKey(config),
+              value: '1',
+            },
+          ],
+        ],
+        renderedText: '',
+      }),
+    ).not.toThrow();
+  });
+
   it('keeps callback-success credentials, claims, URL, code, verifier, and nonce out of logs and non-secure storage', async () => {
     const consoleCapture = captureConsoleCalls();
     const harness = makeHarness({ isDevelopment: true });
@@ -3521,6 +3662,10 @@ describe('cross-boundary secret leakage regressions', () => {
       notice: null,
       user: null,
     });
+    const disposalOutput = searchable(consoleCapture.calls());
+    expect(disposalOutput).not.toContain('SECRET-app-remove-failure');
+    expect(disposalOutput).not.toContain('SECRET-browser-remove-failure');
+    expect(disposalOutput).not.toContain('SECRET-');
     expectHarnessHasNoSecretLeak(harness, consoleCapture.calls());
   });
 });

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -94,6 +94,8 @@ export const MOBILE_AUTH_KEY: InjectionKey<MobileAuthCoordinator> = Symbol('mobi
  * back through their existing failure paths so the user can retry.
  */
 export const MOBILE_AUTH_NETWORK_TIMEOUT_MS = 15_000;
+export const MOBILE_AUTH_REFRESH_LEAD_MS = 60_000;
+export const MOBILE_AUTH_SOFT_RETRY_DELAY_MS = 5_000;
 
 const RESTARTABLE_OAUTH_ERRORS = new Set<MobileAuthErrorCode>([
   'browser_launch_failed',
@@ -210,8 +212,16 @@ export function createMobileAuthCoordinator(
 
   let operationTail = Promise.resolve();
   let appUrlHandle: ListenerHandle | undefined;
+  let appStateHandle: ListenerHandle | undefined;
   let browserFinishedHandle: ListenerHandle | undefined;
+  let proactiveRefreshTimer: ReturnType<typeof setTimeout> | undefined;
+  let accessExpiryTimer: ReturnType<typeof setTimeout> | undefined;
+  let automaticRetryTimer: ReturnType<typeof setTimeout> | undefined;
+  let refreshPromise: Promise<void> | undefined;
   let active: ActiveSession | undefined;
+  let activeBundleGeneration = 0;
+  let appIsActive = true;
+  let automaticRetryUsed = false;
   let pendingCandidate: PendingCandidate | undefined;
   let pendingSubject: string | undefined;
   let restoreRefreshToken: string | undefined;
@@ -235,6 +245,10 @@ export function createMobileAuthCoordinator(
       now: dependencies.now(),
     });
     Object.assign(state, next);
+  }
+
+  function activeSessionIsUsable(): boolean {
+    return active !== undefined && active.bundle.expiresAt > dependencies.now();
   }
 
   const transitions = {
@@ -333,21 +347,26 @@ export function createMobileAuthCoordinator(
         verify: 'verifying',
         cleanup: 'cleaningUp',
       };
+      const isInSessionRetry =
+        active !== undefined &&
+        (retryAction === 'refresh' ||
+          ((retryAction === 'persist' || retryAction === 'verify') &&
+            pendingCandidate?.context === 'refresh'));
       const phaseByAction: Record<MobileAuthRetryAction, MobileAuthPhase> = {
         restore: 'initializing',
         refresh: 'authenticated',
-        persist: 'exchangingCode',
-        verify: 'verifyingSession',
+        persist: isInSessionRetry ? 'authenticated' : 'exchangingCode',
+        verify: isInSessionRetry ? 'authenticated' : 'verifyingSession',
         cleanup: 'signedOut',
       };
       applyState({
         phase: phaseByAction[retryAction],
         operation: operationByAction[retryAction],
-        sessionUsable: false,
+        sessionUsable: isInSessionRetry && activeSessionIsUsable(),
         errorCode: null,
         retryAction: null,
         notice: null,
-        user: retryAction === 'refresh' ? (active?.user ?? null) : null,
+        user: isInSessionRetry ? (active?.user ?? null) : null,
       });
     },
 
@@ -376,6 +395,238 @@ export function createMobileAuthCoordinator(
     },
   };
 
+  function cancelProactiveRefreshTimer(): void {
+    if (proactiveRefreshTimer !== undefined) {
+      clearTimeout(proactiveRefreshTimer);
+      proactiveRefreshTimer = undefined;
+    }
+  }
+
+  function cancelAccessExpiryTimer(): void {
+    if (accessExpiryTimer !== undefined) {
+      clearTimeout(accessExpiryTimer);
+      accessExpiryTimer = undefined;
+    }
+  }
+
+  function cancelAutomaticRetryTimer(): void {
+    if (automaticRetryTimer !== undefined) {
+      clearTimeout(automaticRetryTimer);
+      automaticRetryTimer = undefined;
+    }
+  }
+
+  function cancelActiveSessionTimers(): void {
+    cancelProactiveRefreshTimer();
+    cancelAccessExpiryTimer();
+    cancelAutomaticRetryTimer();
+  }
+
+  function clearActiveSession(): void {
+    cancelActiveSessionTimers();
+    active = undefined;
+    activeBundleGeneration += 1;
+    automaticRetryUsed = false;
+  }
+
+  async function closeExpiredActiveSessionUnlocked(
+    owner: ActiveSession,
+    generation: number,
+  ): Promise<void> {
+    if (disposed || active !== owner || activeBundleGeneration !== generation) {
+      return;
+    }
+    if (owner.bundle.expiresAt > dependencies.now()) {
+      scheduleAccessExpiryTimer(owner, generation);
+      return;
+    }
+
+    cancelProactiveRefreshTimer();
+    cancelAutomaticRetryTimer();
+    const retainedRetry =
+      state.operation === 'idle' &&
+      state.errorCode !== null &&
+      (state.retryAction === 'refresh' ||
+        state.retryAction === 'persist' ||
+        state.retryAction === 'verify')
+        ? {
+            errorCode: state.errorCode,
+            retryAction: state.retryAction,
+          }
+        : {
+            errorCode: 'session_refresh_failed' as const,
+            retryAction: 'refresh' as const,
+          };
+    transitions.enterSessionFailure({
+      phase: 'authenticated',
+      sessionUsable: false,
+      errorCode: retainedRetry.errorCode,
+      retryAction: retainedRetry.retryAction,
+      user: owner.user,
+    });
+  }
+
+  function scheduleAccessExpiryTimer(owner: ActiveSession, generation: number): void {
+    cancelAccessExpiryTimer();
+    const delay = Math.max(0, owner.bundle.expiresAt - dependencies.now());
+    accessExpiryTimer = setTimeout(() => {
+      accessExpiryTimer = undefined;
+      void serialize(() => closeExpiredActiveSessionUnlocked(owner, generation));
+    }, delay);
+  }
+
+  function scheduleProactiveRefreshTimer(owner: ActiveSession, generation: number): void {
+    cancelProactiveRefreshTimer();
+    if (!appIsActive || disposed || active !== owner || activeBundleGeneration !== generation) {
+      return;
+    }
+    const delay = Math.max(
+      0,
+      owner.bundle.expiresAt - dependencies.now() - MOBILE_AUTH_REFRESH_LEAD_MS,
+    );
+    proactiveRefreshTimer = setTimeout(() => {
+      proactiveRefreshTimer = undefined;
+      void queueRefresh({ requireDue: true, owner, generation });
+    }, delay);
+  }
+
+  function scheduleActiveSessionTimers(): void {
+    const owner = active;
+    if (!owner || disposed) {
+      return;
+    }
+    const generation = activeBundleGeneration;
+    scheduleAccessExpiryTimer(owner, generation);
+    scheduleProactiveRefreshTimer(owner, generation);
+  }
+
+  function queueRefresh(options: {
+    requireDue: boolean;
+    owner?: ActiveSession;
+    generation?: number;
+  }): Promise<void> {
+    if (refreshPromise !== undefined) {
+      return refreshPromise;
+    }
+
+    const owner = options.owner ?? active;
+    const generation = options.generation ?? activeBundleGeneration;
+    if (!owner) {
+      return Promise.resolve();
+    }
+
+    cancelProactiveRefreshTimer();
+    const operation = serialize(async () => {
+      if (
+        disposed ||
+        !appIsActive ||
+        active !== owner ||
+        activeBundleGeneration !== generation ||
+        pendingCandidate !== undefined
+      ) {
+        return;
+      }
+      if (
+        options.requireDue &&
+        owner.bundle.expiresAt - dependencies.now() > MOBILE_AUTH_REFRESH_LEAD_MS
+      ) {
+        scheduleProactiveRefreshTimer(owner, generation);
+        return;
+      }
+      await refreshActiveSessionUnlocked();
+    });
+    let tracked!: Promise<void>;
+    tracked = operation.finally(() => {
+      if (refreshPromise === tracked) {
+        refreshPromise = undefined;
+      }
+    });
+    refreshPromise = tracked;
+    return tracked;
+  }
+
+  function queueRecordedRetry(): void {
+    if (state.retryAction === null || state.operation !== 'idle' || disposed || !appIsActive) {
+      return;
+    }
+    if (state.retryAction === 'refresh') {
+      void queueRefresh({ requireDue: false });
+      return;
+    }
+    if (state.retryAction === 'persist' || state.retryAction === 'verify') {
+      void serialize(retryCurrentOperationUnlocked);
+    }
+  }
+
+  function scheduleAutomaticRetry(): void {
+    const owner = active;
+    const retryAction = state.retryAction;
+    if (
+      !owner ||
+      disposed ||
+      !appIsActive ||
+      automaticRetryUsed ||
+      automaticRetryTimer !== undefined ||
+      (retryAction !== 'refresh' && retryAction !== 'persist' && retryAction !== 'verify')
+    ) {
+      return;
+    }
+    const enoughLifetime =
+      owner.bundle.expiresAt - dependencies.now() >
+      MOBILE_AUTH_SOFT_RETRY_DELAY_MS + MOBILE_AUTH_NETWORK_TIMEOUT_MS;
+    if (!enoughLifetime) {
+      return;
+    }
+
+    automaticRetryUsed = true;
+    automaticRetryTimer = setTimeout(() => {
+      automaticRetryTimer = undefined;
+      if (
+        disposed ||
+        !appIsActive ||
+        active !== owner ||
+        owner.bundle.expiresAt <= dependencies.now() ||
+        state.retryAction !== retryAction
+      ) {
+        return;
+      }
+      queueRecordedRetry();
+    }, MOBILE_AUTH_SOFT_RETRY_DELAY_MS);
+  }
+
+  function handleAppStateChange(isActive: boolean): void {
+    appIsActive = isActive;
+    if (!isActive) {
+      cancelProactiveRefreshTimer();
+      cancelAutomaticRetryTimer();
+      return;
+    }
+
+    const owner = active;
+    if (!owner || disposed) {
+      return;
+    }
+    if (state.retryAction === 'persist' || state.retryAction === 'verify') {
+      queueRecordedRetry();
+      return;
+    }
+
+    const generation = activeBundleGeneration;
+    if (owner.bundle.expiresAt <= dependencies.now()) {
+      void serialize(() => closeExpiredActiveSessionUnlocked(owner, generation));
+      void queueRefresh({ requireDue: false, owner, generation });
+      return;
+    }
+    if (
+      state.retryAction === 'refresh' ||
+      owner.bundle.expiresAt - dependencies.now() <= MOBILE_AUTH_REFRESH_LEAD_MS
+    ) {
+      void queueRefresh({ requireDue: state.retryAction !== 'refresh', owner, generation });
+      return;
+    }
+    scheduleProactiveRefreshTimer(owner, generation);
+  }
+
   async function removeListener(handle: ListenerHandle | undefined): Promise<void> {
     try {
       await handle?.remove();
@@ -393,7 +644,7 @@ export function createMobileAuthCoordinator(
   }
 
   async function failCallback(errorCode: MobileAuthErrorCode): Promise<void> {
-    active = undefined;
+    clearActiveSession();
     pendingCandidate = undefined;
     pendingSubject = undefined;
     restoreRefreshToken = undefined;
@@ -411,7 +662,7 @@ export function createMobileAuthCoordinator(
   }
 
   async function terminalSessionCleanupUnlocked(): Promise<void> {
-    active = undefined;
+    clearActiveSession();
     pendingCandidate = undefined;
     pendingSubject = undefined;
     restoreRefreshToken = undefined;
@@ -426,6 +677,27 @@ export function createMobileAuthCoordinator(
     transitions.enterTerminalNotice();
   }
 
+  function enterCandidateFailure(
+    candidate: PendingCandidate,
+    errorCode: Extract<
+      MobileAuthErrorCode,
+      'session_persistence_failed' | 'session_verification_failed'
+    >,
+    retryAction: Extract<MobileAuthRetryAction, 'persist' | 'verify'>,
+  ): void {
+    const isInSession = candidate.context === 'refresh' && active !== undefined;
+    transitions.enterSessionFailure({
+      phase: isInSession ? 'authenticated' : 'error',
+      sessionUsable: isInSession && activeSessionIsUsable(),
+      errorCode,
+      retryAction,
+      user: isInSession ? (active?.user ?? null) : null,
+    });
+    if (isInSession) {
+      scheduleAutomaticRetry();
+    }
+  }
+
   async function verifyCandidateSessionUnlocked(): Promise<void> {
     const candidate = pendingCandidate;
     if (!candidate || disposed) {
@@ -433,11 +705,11 @@ export function createMobileAuthCoordinator(
     }
 
     transitions.enterOperation({
-      phase: 'verifyingSession',
+      phase: candidate.context === 'refresh' ? 'authenticated' : 'verifyingSession',
       operation: 'verifying',
-      sessionUsable: false,
+      sessionUsable: candidate.context === 'refresh' && activeSessionIsUsable(),
       notice: null,
-      user: null,
+      user: candidate.context === 'refresh' ? (active?.user ?? null) : null,
     });
 
     // The timeout and AbortController must remain active until the response
@@ -459,13 +731,7 @@ export function createMobileAuthCoordinator(
           signal: controller.signal,
         });
       } catch {
-        transitions.enterSessionFailure({
-          phase: 'error',
-          sessionUsable: false,
-          errorCode: 'session_verification_failed',
-          retryAction: 'verify',
-          user: null,
-        });
+        enterCandidateFailure(candidate, 'session_verification_failed', 'verify');
         return;
       }
 
@@ -475,13 +741,7 @@ export function createMobileAuthCoordinator(
       }
 
       if (!response.ok) {
-        transitions.enterSessionFailure({
-          phase: 'error',
-          sessionUsable: false,
-          errorCode: 'session_verification_failed',
-          retryAction: 'verify',
-          user: null,
-        });
+        enterCandidateFailure(candidate, 'session_verification_failed', 'verify');
         return;
       }
 
@@ -489,25 +749,13 @@ export function createMobileAuthCoordinator(
       try {
         data = await response.json();
       } catch {
-        transitions.enterSessionFailure({
-          phase: 'error',
-          sessionUsable: false,
-          errorCode: 'session_verification_failed',
-          retryAction: 'verify',
-          user: null,
-        });
+        enterCandidateFailure(candidate, 'session_verification_failed', 'verify');
         return;
       }
 
       const user = parseSessionUser(data);
       if (!user) {
-        transitions.enterSessionFailure({
-          phase: 'error',
-          sessionUsable: false,
-          errorCode: 'session_verification_failed',
-          retryAction: 'verify',
-          user: null,
-        });
+        enterCandidateFailure(candidate, 'session_verification_failed', 'verify');
         return;
       }
 
@@ -516,6 +764,7 @@ export function createMobileAuthCoordinator(
         return;
       }
 
+      cancelActiveSessionTimers();
       active = {
         bundle: {
           ...candidate.bundle,
@@ -523,11 +772,14 @@ export function createMobileAuthCoordinator(
         },
         user,
       };
+      activeBundleGeneration += 1;
+      automaticRetryUsed = false;
       pendingCandidate = undefined;
       pendingSubject = undefined;
       restoreRefreshToken = undefined;
       cleanupContext = undefined;
       transitions.enterAuthenticated(user);
+      scheduleActiveSessionTimers();
     } finally {
       clearTimeout(timeout);
     }
@@ -543,22 +795,16 @@ export function createMobileAuthCoordinator(
       candidate.context === 'authorizationCode' || candidate.returnedRefreshToken !== undefined;
     if (needsPersistence) {
       transitions.enterOperation({
-        phase: 'exchangingCode',
+        phase: candidate.context === 'refresh' ? 'authenticated' : 'exchangingCode',
         operation: 'persisting',
-        sessionUsable: false,
+        sessionUsable: candidate.context === 'refresh' && activeSessionIsUsable(),
         notice: null,
-        user: null,
+        user: candidate.context === 'refresh' ? (active?.user ?? null) : null,
       });
       try {
         await dependencies.sessionStore.saveRefreshToken(candidate.durableRefreshToken);
       } catch {
-        transitions.enterSessionFailure({
-          phase: 'error',
-          sessionUsable: false,
-          errorCode: 'session_persistence_failed',
-          retryAction: 'persist',
-          user: null,
-        });
+        enterCandidateFailure(candidate, 'session_persistence_failed', 'persist');
         return;
       }
 
@@ -715,6 +961,17 @@ export function createMobileAuthCoordinator(
   }
 
   function enterRefreshFailure(context: 'restore' | 'refresh'): void {
+    if (context === 'refresh' && active !== undefined) {
+      transitions.enterSessionFailure({
+        phase: 'authenticated',
+        sessionUsable: activeSessionIsUsable(),
+        errorCode: 'session_refresh_failed',
+        retryAction: 'refresh',
+        user: active.user,
+      });
+      scheduleAutomaticRetry();
+      return;
+    }
     transitions.enterSessionFailure({
       phase: 'error',
       sessionUsable: false,
@@ -740,7 +997,7 @@ export function createMobileAuthCoordinator(
     transitions.enterOperation({
       phase: context === 'restore' ? 'initializing' : 'authenticated',
       operation: context === 'restore' ? 'restoring' : 'refreshing',
-      sessionUsable: false,
+      sessionUsable: context === 'refresh' && activeSessionIsUsable(),
       notice: null,
       user: context === 'refresh' ? (active?.user ?? null) : null,
     });
@@ -869,8 +1126,10 @@ export function createMobileAuthCoordinator(
       launchUrl = await dependencies.app.getLaunchUrl();
     } catch {
       await removeListener(appUrlHandle);
+      await removeListener(appStateHandle);
       await removeListener(browserFinishedHandle);
       appUrlHandle = undefined;
+      appStateHandle = undefined;
       browserFinishedHandle = undefined;
       transitions.enterOAuthError('configuration_error');
       return;
@@ -949,13 +1208,18 @@ export function createMobileAuthCoordinator(
       appUrlHandle = await dependencies.app.addListener('appUrlOpen', (event) => {
         void coordinator.completeCallback(event.url);
       });
+      appStateHandle = await dependencies.app.addListener('appStateChange', (event) => {
+        handleAppStateChange(event.isActive);
+      });
       browserFinishedHandle = await dependencies.browser.addListener('browserFinished', () => {
         void serialize(handleBrowserFinishedUnlocked);
       });
     } catch {
       await removeListener(appUrlHandle);
+      await removeListener(appStateHandle);
       await removeListener(browserFinishedHandle);
       appUrlHandle = undefined;
+      appStateHandle = undefined;
       browserFinishedHandle = undefined;
       transitions.enterOAuthError('configuration_error');
       return;
@@ -1078,16 +1342,39 @@ export function createMobileAuthCoordinator(
     }
   }
 
+  function retryCurrentOperation(): Promise<void> {
+    if (refreshPromise !== undefined) {
+      cancelAutomaticRetryTimer();
+      return refreshPromise;
+    }
+
+    const retryAction = state.retryAction;
+    if (
+      active !== undefined &&
+      (retryAction === 'refresh' || retryAction === 'persist' || retryAction === 'verify')
+    ) {
+      cancelAutomaticRetryTimer();
+      automaticRetryUsed = true;
+    }
+    if (retryAction === 'refresh') {
+      return queueRefresh({ requireDue: false });
+    }
+    return serialize(retryCurrentOperationUnlocked);
+  }
+
   async function disposeUnlocked(): Promise<void> {
     if (disposed) {
       return;
     }
     disposed = true;
+    cancelActiveSessionTimers();
     await removeListener(appUrlHandle);
+    await removeListener(appStateHandle);
     await removeListener(browserFinishedHandle);
     appUrlHandle = undefined;
+    appStateHandle = undefined;
     browserFinishedHandle = undefined;
-    active = undefined;
+    clearActiveSession();
     pendingCandidate = undefined;
     pendingSubject = undefined;
     restoreRefreshToken = undefined;
@@ -1100,7 +1387,7 @@ export function createMobileAuthCoordinator(
     initialize: () => serialize(initializeUnlocked),
     startSignIn: () => serialize(startSignInUnlocked),
     completeCallback: (url) => serialize(() => completeCallbackUnlocked(url).then(() => undefined)),
-    retryCurrentOperation: () => serialize(retryCurrentOperationUnlocked),
+    retryCurrentOperation,
     dispose: () => serialize(disposeUnlocked),
   };
 

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -15,7 +15,10 @@ import {
   type MobileBrowserAdapter,
   type MobileOAuthConfig,
   type MobileTokenTransportAdapter,
+  type OAuthTokenBundleBase,
 } from '../auth/mobile-auth-contract';
+import type { MobileInstallationStore } from '../auth/mobile-installation-store';
+import type { MobileSessionStore } from '../auth/mobile-session-store';
 import {
   containsWhitespace,
   hasMatchingUserPoolRegion,
@@ -37,11 +40,23 @@ type ListenerHandle = {
   remove(): Promise<void>;
 };
 
+type PendingCandidate = {
+  bundle: OAuthTokenBundleBase;
+  durableRefreshToken: string;
+  returnedRefreshToken?: string;
+  context: 'authorizationCode' | 'restore' | 'refresh';
+};
+
+type CleanupContext = { kind: 'terminalSession' } | { kind: 'installationReset' };
+
 export type MobileAuthCoordinatorDependencies = {
   app: MobileAppAdapter;
   browser: MobileBrowserAdapter;
   transactionStore: OAuthTransactionStore;
   tokenTransport: MobileTokenTransportAdapter;
+  sessionStore: MobileSessionStore;
+  installationStore: MobileInstallationStore;
+  isNativeIos: boolean;
   crypto: Crypto | undefined;
   isSecureContext: boolean;
   fetch: typeof fetch;
@@ -59,6 +74,18 @@ export const MOBILE_AUTH_KEY: InjectionKey<MobileAuthCoordinator> = Symbol('mobi
  * back through their existing failure paths so the user can retry.
  */
 export const MOBILE_AUTH_NETWORK_TIMEOUT_MS = 15_000;
+
+const RESTARTABLE_OAUTH_ERRORS = new Set<MobileAuthErrorCode>([
+  'browser_launch_failed',
+  'cancelled',
+  'interrupted',
+  'transaction_expired',
+  'malformed_callback',
+  'provider_error',
+  'code_exchange_failed',
+  'token_validation_failed',
+  'session_unauthorized',
+]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -165,6 +192,8 @@ export function createMobileAuthCoordinator(
   let appUrlHandle: ListenerHandle | undefined;
   let browserFinishedHandle: ListenerHandle | undefined;
   let tokenBundle: AuthorizationCodeTokenBundle | undefined;
+  let pendingCandidate: PendingCandidate | undefined;
+  let cleanupContext: CleanupContext | undefined;
   let initialized = false;
   let disposed = false;
   const isDevelopment = dependencies.isDevelopment ?? import.meta.env.DEV;
@@ -314,6 +343,8 @@ export function createMobileAuthCoordinator(
 
   async function failCallback(errorCode: MobileAuthErrorCode): Promise<void> {
     tokenBundle = undefined;
+    pendingCandidate = undefined;
+    cleanupContext = undefined;
     transitions.enterOAuthError(errorCode);
     await clearTransaction();
   }
@@ -326,13 +357,19 @@ export function createMobileAuthCoordinator(
     }
   }
 
-  async function verifySessionUnlocked(): Promise<void> {
-    const bundle = tokenBundle;
-    if (!bundle || disposed) {
+  async function verifyCandidateSessionUnlocked(): Promise<void> {
+    const candidate = pendingCandidate;
+    if (!candidate || disposed) {
       return;
     }
 
-    transitions.enterOAuthProgress('verifyingSession');
+    transitions.enterOperation({
+      phase: 'verifyingSession',
+      operation: 'verifying',
+      sessionUsable: false,
+      notice: null,
+      user: null,
+    });
 
     // The timeout and AbortController must remain active until the response
     // body has been fully consumed. fetch() resolves as soon as the response
@@ -348,7 +385,7 @@ export function createMobileAuthCoordinator(
           method: 'GET',
           headers: {
             Accept: 'application/json',
-            Authorization: `Bearer ${bundle.idToken}`,
+            Authorization: `Bearer ${candidate.bundle.idToken}`,
           },
           signal: controller.signal,
         });
@@ -365,7 +402,16 @@ export function createMobileAuthCoordinator(
 
       if (response.status === 401 || response.status === 403) {
         tokenBundle = undefined;
-        transitions.enterOAuthError('session_unauthorized');
+        cleanupContext = { kind: 'terminalSession' };
+        try {
+          await dependencies.sessionStore.clearRefreshToken();
+        } catch {
+          transitions.enterCleanupFailure();
+          return;
+        }
+        pendingCandidate = undefined;
+        cleanupContext = undefined;
+        transitions.enterTerminalNotice();
         return;
       }
 
@@ -406,10 +452,52 @@ export function createMobileAuthCoordinator(
         return;
       }
 
+      tokenBundle = {
+        ...candidate.bundle,
+        refreshToken: candidate.durableRefreshToken,
+      };
+      pendingCandidate = undefined;
+      cleanupContext = undefined;
       transitions.enterAuthenticated(user);
     } finally {
       clearTimeout(timeout);
     }
+  }
+
+  async function persistPendingCandidateUnlocked(): Promise<void> {
+    const candidate = pendingCandidate;
+    if (!candidate || disposed) {
+      return;
+    }
+
+    transitions.enterOperation({
+      phase: 'exchangingCode',
+      operation: 'persisting',
+      sessionUsable: false,
+      notice: null,
+      user: null,
+    });
+    try {
+      await dependencies.sessionStore.saveRefreshToken(candidate.durableRefreshToken);
+    } catch {
+      transitions.enterSessionFailure({
+        phase: 'error',
+        sessionUsable: false,
+        errorCode: 'session_persistence_failed',
+        retryAction: 'persist',
+        user: null,
+      });
+      return;
+    }
+
+    if (candidate.context === 'authorizationCode') {
+      // Only a durable refresh credential permits transaction removal. A
+      // failed Preferences cleanup remains best effort because the exchanged
+      // authorization code is single-use.
+      await clearTransaction();
+    }
+
+    await verifyCandidateSessionUnlocked();
   }
 
   async function completeCallbackUnlocked(rawUrl: string): Promise<boolean> {
@@ -419,7 +507,7 @@ export function createMobileAuthCoordinator(
       state.phase === 'awaitingCallback' ||
       (state.phase === 'error' && state.errorCode === 'interrupted');
 
-    if (disposed || !initialized || tokenBundle || !isActiveCallbackPhase) {
+    if (disposed || !initialized || tokenBundle || pendingCandidate || !isActiveCallbackPhase) {
       return false;
     }
 
@@ -512,13 +600,13 @@ export function createMobileAuthCoordinator(
       return true;
     }
 
-    tokenBundle = bundle;
-    // Best-effort cleanup: a clear failure does not invalidate the exchanged
-    // tokens. The transaction is single-use (Cognito rejects a replayed
-    // verifier), so a stale entry only affects the next launch's resume path.
-    await clearTransaction();
-
-    await verifySessionUnlocked();
+    const { refreshToken, ...candidateBundle } = bundle;
+    pendingCandidate = {
+      bundle: candidateBundle,
+      durableRefreshToken: refreshToken,
+      context: 'authorizationCode',
+    };
+    await persistPendingCandidateUnlocked();
     return true;
   }
 
@@ -558,6 +646,11 @@ export function createMobileAuthCoordinator(
       return;
     }
 
+    if (!dependencies.isNativeIos) {
+      transitions.enterOAuthError('unsupported_platform');
+      return;
+    }
+
     try {
       appUrlHandle = await dependencies.app.addListener('appUrlOpen', (event) => {
         void coordinator.completeCallback(event.url);
@@ -565,6 +658,37 @@ export function createMobileAuthCoordinator(
       browserFinishedHandle = await dependencies.browser.addListener('browserFinished', () => {
         void serialize(handleBrowserFinishedUnlocked);
       });
+    } catch {
+      await removeListener(appUrlHandle);
+      await removeListener(browserFinishedHandle);
+      appUrlHandle = undefined;
+      browserFinishedHandle = undefined;
+      transitions.enterOAuthError('configuration_error');
+      return;
+    }
+
+    try {
+      cleanupContext = { kind: 'installationReset' };
+      const isMarked = await dependencies.installationStore.isCurrentInstallationMarked();
+      if (!isMarked) {
+        transitions.enterOperation({
+          phase: 'initializing',
+          operation: 'cleaningUp',
+          sessionUsable: false,
+          notice: null,
+          user: null,
+        });
+        await dependencies.sessionStore.clearRefreshToken();
+        await dependencies.installationStore.markCurrentInstallation();
+        transitions.enterOAuthProgress('initializing');
+      }
+      cleanupContext = undefined;
+    } catch {
+      transitions.enterCleanupFailure();
+      return;
+    }
+
+    try {
       const launchUrl = await dependencies.app.getLaunchUrl();
       if (launchUrl && parseOAuthCallback(launchUrl.url).kind !== 'unrelated') {
         const consumed = await completeCallbackUnlocked(launchUrl.url);
@@ -590,18 +714,17 @@ export function createMobileAuthCoordinator(
   }
 
   async function startSignInUnlocked(): Promise<void> {
-    if (
-      disposed ||
-      state.phase === 'initializing' ||
-      state.phase === 'openingBrowser' ||
-      state.phase === 'awaitingCallback' ||
-      state.phase === 'exchangingCode' ||
-      state.phase === 'verifyingSession' ||
-      state.phase === 'authenticated' ||
-      (state.phase === 'error' &&
-        (state.errorCode === 'configuration_error' ||
-          state.errorCode === 'session_verification_failed'))
-    ) {
+    const canStartSignIn =
+      dependencies.isNativeIos &&
+      state.operation === 'idle' &&
+      ((state.phase === 'signedOut' &&
+        state.retryAction === null &&
+        (state.notice === null || state.notice === 'session_unusable')) ||
+        (state.phase === 'error' &&
+          state.errorCode !== null &&
+          RESTARTABLE_OAUTH_ERRORS.has(state.errorCode)));
+
+    if (disposed || !canStartSignIn) {
       return;
     }
 
@@ -652,15 +775,19 @@ export function createMobileAuthCoordinator(
   }
 
   async function retrySessionVerificationUnlocked(): Promise<void> {
-    if (
-      disposed ||
-      state.phase !== 'error' ||
-      state.errorCode !== 'session_verification_failed' ||
-      !tokenBundle
-    ) {
+    // Cleanup retries have distinct installation-reset versus terminal-session
+    // semantics. Retain that context for the dedicated cleanup flow rather
+    // than routing either case through a verification retry.
+    if (disposed || cleanupContext || state.phase !== 'error' || !pendingCandidate) {
       return;
     }
-    await verifySessionUnlocked();
+    if (state.errorCode === 'session_persistence_failed' && state.retryAction === 'persist') {
+      await persistPendingCandidateUnlocked();
+      return;
+    }
+    if (state.errorCode === 'session_verification_failed') {
+      await verifyCandidateSessionUnlocked();
+    }
   }
 
   async function disposeUnlocked(): Promise<void> {
@@ -673,6 +800,8 @@ export function createMobileAuthCoordinator(
     appUrlHandle = undefined;
     browserFinishedHandle = undefined;
     tokenBundle = undefined;
+    pendingCandidate = undefined;
+    cleanupContext = undefined;
     transitions.enterSignedOut();
   }
 

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -1,6 +1,7 @@
 import { reactive, readonly, type InjectionKey } from 'vue';
 import {
   MOBILE_OAUTH_CALLBACK_URI,
+  type AuthorizationCodeTokenBundle,
   type MobileAppAdapter,
   type MobileAuthCoordinator,
   type MobileAuthErrorCode,
@@ -8,7 +9,6 @@ import {
   type MobileBrowserAdapter,
   type MobileOAuthConfig,
   type MobileTokenTransportAdapter,
-  type OAuthTokenBundle,
 } from '../auth/mobile-auth-contract';
 import {
   containsWhitespace,
@@ -17,13 +17,13 @@ import {
 } from '../auth/config-validators';
 import {
   buildAuthorizationUrl,
-  buildTokenRequest,
+  buildAuthorizationCodeTokenRequest,
   createOAuthTransaction,
   createPkceChallenge,
   hasOAuthCryptoCapabilities,
   parseOAuthCallback,
-  parseTokenResponse,
-  validateIdTokenClaims,
+  parseAuthorizationCodeTokenResponse,
+  validateAuthorizationCodeIdTokenClaims,
 } from '../auth/mobile-oauth';
 import type { OAuthTransactionStore } from '../auth/oauth-transaction-store';
 
@@ -154,7 +154,7 @@ export function createMobileAuthCoordinator(
   let operationTail = Promise.resolve();
   let appUrlHandle: ListenerHandle | undefined;
   let browserFinishedHandle: ListenerHandle | undefined;
-  let tokenBundle: OAuthTokenBundle | undefined;
+  let tokenBundle: AuthorizationCodeTokenBundle | undefined;
   let initialized = false;
   let disposed = false;
   const isDevelopment = dependencies.isDevelopment ?? import.meta.env.DEV;
@@ -347,24 +347,30 @@ export function createMobileAuthCoordinator(
       return true;
     }
 
-    let bundle: OAuthTokenBundle;
+    let response: { status: number; data: unknown };
     try {
-      const response = await dependencies.tokenTransport.request(
-        buildTokenRequest(dependencies.config, transaction, parsed.code, {
+      response = await dependencies.tokenTransport.request(
+        buildAuthorizationCodeTokenRequest(dependencies.config, transaction, parsed.code, {
           timeoutMs: MOBILE_AUTH_NETWORK_TIMEOUT_MS,
         }),
       );
-      if (response.status < 200 || response.status >= 300) {
-        throw new Error('token_endpoint_rejected');
-      }
-      bundle = parseTokenResponse(parseTransportData(response.data), dependencies.now());
     } catch {
       await failCallback('code_exchange_failed');
       return true;
     }
 
+    if (response.status < 200 || response.status >= 300) {
+      await failCallback('code_exchange_failed');
+      return true;
+    }
+
+    let bundle: AuthorizationCodeTokenBundle;
     try {
-      validateIdTokenClaims(bundle.idToken, {
+      bundle = parseAuthorizationCodeTokenResponse(
+        parseTransportData(response.data),
+        dependencies.now(),
+      );
+      validateAuthorizationCodeIdTokenClaims(bundle.idToken, {
         config: dependencies.config,
         transaction,
         now: dependencies.now(),

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -429,10 +429,7 @@ export function createMobileAuthCoordinator(
     automaticRetryUsed = false;
   }
 
-  async function closeExpiredActiveSessionUnlocked(
-    owner: ActiveSession,
-    generation: number,
-  ): Promise<void> {
+  function closeExpiredActiveSession(owner: ActiveSession, generation: number): void {
     if (disposed || active !== owner || activeBundleGeneration !== generation) {
       return;
     }
@@ -443,8 +440,20 @@ export function createMobileAuthCoordinator(
 
     cancelProactiveRefreshTimer();
     cancelAutomaticRetryTimer();
+    if (state.operation !== 'idle') {
+      applyState({
+        phase: state.phase,
+        operation: state.operation,
+        sessionUsable: false,
+        errorCode: state.errorCode,
+        retryAction: state.retryAction,
+        notice: state.notice,
+        user: state.user,
+      });
+      return;
+    }
+
     const retainedRetry =
-      state.operation === 'idle' &&
       state.errorCode !== null &&
       (state.retryAction === 'refresh' ||
         state.retryAction === 'persist' ||
@@ -471,7 +480,7 @@ export function createMobileAuthCoordinator(
     const delay = Math.max(0, owner.bundle.expiresAt - dependencies.now());
     accessExpiryTimer = setTimeout(() => {
       accessExpiryTimer = undefined;
-      void serialize(() => closeExpiredActiveSessionUnlocked(owner, generation));
+      closeExpiredActiveSession(owner, generation);
     }, delay);
   }
 
@@ -613,7 +622,7 @@ export function createMobileAuthCoordinator(
 
     const generation = activeBundleGeneration;
     if (owner.bundle.expiresAt <= dependencies.now()) {
-      void serialize(() => closeExpiredActiveSessionUnlocked(owner, generation));
+      closeExpiredActiveSession(owner, generation);
       void queueRefresh({ requireDue: false, owner, generation });
       return;
     }

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -363,11 +363,22 @@ export function createMobileAuthCoordinator(
         (retryAction === 'refresh' ||
           ((retryAction === 'persist' || retryAction === 'verify') &&
             pendingCandidate?.context === 'refresh'));
+      const isRestoreCandidateRetry =
+        (retryAction === 'persist' || retryAction === 'verify') &&
+        pendingCandidate?.context === 'restore';
       const phaseByAction: Record<MobileAuthRetryAction, MobileAuthPhase> = {
         restore: 'initializing',
         refresh: 'authenticated',
-        persist: isInSessionRetry ? 'authenticated' : 'exchangingCode',
-        verify: isInSessionRetry ? 'authenticated' : 'verifyingSession',
+        persist: isInSessionRetry
+          ? 'authenticated'
+          : isRestoreCandidateRetry
+            ? 'initializing'
+            : 'exchangingCode',
+        verify: isInSessionRetry
+          ? 'authenticated'
+          : isRestoreCandidateRetry
+            ? 'initializing'
+            : 'verifyingSession',
         cleanup: 'signedOut',
       };
       applyState({
@@ -699,12 +710,27 @@ export function createMobileAuthCoordinator(
   }
 
   async function terminalSessionCleanupUnlocked(): Promise<void> {
+    const cleanupPhase: MobileAuthPhase =
+      state.phase === 'signedOut'
+        ? 'signedOut'
+        : active !== undefined || state.phase === 'authenticated'
+          ? 'authenticated'
+          : 'initializing';
+    const cleanupUser =
+      cleanupPhase === 'authenticated' ? (state.user ?? active?.user ?? null) : null;
     clearActiveSession();
     const cleanupGeneration = activeBundleGeneration;
     pendingCandidate = undefined;
     pendingSubject = undefined;
     restoreRefreshToken = undefined;
     cleanupContext = { kind: 'terminalSession' };
+    transitions.enterOperation({
+      phase: cleanupPhase,
+      operation: 'cleaningUp',
+      sessionUsable: false,
+      notice: null,
+      user: cleanupUser,
+    });
     try {
       await dependencies.sessionStore.clearRefreshToken();
     } catch {
@@ -731,7 +757,11 @@ export function createMobileAuthCoordinator(
   ): void {
     const isInSession = candidate.context === 'refresh' && active !== undefined;
     transitions.enterSessionFailure({
-      phase: isInSession ? 'authenticated' : 'error',
+      phase: isInSession
+        ? 'authenticated'
+        : candidate.context === 'restore'
+          ? 'initializing'
+          : 'error',
       sessionUsable: isInSession && activeSessionIsUsable(),
       errorCode,
       retryAction,
@@ -749,7 +779,12 @@ export function createMobileAuthCoordinator(
     }
 
     transitions.enterOperation({
-      phase: candidate.context === 'refresh' ? 'authenticated' : 'verifyingSession',
+      phase:
+        candidate.context === 'refresh'
+          ? 'authenticated'
+          : candidate.context === 'restore'
+            ? 'initializing'
+            : 'verifyingSession',
       operation: 'verifying',
       sessionUsable: candidate.context === 'refresh' && activeSessionIsUsable(),
       notice: null,
@@ -851,7 +886,12 @@ export function createMobileAuthCoordinator(
       candidate.context === 'authorizationCode' || candidate.returnedRefreshToken !== undefined;
     if (needsPersistence) {
       transitions.enterOperation({
-        phase: candidate.context === 'refresh' ? 'authenticated' : 'exchangingCode',
+        phase:
+          candidate.context === 'refresh'
+            ? 'authenticated'
+            : candidate.context === 'restore'
+              ? 'initializing'
+              : 'exchangingCode',
         operation: 'persisting',
         sessionUsable: candidate.context === 'refresh' && activeSessionIsUsable(),
         notice: null,
@@ -1062,7 +1102,7 @@ export function createMobileAuthCoordinator(
       return;
     }
     transitions.enterSessionFailure({
-      phase: 'error',
+      phase: context === 'restore' ? 'initializing' : 'error',
       sessionUsable: false,
       errorCode: context === 'restore' ? 'session_restore_failed' : 'session_refresh_failed',
       retryAction: context,
@@ -1124,34 +1164,40 @@ export function createMobileAuthCoordinator(
       return;
     }
 
+    let refreshed: ReturnType<typeof parseRefreshTokenResponse>;
     try {
-      const refreshed = parseRefreshTokenResponse(
-        parseTransportData(response.data),
-        dependencies.now(),
-      );
-      const subject = validateRefreshedIdTokenClaims(refreshed.idToken, {
+      refreshed = parseRefreshTokenResponse(parseTransportData(response.data), dependencies.now());
+    } catch {
+      enterRefreshFailure(context);
+      return;
+    }
+
+    let subject: string;
+    try {
+      subject = validateRefreshedIdTokenClaims(refreshed.idToken, {
         config: dependencies.config,
         now: dependencies.now(),
         ...(expectedSubject === undefined ? {} : { expectedSubject }),
       });
-      const { refreshToken: returnedRefreshToken, ...bundle } = refreshed;
-      pendingCandidate = {
-        bundle,
-        durableRefreshToken: returnedRefreshToken ?? refreshToken,
-        ...(returnedRefreshToken === undefined ? {} : { returnedRefreshToken }),
-        context,
-        ...(context === 'refresh'
-          ? {
-              refreshOwner: refreshOwner!,
-              refreshGeneration: refreshGeneration!,
-            }
-          : {}),
-      };
-      pendingSubject = subject;
     } catch {
       await terminalSessionCleanupUnlocked();
       return;
     }
+
+    const { refreshToken: returnedRefreshToken, ...bundle } = refreshed;
+    pendingCandidate = {
+      bundle,
+      durableRefreshToken: returnedRefreshToken ?? refreshToken,
+      ...(returnedRefreshToken === undefined ? {} : { returnedRefreshToken }),
+      context,
+      ...(context === 'refresh'
+        ? {
+            refreshOwner: refreshOwner!,
+            refreshGeneration: refreshGeneration!,
+          }
+        : {}),
+    };
+    pendingSubject = subject;
 
     await persistPendingCandidateUnlocked();
   }
@@ -1242,34 +1288,26 @@ export function createMobileAuthCoordinator(
   async function continueColdInitializationUnlocked(
     refreshTokenResultPromise: Promise<SettledRefreshToken>,
   ): Promise<void> {
-    let launchUrl: { url: string } | undefined;
-    try {
-      launchUrl = await dependencies.app.getLaunchUrl();
-    } catch {
-      await removeListener(appUrlHandle);
-      await removeListener(appStateHandle);
-      await removeListener(browserFinishedHandle);
-      appUrlHandle = undefined;
-      appStateHandle = undefined;
-      browserFinishedHandle = undefined;
-      if (unavailable()) {
-        return;
-      }
-      transitions.enterOAuthError('configuration_error');
-      return;
-    }
+    const [launchUrlResult] = await Promise.allSettled([dependencies.app.getLaunchUrl()]);
 
     if (unavailable()) {
       return;
     }
-    const transaction = await loadTransactionSettled();
-    if (unavailable()) {
-      return;
-    }
-    if (launchUrl && isMatchingLaunchCallback(launchUrl.url, transaction)) {
-      await completeCallbackUnlocked(launchUrl.url, transaction.transaction);
-      await refreshTokenResultPromise;
-      return;
+
+    let transaction: SettledTransaction | undefined;
+    if (launchUrlResult.status === 'fulfilled') {
+      transaction = await loadTransactionSettled();
+      if (unavailable()) {
+        return;
+      }
+      if (
+        launchUrlResult.value &&
+        isMatchingLaunchCallback(launchUrlResult.value.url, transaction)
+      ) {
+        await completeCallbackUnlocked(launchUrlResult.value.url, transaction.transaction);
+        await refreshTokenResultPromise;
+        return;
+      }
     }
 
     const refreshTokenResult = await refreshTokenResultPromise;
@@ -1286,7 +1324,11 @@ export function createMobileAuthCoordinator(
     }
     if (refreshTokenResult.refreshToken !== null) {
       restoreRefreshToken = refreshTokenResult.refreshToken;
-      if (transaction.kind === 'unavailable' || transaction.transaction.kind !== 'missing') {
+      if (
+        transaction === undefined ||
+        transaction.kind === 'unavailable' ||
+        transaction.transaction.kind !== 'missing'
+      ) {
         await clearTransaction();
         if (unavailable()) {
           return;
@@ -1296,6 +1338,24 @@ export function createMobileAuthCoordinator(
       return;
     }
 
+    if (launchUrlResult.status === 'rejected') {
+      await removeListener(appUrlHandle);
+      await removeListener(appStateHandle);
+      await removeListener(browserFinishedHandle);
+      appUrlHandle = undefined;
+      appStateHandle = undefined;
+      browserFinishedHandle = undefined;
+      if (unavailable()) {
+        return;
+      }
+      transitions.enterOAuthError('configuration_error');
+      return;
+    }
+
+    if (!transaction) {
+      transitions.enterOAuthError('configuration_error');
+      return;
+    }
     resumeStoredTransactionUnlocked(transaction);
   }
 
@@ -1303,9 +1363,13 @@ export function createMobileAuthCoordinator(
     if (unavailable()) {
       return;
     }
+    const resetPhase: MobileAuthPhase =
+      state.phase === 'signedOut' && state.operation === 'cleaningUp'
+        ? 'signedOut'
+        : 'initializing';
     cleanupContext = { kind: 'installationReset' };
     transitions.enterOperation({
-      phase: 'initializing',
+      phase: resetPhase,
       operation: 'cleaningUp',
       sessionUsable: false,
       notice: null,
@@ -1385,28 +1449,28 @@ export function createMobileAuthCoordinator(
       browserFinishedHandle = undefined;
       return;
     }
-    const installationMarkerPromise = dependencies.installationStore.isCurrentInstallationMarked();
-    const refreshTokenResultPromise = loadRefreshTokenSettled();
-    const [installationMarkerResult] = await Promise.allSettled([installationMarkerPromise]);
-
-    if (unavailable()) {
-      await refreshTokenResultPromise;
-      return;
-    }
-    if (installationMarkerResult.status === 'rejected') {
-      await refreshTokenResultPromise;
+    let installationMarked: boolean;
+    try {
+      installationMarked = await dependencies.installationStore.isCurrentInstallationMarked();
+    } catch {
+      if (unavailable()) {
+        return;
+      }
       cleanupContext = { kind: 'installationReset' };
       transitions.enterCleanupFailure();
       return;
     }
-    if (!installationMarkerResult.value) {
-      await refreshTokenResultPromise;
+
+    if (unavailable()) {
+      return;
+    }
+    if (!installationMarked) {
       await performInstallationResetUnlocked();
       return;
     }
 
     cleanupContext = undefined;
-    await continueColdInitializationUnlocked(refreshTokenResultPromise);
+    await continueColdInitializationUnlocked(loadRefreshTokenSettled());
   }
 
   async function startSignInUnlocked(): Promise<void> {
@@ -1498,17 +1562,23 @@ export function createMobileAuthCoordinator(
     cancelActiveSessionTimers();
     activeBundleGeneration += 1;
 
-    let cleanupSucceeded = false;
+    let durableCleanupSucceeded = false;
+    let transactionCleanupSucceeded = false;
     try {
       await dependencies.sessionStore.clearRefreshToken();
+      durableCleanupSucceeded = true;
+    } catch {
+      // Durable and transaction cleanup are independent requirements.
+    }
+    try {
       await dependencies.transactionStore.clear();
-      cleanupSucceeded = true;
+      transactionCleanupSucceeded = true;
     } catch {
       // Cleanup failures publish only the stable retry context below.
     }
 
     eraseSessionMaterial();
-    if (!cleanupSucceeded) {
+    if (!durableCleanupSucceeded || !transactionCleanupSucceeded) {
       transitions.enterCleanupFailure();
       return;
     }
@@ -1541,12 +1611,14 @@ export function createMobileAuthCoordinator(
     cancelActiveSessionTimers();
     activeBundleGeneration += 1;
     automaticRetryUsed = false;
+    const signOutPhase: MobileAuthPhase =
+      active !== undefined || state.phase === 'authenticated' ? 'authenticated' : 'initializing';
     transitions.enterOperation({
-      phase: 'signedOut',
+      phase: signOutPhase,
       operation: 'signingOut',
       sessionUsable: false,
       notice: null,
-      user: null,
+      user: signOutPhase === 'authenticated' ? (state.user ?? active?.user ?? null) : null,
     });
 
     const cleanup = serialize(finishSignOutCleanupUnlocked);

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -1,11 +1,17 @@
 import { reactive, readonly, type InjectionKey } from 'vue';
 import {
   MOBILE_OAUTH_CALLBACK_URI,
+  assertMobileAuthState,
   type AuthorizationCodeTokenBundle,
   type MobileAppAdapter,
   type MobileAuthCoordinator,
   type MobileAuthErrorCode,
+  type MobileAuthNotice,
+  type MobileAuthOperation,
+  type MobileAuthPhase,
+  type MobileAuthRetryAction,
   type MobileAuthState,
+  type MobileAuthUser,
   type MobileBrowserAdapter,
   type MobileOAuthConfig,
   type MobileTokenTransportAdapter,
@@ -146,7 +152,11 @@ export function createMobileAuthCoordinator(
 ): MobileAuthCoordinator {
   const state = reactive<MobileAuthState>({
     phase: 'initializing',
+    operation: 'idle',
+    sessionUsable: false,
     errorCode: null,
+    retryAction: null,
+    notice: null,
     user: null,
   });
   const publicState = readonly(state) as Readonly<MobileAuthState>;
@@ -168,25 +178,123 @@ export function createMobileAuthCoordinator(
     return result;
   }
 
-  function setPhase(phase: MobileAuthState['phase']): void {
-    state.phase = phase;
-    state.errorCode = null;
-    if (phase !== 'authenticated') {
-      state.user = null;
-    }
+  function applyState(next: MobileAuthState): void {
+    assertMobileAuthState(next, {
+      activeBundle: tokenBundle ?? null,
+      now: dependencies.now(),
+    });
+    Object.assign(state, next);
   }
 
-  function setError(errorCode: MobileAuthErrorCode): void {
-    state.phase = 'error';
-    state.errorCode = errorCode;
-    state.user = null;
-  }
+  const transitions = {
+    enterOAuthProgress(phase: MobileAuthPhase): void {
+      applyState({
+        phase,
+        operation: 'idle',
+        sessionUsable: false,
+        errorCode: null,
+        retryAction: null,
+        notice: null,
+        user: null,
+      });
+    },
 
-  function setAuthenticated(user: { userId: string; email: string | null }): void {
-    state.phase = 'authenticated';
-    state.errorCode = null;
-    state.user = user;
-  }
+    enterOAuthError(errorCode: MobileAuthErrorCode): void {
+      applyState({
+        phase: 'error',
+        operation: 'idle',
+        sessionUsable: false,
+        errorCode,
+        retryAction: null,
+        notice: null,
+        user: null,
+      });
+    },
+
+    enterAuthenticated(user: MobileAuthUser): void {
+      applyState({
+        phase: 'authenticated',
+        operation: 'idle',
+        sessionUsable: true,
+        errorCode: null,
+        retryAction: null,
+        notice: null,
+        user,
+      });
+    },
+
+    enterSignedOut(notice: Extract<MobileAuthNotice, 'session_unusable' | null> = null): void {
+      applyState({
+        phase: 'signedOut',
+        operation: 'idle',
+        sessionUsable: false,
+        errorCode: null,
+        retryAction: null,
+        notice,
+        user: null,
+      });
+    },
+
+    enterSessionFailure(options: {
+      phase: MobileAuthPhase;
+      sessionUsable: boolean;
+      errorCode: MobileAuthErrorCode;
+      retryAction: MobileAuthRetryAction | null;
+      user: MobileAuthUser | null;
+    }): void {
+      applyState({
+        phase: options.phase,
+        operation: 'idle',
+        sessionUsable: options.sessionUsable,
+        errorCode: options.errorCode,
+        retryAction: options.retryAction,
+        notice: null,
+        user: options.user,
+      });
+    },
+
+    enterOperation(options: {
+      phase: MobileAuthPhase;
+      operation: Exclude<MobileAuthOperation, 'idle'>;
+      sessionUsable: boolean;
+      notice: MobileAuthNotice;
+      user: MobileAuthUser | null;
+    }): void {
+      applyState({
+        phase: options.phase,
+        operation: options.operation,
+        sessionUsable: options.sessionUsable,
+        errorCode: null,
+        retryAction: null,
+        notice: options.notice,
+        user: options.user,
+      });
+    },
+
+    enterTerminalNotice(): void {
+      applyState({
+        phase: 'signedOut',
+        operation: 'idle',
+        sessionUsable: false,
+        errorCode: null,
+        retryAction: null,
+        notice: 'session_unusable',
+        user: null,
+      });
+    },
+
+    enterCleanupFailure(): void {
+      applyState({
+        phase: 'signedOut',
+        operation: 'idle',
+        sessionUsable: false,
+        errorCode: 'session_cleanup_failed',
+        retryAction: 'cleanup',
+        notice: 'cleanup_incomplete',
+        user: null,
+      });
+    },
+  };
 
   async function removeListener(handle: ListenerHandle | undefined): Promise<void> {
     try {
@@ -206,7 +314,7 @@ export function createMobileAuthCoordinator(
 
   async function failCallback(errorCode: MobileAuthErrorCode): Promise<void> {
     tokenBundle = undefined;
-    setError(errorCode);
+    transitions.enterOAuthError(errorCode);
     await clearTransaction();
   }
 
@@ -224,7 +332,7 @@ export function createMobileAuthCoordinator(
       return;
     }
 
-    setPhase('verifyingSession');
+    transitions.enterOAuthProgress('verifyingSession');
 
     // The timeout and AbortController must remain active until the response
     // body has been fully consumed. fetch() resolves as soon as the response
@@ -245,18 +353,30 @@ export function createMobileAuthCoordinator(
           signal: controller.signal,
         });
       } catch {
-        setError('session_verification_failed');
+        transitions.enterSessionFailure({
+          phase: 'error',
+          sessionUsable: false,
+          errorCode: 'session_verification_failed',
+          retryAction: null,
+          user: null,
+        });
         return;
       }
 
       if (response.status === 401 || response.status === 403) {
         tokenBundle = undefined;
-        setError('session_unauthorized');
+        transitions.enterOAuthError('session_unauthorized');
         return;
       }
 
       if (!response.ok) {
-        setError('session_verification_failed');
+        transitions.enterSessionFailure({
+          phase: 'error',
+          sessionUsable: false,
+          errorCode: 'session_verification_failed',
+          retryAction: null,
+          user: null,
+        });
         return;
       }
 
@@ -264,17 +384,29 @@ export function createMobileAuthCoordinator(
       try {
         data = await response.json();
       } catch {
-        setError('session_verification_failed');
+        transitions.enterSessionFailure({
+          phase: 'error',
+          sessionUsable: false,
+          errorCode: 'session_verification_failed',
+          retryAction: null,
+          user: null,
+        });
         return;
       }
 
       const user = parseSessionUser(data);
       if (!user) {
-        setError('session_verification_failed');
+        transitions.enterSessionFailure({
+          phase: 'error',
+          sessionUsable: false,
+          errorCode: 'session_verification_failed',
+          retryAction: null,
+          user: null,
+        });
         return;
       }
 
-      setAuthenticated(user);
+      transitions.enterAuthenticated(user);
     } finally {
       clearTimeout(timeout);
     }
@@ -308,20 +440,20 @@ export function createMobileAuthCoordinator(
     try {
       loaded = await dependencies.transactionStore.load();
     } catch {
-      setPhase('exchangingCode');
+      transitions.enterOAuthProgress('exchangingCode');
       await closeBrowser();
       await failCallback('interrupted');
       return true;
     }
 
     if (loaded.kind === 'missing' || loaded.kind === 'corrupt') {
-      setPhase('exchangingCode');
+      transitions.enterOAuthProgress('exchangingCode');
       await closeBrowser();
       await failCallback(parsed.kind === 'malformed' ? 'malformed_callback' : 'interrupted');
       return true;
     }
     if (loaded.kind === 'expired') {
-      setPhase('exchangingCode');
+      transitions.enterOAuthProgress('exchangingCode');
       await closeBrowser();
       await failCallback('transaction_expired');
       return true;
@@ -339,7 +471,7 @@ export function createMobileAuthCoordinator(
       return false;
     }
 
-    setPhase('exchangingCode');
+    transitions.enterOAuthProgress('exchangingCode');
     await closeBrowser();
 
     if (parsed.kind === 'providerError') {
@@ -395,23 +527,23 @@ export function createMobileAuthCoordinator(
     try {
       loaded = await dependencies.transactionStore.load();
     } catch {
-      setError('configuration_error');
+      transitions.enterOAuthError('configuration_error');
       return;
     }
 
     if (loaded.kind === 'missing') {
-      setPhase('signedOut');
+      transitions.enterSignedOut();
       return;
     }
     if (loaded.kind === 'expired') {
-      setError('transaction_expired');
+      transitions.enterOAuthError('transaction_expired');
       return;
     }
     if (loaded.kind === 'corrupt') {
-      setError('interrupted');
+      transitions.enterOAuthError('interrupted');
       return;
     }
-    setError('interrupted');
+    transitions.enterOAuthError('interrupted');
   }
 
   async function initializeUnlocked(): Promise<void> {
@@ -419,10 +551,10 @@ export function createMobileAuthCoordinator(
       return;
     }
     initialized = true;
-    setPhase('initializing');
+    transitions.enterOAuthProgress('initializing');
 
     if (!hasValidConfig(dependencies.config, isDevelopment)) {
-      setError('configuration_error');
+      transitions.enterOAuthError('configuration_error');
       return;
     }
 
@@ -450,7 +582,7 @@ export function createMobileAuthCoordinator(
       await removeListener(browserFinishedHandle);
       appUrlHandle = undefined;
       browserFinishedHandle = undefined;
-      setError('configuration_error');
+      transitions.enterOAuthError('configuration_error');
       return;
     }
 
@@ -477,11 +609,11 @@ export function createMobileAuthCoordinator(
       !hasValidConfig(dependencies.config, isDevelopment) ||
       !hasOAuthCryptoCapabilities(dependencies.crypto, dependencies.isSecureContext)
     ) {
-      setError('configuration_error');
+      transitions.enterOAuthError('configuration_error');
       return;
     }
 
-    setPhase('openingBrowser');
+    transitions.enterOAuthProgress('openingBrowser');
 
     let authorizationUrl: string;
     try {
@@ -490,7 +622,7 @@ export function createMobileAuthCoordinator(
       authorizationUrl = buildAuthorizationUrl(dependencies.config, transaction, challenge);
       await dependencies.transactionStore.replace(transaction);
     } catch {
-      setError('configuration_error');
+      transitions.enterOAuthError('configuration_error');
       return;
     }
 
@@ -498,11 +630,11 @@ export function createMobileAuthCoordinator(
       await dependencies.browser.open({ url: authorizationUrl });
     } catch {
       await clearTransaction();
-      setError('browser_launch_failed');
+      transitions.enterOAuthError('browser_launch_failed');
       return;
     }
 
-    setPhase('awaitingCallback');
+    transitions.enterOAuthProgress('awaitingCallback');
   }
 
   async function handleBrowserFinishedUnlocked(): Promise<void> {
@@ -510,7 +642,7 @@ export function createMobileAuthCoordinator(
       return;
     }
 
-    setError('cancelled');
+    transitions.enterOAuthError('cancelled');
     await clearTransaction();
     if (isDevelopment) {
       console.info(
@@ -541,9 +673,7 @@ export function createMobileAuthCoordinator(
     appUrlHandle = undefined;
     browserFinishedHandle = undefined;
     tokenBundle = undefined;
-    state.phase = 'signedOut';
-    state.errorCode = null;
-    state.user = null;
+    transitions.enterSignedOut();
   }
 
   const coordinator: MobileAuthCoordinator = {

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -797,6 +797,23 @@ export function createMobileAuthCoordinator(
       return;
     }
 
+    // An expired candidate must not be verified directly: the expired ID
+    // token would elicit a 401 from /auth/session, which terminal cleanup
+    // treats as proof the durable refresh token is unusable — destroying a
+    // still-valid credential. Discard the expired candidate and obtain a
+    // fresh one through the refresh grant instead.
+    if (candidate.bundle.expiresAt <= dependencies.now()) {
+      const durableRefreshToken = candidate.durableRefreshToken;
+      pendingCandidate = undefined;
+      pendingSubject = undefined;
+      if (candidate.context === 'refresh') {
+        await refreshActiveSessionUnlocked();
+      } else {
+        await restoreSessionUnlocked(durableRefreshToken);
+      }
+      return;
+    }
+
     transitions.enterOperation({
       phase:
         candidate.context === 'refresh'
@@ -1128,8 +1145,26 @@ export function createMobileAuthCoordinator(
     });
   }
 
-  function isTerminalRefreshStatus(status: number): boolean {
-    return status === 400 || status === 401 || status === 403;
+  // RFC 6749 §5.2 requires token-endpoint errors to use HTTP 400 with an
+  // `error` parameter. Only `invalid_grant` establishes that the refresh
+  // token itself is revoked or otherwise unusable; other 400 errors
+  // (`invalid_client`, `invalid_request`, `unauthorized_client`,
+  // `unsupported_grant_type`) indicate client/config faults that don't
+  // invalidate the credential. A 401/403 from a gateway or WAF in front of
+  // Cognito is not an OAuth error at all. Treating any of those as terminal
+  // would destroy a still-valid durable refresh token and force an
+  // unnecessary interactive sign-in.
+  function isInvalidGrantRefreshFailure(response: { status: number; data: unknown }): boolean {
+    if (response.status !== 400) {
+      return false;
+    }
+    let parsed: unknown;
+    try {
+      parsed = parseTransportData(response.data);
+    } catch {
+      return false;
+    }
+    return isRecord(parsed) && parsed.error === 'invalid_grant';
   }
 
   async function refreshCandidateUnlocked(
@@ -1174,7 +1209,7 @@ export function createMobileAuthCoordinator(
       return;
     }
     if (response.status < 200 || response.status >= 300) {
-      if (isTerminalRefreshStatus(response.status)) {
+      if (isInvalidGrantRefreshFailure(response)) {
         await terminalSessionCleanupUnlocked();
       } else {
         enterRefreshFailure(context);

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -18,7 +18,7 @@ import {
   type OAuthTokenBundleBase,
 } from '../auth/mobile-auth-contract';
 import type { MobileInstallationStore } from '../auth/mobile-installation-store';
-import type { MobileSessionStore } from '../auth/mobile-session-store';
+import { MobileSessionStoreError, type MobileSessionStore } from '../auth/mobile-session-store';
 import {
   containsWhitespace,
   hasMatchingUserPoolRegion,
@@ -27,14 +27,20 @@ import {
 import {
   buildAuthorizationUrl,
   buildAuthorizationCodeTokenRequest,
+  buildRefreshTokenRequest,
   createOAuthTransaction,
   createPkceChallenge,
   hasOAuthCryptoCapabilities,
   parseOAuthCallback,
   parseAuthorizationCodeTokenResponse,
+  parseRefreshTokenResponse,
   validateAuthorizationCodeIdTokenClaims,
+  validateRefreshedIdTokenClaims,
 } from '../auth/mobile-oauth';
-import type { OAuthTransactionStore } from '../auth/oauth-transaction-store';
+import type {
+  LoadedOAuthTransaction,
+  OAuthTransactionStore,
+} from '../auth/oauth-transaction-store';
 
 type ListenerHandle = {
   remove(): Promise<void>;
@@ -47,7 +53,21 @@ type PendingCandidate = {
   context: 'authorizationCode' | 'restore' | 'refresh';
 };
 
+type ActiveSession = {
+  bundle: OAuthTokenBundleBase & { refreshToken: string };
+  user: MobileAuthUser;
+};
+
 type CleanupContext = { kind: 'terminalSession' } | { kind: 'installationReset' };
+
+type SettledRefreshToken =
+  | { kind: 'loaded'; refreshToken: string | null }
+  | { kind: 'corrupt' }
+  | { kind: 'unavailable' };
+
+type SettledTransaction =
+  | { kind: 'loaded'; transaction: LoadedOAuthTransaction }
+  | { kind: 'unavailable' };
 
 export type MobileAuthCoordinatorDependencies = {
   app: MobileAppAdapter;
@@ -191,8 +211,10 @@ export function createMobileAuthCoordinator(
   let operationTail = Promise.resolve();
   let appUrlHandle: ListenerHandle | undefined;
   let browserFinishedHandle: ListenerHandle | undefined;
-  let tokenBundle: AuthorizationCodeTokenBundle | undefined;
+  let active: ActiveSession | undefined;
   let pendingCandidate: PendingCandidate | undefined;
+  let pendingSubject: string | undefined;
+  let restoreRefreshToken: string | undefined;
   let cleanupContext: CleanupContext | undefined;
   let initialized = false;
   let disposed = false;
@@ -209,7 +231,7 @@ export function createMobileAuthCoordinator(
 
   function applyState(next: MobileAuthState): void {
     assertMobileAuthState(next, {
-      activeBundle: tokenBundle ?? null,
+      activeBundle: active?.bundle ?? null,
       now: dependencies.now(),
     });
     Object.assign(state, next);
@@ -300,6 +322,35 @@ export function createMobileAuthCoordinator(
       });
     },
 
+    enterRetryOperation(retryAction: MobileAuthRetryAction): void {
+      const operationByAction: Record<
+        MobileAuthRetryAction,
+        Exclude<MobileAuthOperation, 'idle'>
+      > = {
+        restore: 'restoring',
+        refresh: 'refreshing',
+        persist: 'persisting',
+        verify: 'verifying',
+        cleanup: 'cleaningUp',
+      };
+      const phaseByAction: Record<MobileAuthRetryAction, MobileAuthPhase> = {
+        restore: 'initializing',
+        refresh: 'authenticated',
+        persist: 'exchangingCode',
+        verify: 'verifyingSession',
+        cleanup: 'signedOut',
+      };
+      applyState({
+        phase: phaseByAction[retryAction],
+        operation: operationByAction[retryAction],
+        sessionUsable: false,
+        errorCode: null,
+        retryAction: null,
+        notice: null,
+        user: retryAction === 'refresh' ? (active?.user ?? null) : null,
+      });
+    },
+
     enterTerminalNotice(): void {
       applyState({
         phase: 'signedOut',
@@ -342,8 +393,10 @@ export function createMobileAuthCoordinator(
   }
 
   async function failCallback(errorCode: MobileAuthErrorCode): Promise<void> {
-    tokenBundle = undefined;
+    active = undefined;
     pendingCandidate = undefined;
+    pendingSubject = undefined;
+    restoreRefreshToken = undefined;
     cleanupContext = undefined;
     transitions.enterOAuthError(errorCode);
     await clearTransaction();
@@ -355,6 +408,22 @@ export function createMobileAuthCoordinator(
     } catch {
       // A callback is authoritative even if SFSafariViewController cannot close.
     }
+  }
+
+  async function terminalSessionCleanupUnlocked(): Promise<void> {
+    active = undefined;
+    pendingCandidate = undefined;
+    pendingSubject = undefined;
+    restoreRefreshToken = undefined;
+    cleanupContext = { kind: 'terminalSession' };
+    try {
+      await dependencies.sessionStore.clearRefreshToken();
+    } catch {
+      transitions.enterCleanupFailure();
+      return;
+    }
+    cleanupContext = undefined;
+    transitions.enterTerminalNotice();
   }
 
   async function verifyCandidateSessionUnlocked(): Promise<void> {
@@ -394,24 +463,14 @@ export function createMobileAuthCoordinator(
           phase: 'error',
           sessionUsable: false,
           errorCode: 'session_verification_failed',
-          retryAction: null,
+          retryAction: 'verify',
           user: null,
         });
         return;
       }
 
       if (response.status === 401 || response.status === 403) {
-        tokenBundle = undefined;
-        cleanupContext = { kind: 'terminalSession' };
-        try {
-          await dependencies.sessionStore.clearRefreshToken();
-        } catch {
-          transitions.enterCleanupFailure();
-          return;
-        }
-        pendingCandidate = undefined;
-        cleanupContext = undefined;
-        transitions.enterTerminalNotice();
+        await terminalSessionCleanupUnlocked();
         return;
       }
 
@@ -420,7 +479,7 @@ export function createMobileAuthCoordinator(
           phase: 'error',
           sessionUsable: false,
           errorCode: 'session_verification_failed',
-          retryAction: null,
+          retryAction: 'verify',
           user: null,
         });
         return;
@@ -434,7 +493,7 @@ export function createMobileAuthCoordinator(
           phase: 'error',
           sessionUsable: false,
           errorCode: 'session_verification_failed',
-          retryAction: null,
+          retryAction: 'verify',
           user: null,
         });
         return;
@@ -446,17 +505,27 @@ export function createMobileAuthCoordinator(
           phase: 'error',
           sessionUsable: false,
           errorCode: 'session_verification_failed',
-          retryAction: null,
+          retryAction: 'verify',
           user: null,
         });
         return;
       }
 
-      tokenBundle = {
-        ...candidate.bundle,
-        refreshToken: candidate.durableRefreshToken,
+      if (pendingSubject !== undefined && user.userId !== pendingSubject) {
+        await terminalSessionCleanupUnlocked();
+        return;
+      }
+
+      active = {
+        bundle: {
+          ...candidate.bundle,
+          refreshToken: candidate.durableRefreshToken,
+        },
+        user,
       };
       pendingCandidate = undefined;
+      pendingSubject = undefined;
+      restoreRefreshToken = undefined;
       cleanupContext = undefined;
       transitions.enterAuthenticated(user);
     } finally {
@@ -470,44 +539,51 @@ export function createMobileAuthCoordinator(
       return;
     }
 
-    transitions.enterOperation({
-      phase: 'exchangingCode',
-      operation: 'persisting',
-      sessionUsable: false,
-      notice: null,
-      user: null,
-    });
-    try {
-      await dependencies.sessionStore.saveRefreshToken(candidate.durableRefreshToken);
-    } catch {
-      transitions.enterSessionFailure({
-        phase: 'error',
+    const needsPersistence =
+      candidate.context === 'authorizationCode' || candidate.returnedRefreshToken !== undefined;
+    if (needsPersistence) {
+      transitions.enterOperation({
+        phase: 'exchangingCode',
+        operation: 'persisting',
         sessionUsable: false,
-        errorCode: 'session_persistence_failed',
-        retryAction: 'persist',
+        notice: null,
         user: null,
       });
-      return;
-    }
+      try {
+        await dependencies.sessionStore.saveRefreshToken(candidate.durableRefreshToken);
+      } catch {
+        transitions.enterSessionFailure({
+          phase: 'error',
+          sessionUsable: false,
+          errorCode: 'session_persistence_failed',
+          retryAction: 'persist',
+          user: null,
+        });
+        return;
+      }
 
-    if (candidate.context === 'authorizationCode') {
-      // Only a durable refresh credential permits transaction removal. A
-      // failed Preferences cleanup remains best effort because the exchanged
-      // authorization code is single-use.
-      await clearTransaction();
+      if (candidate.context === 'authorizationCode') {
+        // Only a durable refresh credential permits transaction removal. A
+        // failed Preferences cleanup remains best effort because the exchanged
+        // authorization code is single-use.
+        await clearTransaction();
+      }
     }
 
     await verifyCandidateSessionUnlocked();
   }
 
-  async function completeCallbackUnlocked(rawUrl: string): Promise<boolean> {
+  async function completeCallbackUnlocked(
+    rawUrl: string,
+    loadedTransaction?: LoadedOAuthTransaction,
+  ): Promise<boolean> {
     const isActiveCallbackPhase =
       state.phase === 'initializing' ||
       state.phase === 'openingBrowser' ||
       state.phase === 'awaitingCallback' ||
       (state.phase === 'error' && state.errorCode === 'interrupted');
 
-    if (disposed || !initialized || tokenBundle || pendingCandidate || !isActiveCallbackPhase) {
+    if (disposed || !initialized || active || pendingCandidate || !isActiveCallbackPhase) {
       return false;
     }
 
@@ -524,14 +600,16 @@ export function createMobileAuthCoordinator(
     // transaction, failCallback clears it, and the replacement flow is dead.
     // By validating first we preserve the current transaction, phase, and
     // browser session for the legitimate callback.
-    let loaded: Awaited<ReturnType<OAuthTransactionStore['load']>>;
-    try {
-      loaded = await dependencies.transactionStore.load();
-    } catch {
-      transitions.enterOAuthProgress('exchangingCode');
-      await closeBrowser();
-      await failCallback('interrupted');
-      return true;
+    let loaded = loadedTransaction;
+    if (!loaded) {
+      try {
+        loaded = await dependencies.transactionStore.load();
+      } catch {
+        transitions.enterOAuthProgress('exchangingCode');
+        await closeBrowser();
+        await failCallback('interrupted');
+        return true;
+      }
     }
 
     if (loaded.kind === 'missing' || loaded.kind === 'corrupt') {
@@ -606,32 +684,248 @@ export function createMobileAuthCoordinator(
       durableRefreshToken: refreshToken,
       context: 'authorizationCode',
     };
+    pendingSubject = undefined;
     await persistPendingCandidateUnlocked();
     return true;
   }
 
-  async function resumeStoredTransactionUnlocked(): Promise<void> {
-    let loaded: Awaited<ReturnType<OAuthTransactionStore['load']>>;
+  function classifyRefreshTokenLoad(
+    result: PromiseSettledResult<string | null>,
+  ): SettledRefreshToken {
+    if (result.status === 'fulfilled') {
+      return { kind: 'loaded', refreshToken: result.value };
+    }
+    if (result.reason instanceof MobileSessionStoreError && result.reason.code === 'corrupt') {
+      return { kind: 'corrupt' };
+    }
+    return { kind: 'unavailable' };
+  }
+
+  async function loadRefreshTokenSettled(): Promise<SettledRefreshToken> {
+    const [result] = await Promise.allSettled([dependencies.sessionStore.loadRefreshToken()]);
+    return classifyRefreshTokenLoad(result!);
+  }
+
+  async function loadTransactionSettled(): Promise<SettledTransaction> {
     try {
-      loaded = await dependencies.transactionStore.load();
+      return { kind: 'loaded', transaction: await dependencies.transactionStore.load() };
     } catch {
-      transitions.enterOAuthError('configuration_error');
+      return { kind: 'unavailable' };
+    }
+  }
+
+  function enterRefreshFailure(context: 'restore' | 'refresh'): void {
+    transitions.enterSessionFailure({
+      phase: 'error',
+      sessionUsable: false,
+      errorCode: context === 'restore' ? 'session_restore_failed' : 'session_refresh_failed',
+      retryAction: context,
+      user: null,
+    });
+  }
+
+  function isTerminalRefreshStatus(status: number): boolean {
+    return status === 400 || status === 401 || status === 403;
+  }
+
+  async function refreshCandidateUnlocked(
+    refreshToken: string,
+    context: 'restore' | 'refresh',
+    expectedSubject?: string,
+  ): Promise<void> {
+    if (disposed) {
       return;
     }
 
-    if (loaded.kind === 'missing') {
+    transitions.enterOperation({
+      phase: context === 'restore' ? 'initializing' : 'authenticated',
+      operation: context === 'restore' ? 'restoring' : 'refreshing',
+      sessionUsable: false,
+      notice: null,
+      user: context === 'refresh' ? (active?.user ?? null) : null,
+    });
+
+    let response: { status: number; data: unknown };
+    try {
+      response = await dependencies.tokenTransport.request(
+        buildRefreshTokenRequest(dependencies.config, refreshToken, {
+          timeoutMs: MOBILE_AUTH_NETWORK_TIMEOUT_MS,
+        }),
+      );
+    } catch {
+      enterRefreshFailure(context);
+      return;
+    }
+
+    if (response.status < 200 || response.status >= 300) {
+      if (isTerminalRefreshStatus(response.status)) {
+        await terminalSessionCleanupUnlocked();
+      } else {
+        enterRefreshFailure(context);
+      }
+      return;
+    }
+
+    try {
+      const refreshed = parseRefreshTokenResponse(
+        parseTransportData(response.data),
+        dependencies.now(),
+      );
+      const subject = validateRefreshedIdTokenClaims(refreshed.idToken, {
+        config: dependencies.config,
+        now: dependencies.now(),
+        ...(expectedSubject === undefined ? {} : { expectedSubject }),
+      });
+      const { refreshToken: returnedRefreshToken, ...bundle } = refreshed;
+      pendingCandidate = {
+        bundle,
+        durableRefreshToken: returnedRefreshToken ?? refreshToken,
+        ...(returnedRefreshToken === undefined ? {} : { returnedRefreshToken }),
+        context,
+      };
+      pendingSubject = subject;
+    } catch {
+      await terminalSessionCleanupUnlocked();
+      return;
+    }
+
+    await persistPendingCandidateUnlocked();
+  }
+
+  async function restoreSessionUnlocked(refreshToken?: string): Promise<void> {
+    let durableRefreshToken = refreshToken ?? restoreRefreshToken;
+    if (!durableRefreshToken) {
+      const loaded = await loadRefreshTokenSettled();
+      if (loaded.kind === 'corrupt') {
+        await terminalSessionCleanupUnlocked();
+        return;
+      }
+      if (loaded.kind === 'unavailable') {
+        enterRefreshFailure('restore');
+        return;
+      }
+      if (loaded.refreshToken === null) {
+        restoreRefreshToken = undefined;
+        transitions.enterSignedOut();
+        return;
+      }
+      durableRefreshToken = loaded.refreshToken;
+    }
+
+    restoreRefreshToken = durableRefreshToken;
+    await refreshCandidateUnlocked(durableRefreshToken, 'restore');
+  }
+
+  async function refreshActiveSessionUnlocked(): Promise<void> {
+    const current = active;
+    if (!current || disposed) {
+      return;
+    }
+    await refreshCandidateUnlocked(current.bundle.refreshToken, 'refresh', current.user.userId);
+  }
+
+  function resumeStoredTransactionUnlocked(loaded: SettledTransaction): void {
+    if (loaded.kind === 'unavailable') {
+      transitions.enterOAuthError('configuration_error');
+      return;
+    }
+    if (loaded.transaction.kind === 'missing') {
       transitions.enterSignedOut();
       return;
     }
-    if (loaded.kind === 'expired') {
+    if (loaded.transaction.kind === 'expired') {
       transitions.enterOAuthError('transaction_expired');
       return;
     }
-    if (loaded.kind === 'corrupt') {
+    if (loaded.transaction.kind === 'corrupt') {
       transitions.enterOAuthError('interrupted');
       return;
     }
     transitions.enterOAuthError('interrupted');
+  }
+
+  function isMatchingLaunchCallback(
+    rawUrl: string,
+    loaded: SettledTransaction,
+  ): loaded is {
+    kind: 'loaded';
+    transaction: Extract<LoadedOAuthTransaction, { kind: 'active' }>;
+  } {
+    if (loaded.kind !== 'loaded' || loaded.transaction.kind !== 'active') {
+      return false;
+    }
+    const parsed = parseOAuthCallback(rawUrl);
+    return (
+      (parsed.kind === 'success' || parsed.kind === 'providerError') &&
+      parsed.state === loaded.transaction.transaction.state
+    );
+  }
+
+  async function continueColdInitializationUnlocked(
+    refreshTokenResultPromise: Promise<SettledRefreshToken>,
+  ): Promise<void> {
+    let launchUrl: { url: string } | undefined;
+    try {
+      launchUrl = await dependencies.app.getLaunchUrl();
+    } catch {
+      await removeListener(appUrlHandle);
+      await removeListener(browserFinishedHandle);
+      appUrlHandle = undefined;
+      browserFinishedHandle = undefined;
+      transitions.enterOAuthError('configuration_error');
+      return;
+    }
+
+    const transaction = await loadTransactionSettled();
+    if (launchUrl && isMatchingLaunchCallback(launchUrl.url, transaction)) {
+      await completeCallbackUnlocked(launchUrl.url, transaction.transaction);
+      await refreshTokenResultPromise;
+      return;
+    }
+
+    const refreshTokenResult = await refreshTokenResultPromise;
+    if (refreshTokenResult.kind === 'corrupt') {
+      await terminalSessionCleanupUnlocked();
+      return;
+    }
+    if (refreshTokenResult.kind === 'unavailable') {
+      enterRefreshFailure('restore');
+      return;
+    }
+    if (refreshTokenResult.refreshToken !== null) {
+      restoreRefreshToken = refreshTokenResult.refreshToken;
+      if (transaction.kind === 'unavailable' || transaction.transaction.kind !== 'missing') {
+        await clearTransaction();
+      }
+      await restoreSessionUnlocked(refreshTokenResult.refreshToken);
+      return;
+    }
+
+    resumeStoredTransactionUnlocked(transaction);
+  }
+
+  async function performInstallationResetUnlocked(): Promise<void> {
+    cleanupContext = { kind: 'installationReset' };
+    transitions.enterOperation({
+      phase: 'initializing',
+      operation: 'cleaningUp',
+      sessionUsable: false,
+      notice: null,
+      user: null,
+    });
+    try {
+      await dependencies.sessionStore.clearRefreshToken();
+      await dependencies.installationStore.markCurrentInstallation();
+    } catch {
+      transitions.enterCleanupFailure();
+      return;
+    }
+    cleanupContext = undefined;
+    restoreRefreshToken = undefined;
+    transitions.enterOAuthProgress('initializing');
+    await continueColdInitializationUnlocked(
+      Promise.resolve({ kind: 'loaded', refreshToken: null }),
+    );
   }
 
   async function initializeUnlocked(): Promise<void> {
@@ -667,50 +961,24 @@ export function createMobileAuthCoordinator(
       return;
     }
 
-    try {
+    const installationMarkerPromise = dependencies.installationStore.isCurrentInstallationMarked();
+    const refreshTokenResultPromise = loadRefreshTokenSettled();
+    const [installationMarkerResult] = await Promise.allSettled([installationMarkerPromise]);
+
+    if (installationMarkerResult.status === 'rejected') {
+      await refreshTokenResultPromise;
       cleanupContext = { kind: 'installationReset' };
-      const isMarked = await dependencies.installationStore.isCurrentInstallationMarked();
-      if (!isMarked) {
-        transitions.enterOperation({
-          phase: 'initializing',
-          operation: 'cleaningUp',
-          sessionUsable: false,
-          notice: null,
-          user: null,
-        });
-        await dependencies.sessionStore.clearRefreshToken();
-        await dependencies.installationStore.markCurrentInstallation();
-        transitions.enterOAuthProgress('initializing');
-      }
-      cleanupContext = undefined;
-    } catch {
       transitions.enterCleanupFailure();
       return;
     }
-
-    try {
-      const launchUrl = await dependencies.app.getLaunchUrl();
-      if (launchUrl && parseOAuthCallback(launchUrl.url).kind !== 'unrelated') {
-        const consumed = await completeCallbackUnlocked(launchUrl.url);
-        if (consumed) {
-          return;
-        }
-        // The callback was ignored (malformed or state mismatch) to
-        // preserve an in-flight transaction. Fall through to
-        // resumeStoredTransactionUnlocked so the coordinator leaves the
-        // `initializing` phase instead of stranding the user with no
-        // retry action.
-      }
-    } catch {
-      await removeListener(appUrlHandle);
-      await removeListener(browserFinishedHandle);
-      appUrlHandle = undefined;
-      browserFinishedHandle = undefined;
-      transitions.enterOAuthError('configuration_error');
+    if (!installationMarkerResult.value) {
+      await refreshTokenResultPromise;
+      await performInstallationResetUnlocked();
       return;
     }
 
-    await resumeStoredTransactionUnlocked();
+    cleanupContext = undefined;
+    await continueColdInitializationUnlocked(refreshTokenResultPromise);
   }
 
   async function startSignInUnlocked(): Promise<void> {
@@ -774,19 +1042,39 @@ export function createMobileAuthCoordinator(
     }
   }
 
-  async function retrySessionVerificationUnlocked(): Promise<void> {
-    // Cleanup retries have distinct installation-reset versus terminal-session
-    // semantics. Retain that context for the dedicated cleanup flow rather
-    // than routing either case through a verification retry.
-    if (disposed || cleanupContext || state.phase !== 'error' || !pendingCandidate) {
+  async function retryCleanupUnlocked(): Promise<void> {
+    if (cleanupContext?.kind === 'installationReset') {
+      await performInstallationResetUnlocked();
       return;
     }
-    if (state.errorCode === 'session_persistence_failed' && state.retryAction === 'persist') {
-      await persistPendingCandidateUnlocked();
+    if (cleanupContext?.kind === 'terminalSession') {
+      await terminalSessionCleanupUnlocked();
+    }
+  }
+
+  async function retryCurrentOperationUnlocked(): Promise<void> {
+    const retryAction = state.retryAction;
+    if (disposed || retryAction === null || state.operation !== 'idle') {
       return;
     }
-    if (state.errorCode === 'session_verification_failed') {
-      await verifyCandidateSessionUnlocked();
+
+    transitions.enterRetryOperation(retryAction);
+    switch (retryAction) {
+      case 'restore':
+        await restoreSessionUnlocked();
+        return;
+      case 'refresh':
+        await refreshActiveSessionUnlocked();
+        return;
+      case 'persist':
+        await persistPendingCandidateUnlocked();
+        return;
+      case 'verify':
+        await verifyCandidateSessionUnlocked();
+        return;
+      case 'cleanup':
+        await retryCleanupUnlocked();
+        return;
     }
   }
 
@@ -799,8 +1087,10 @@ export function createMobileAuthCoordinator(
     await removeListener(browserFinishedHandle);
     appUrlHandle = undefined;
     browserFinishedHandle = undefined;
-    tokenBundle = undefined;
+    active = undefined;
     pendingCandidate = undefined;
+    pendingSubject = undefined;
+    restoreRefreshToken = undefined;
     cleanupContext = undefined;
     transitions.enterSignedOut();
   }
@@ -810,7 +1100,7 @@ export function createMobileAuthCoordinator(
     initialize: () => serialize(initializeUnlocked),
     startSignIn: () => serialize(startSignInUnlocked),
     completeCallback: (url) => serialize(() => completeCallbackUnlocked(url).then(() => undefined)),
-    retrySessionVerification: () => serialize(retrySessionVerificationUnlocked),
+    retryCurrentOperation: () => serialize(retryCurrentOperationUnlocked),
     dispose: () => serialize(disposeUnlocked),
   };
 

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -808,6 +808,23 @@ export function createMobileAuthCoordinator(
   // guards (refreshCandidateUnlocked's refreshIsCurrent enforces them).
   async function reissueExpiredCandidateUnlocked(candidate: PendingCandidate): Promise<void> {
     const durableRefreshToken = candidate.durableRefreshToken;
+    // For a refresh candidate, active still holds the pre-rotation R1 while
+    // R2 is already persisted in the keychain. If this reissue fails
+    // transiently (network error or retryable server response),
+    // enterRefreshFailure('refresh') records retryAction: 'refresh' and the
+    // next retry dispatches to refreshActiveSessionUnlocked(), which reads
+    // active.bundle.refreshToken. Without promoting R2 into active here,
+    // that retry would send the stale R1 — which after its rotation grace
+    // ends returns invalid_grant and triggers terminal cleanup that deletes
+    // the valid persisted R2. Mutate active.bundle.refreshToken in place
+    // (rather than reassigning active) so refreshCandidateUnlocked's
+    // refreshIsCurrent guard (refreshOwner === active) still holds. The
+    // refresh grant's invalid_grant path still terminally cleans up if R2
+    // itself is genuinely unusable; a successful reissue overwrites active
+    // entirely on promotion.
+    if (candidate.context === 'refresh' && active !== undefined) {
+      active.bundle.refreshToken = durableRefreshToken;
+    }
     pendingCandidate = undefined;
     pendingSubject = undefined;
     if (candidate.context === 'refresh') {
@@ -877,6 +894,18 @@ export function createMobileAuthCoordinator(
         return;
       }
       if (response.status === 401 || response.status === 403) {
+        // The API returns 401 for an expired ID token (auth middleware:
+        // "Invalid or expired token"). A candidate that was valid when the
+        // request started can expire during the network round trip and
+        // arrive as 401, even though its durable refresh token is still
+        // usable. Recheck expiry before treating 401/403 as terminal; an
+        // expired candidate must be reissued so the refresh grant determines
+        // whether the durable credential is actually unusable, rather than
+        // deleting it on the ID token's expiry alone.
+        if (candidate.bundle.expiresAt <= dependencies.now()) {
+          await reissueExpiredCandidateUnlocked(candidate);
+          return;
+        }
         await terminalSessionCleanupUnlocked();
         return;
       }

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -51,6 +51,8 @@ type PendingCandidate = {
   durableRefreshToken: string;
   returnedRefreshToken?: string;
   context: 'authorizationCode' | 'restore' | 'refresh';
+  refreshOwner?: ActiveSession;
+  refreshGeneration?: number;
 };
 
 type ActiveSession = {
@@ -58,7 +60,10 @@ type ActiveSession = {
   user: MobileAuthUser;
 };
 
-type CleanupContext = { kind: 'terminalSession' } | { kind: 'installationReset' };
+type CleanupContext =
+  | { kind: 'signOut' }
+  | { kind: 'terminalSession' }
+  | { kind: 'installationReset' };
 
 type SettledRefreshToken =
   | { kind: 'loaded'; refreshToken: string | null }
@@ -226,8 +231,10 @@ export function createMobileAuthCoordinator(
   let pendingSubject: string | undefined;
   let restoreRefreshToken: string | undefined;
   let cleanupContext: CleanupContext | undefined;
+  let signOutPromise: Promise<void> | undefined;
   let initialized = false;
   let disposed = false;
+  let disposalRequested = false;
   const isDevelopment = dependencies.isDevelopment ?? import.meta.env.DEV;
 
   function serialize<T>(operation: () => Promise<T>): Promise<T> {
@@ -249,6 +256,10 @@ export function createMobileAuthCoordinator(
 
   function activeSessionIsUsable(): boolean {
     return active !== undefined && active.bundle.expiresAt > dependencies.now();
+  }
+
+  function unavailable(): boolean {
+    return disposed || disposalRequested;
   }
 
   const transitions = {
@@ -430,7 +441,7 @@ export function createMobileAuthCoordinator(
   }
 
   function closeExpiredActiveSession(owner: ActiveSession, generation: number): void {
-    if (disposed || active !== owner || activeBundleGeneration !== generation) {
+    if (unavailable() || active !== owner || activeBundleGeneration !== generation) {
       return;
     }
     if (owner.bundle.expiresAt > dependencies.now()) {
@@ -486,7 +497,12 @@ export function createMobileAuthCoordinator(
 
   function scheduleProactiveRefreshTimer(owner: ActiveSession, generation: number): void {
     cancelProactiveRefreshTimer();
-    if (!appIsActive || disposed || active !== owner || activeBundleGeneration !== generation) {
+    if (
+      !appIsActive ||
+      unavailable() ||
+      active !== owner ||
+      activeBundleGeneration !== generation
+    ) {
       return;
     }
     const delay = Math.max(
@@ -501,7 +517,7 @@ export function createMobileAuthCoordinator(
 
   function scheduleActiveSessionTimers(): void {
     const owner = active;
-    if (!owner || disposed) {
+    if (!owner || unavailable()) {
       return;
     }
     const generation = activeBundleGeneration;
@@ -514,6 +530,9 @@ export function createMobileAuthCoordinator(
     owner?: ActiveSession;
     generation?: number;
   }): Promise<void> {
+    if (unavailable()) {
+      return Promise.resolve();
+    }
     if (refreshPromise !== undefined) {
       return refreshPromise;
     }
@@ -527,7 +546,7 @@ export function createMobileAuthCoordinator(
     cancelProactiveRefreshTimer();
     const operation = serialize(async () => {
       if (
-        disposed ||
+        unavailable() ||
         !appIsActive ||
         active !== owner ||
         activeBundleGeneration !== generation ||
@@ -542,7 +561,7 @@ export function createMobileAuthCoordinator(
         scheduleProactiveRefreshTimer(owner, generation);
         return;
       }
-      await refreshActiveSessionUnlocked();
+      await refreshActiveSessionUnlocked(owner, generation);
     });
     let tracked!: Promise<void>;
     tracked = operation.finally(() => {
@@ -555,7 +574,7 @@ export function createMobileAuthCoordinator(
   }
 
   function queueRecordedRetry(): void {
-    if (state.retryAction === null || state.operation !== 'idle' || disposed || !appIsActive) {
+    if (state.retryAction === null || state.operation !== 'idle' || unavailable() || !appIsActive) {
       return;
     }
     if (state.retryAction === 'refresh') {
@@ -572,7 +591,7 @@ export function createMobileAuthCoordinator(
     const retryAction = state.retryAction;
     if (
       !owner ||
-      disposed ||
+      unavailable() ||
       !appIsActive ||
       automaticRetryUsed ||
       automaticRetryTimer !== undefined ||
@@ -591,7 +610,7 @@ export function createMobileAuthCoordinator(
     automaticRetryTimer = setTimeout(() => {
       automaticRetryTimer = undefined;
       if (
-        disposed ||
+        unavailable() ||
         !appIsActive ||
         active !== owner ||
         owner.bundle.expiresAt <= dependencies.now() ||
@@ -612,7 +631,7 @@ export function createMobileAuthCoordinator(
     }
 
     const owner = active;
-    if (!owner || disposed) {
+    if (!owner || unavailable()) {
       return;
     }
     if (state.retryAction === 'persist' || state.retryAction === 'verify') {
@@ -652,6 +671,15 @@ export function createMobileAuthCoordinator(
     }
   }
 
+  function candidateIsCurrent(candidate: PendingCandidate): boolean {
+    return (
+      !unavailable() &&
+      (candidate.context !== 'refresh' ||
+        (candidate.refreshOwner === active &&
+          candidate.refreshGeneration === activeBundleGeneration))
+    );
+  }
+
   async function failCallback(errorCode: MobileAuthErrorCode): Promise<void> {
     clearActiveSession();
     pendingCandidate = undefined;
@@ -672,6 +700,7 @@ export function createMobileAuthCoordinator(
 
   async function terminalSessionCleanupUnlocked(): Promise<void> {
     clearActiveSession();
+    const cleanupGeneration = activeBundleGeneration;
     pendingCandidate = undefined;
     pendingSubject = undefined;
     restoreRefreshToken = undefined;
@@ -679,7 +708,13 @@ export function createMobileAuthCoordinator(
     try {
       await dependencies.sessionStore.clearRefreshToken();
     } catch {
+      if (unavailable() || activeBundleGeneration !== cleanupGeneration) {
+        return;
+      }
       transitions.enterCleanupFailure();
+      return;
+    }
+    if (unavailable() || activeBundleGeneration !== cleanupGeneration) {
       return;
     }
     cleanupContext = undefined;
@@ -709,7 +744,7 @@ export function createMobileAuthCoordinator(
 
   async function verifyCandidateSessionUnlocked(): Promise<void> {
     const candidate = pendingCandidate;
-    if (!candidate || disposed) {
+    if (!candidate || !candidateIsCurrent(candidate)) {
       return;
     }
 
@@ -740,10 +775,16 @@ export function createMobileAuthCoordinator(
           signal: controller.signal,
         });
       } catch {
+        if (!candidateIsCurrent(candidate)) {
+          return;
+        }
         enterCandidateFailure(candidate, 'session_verification_failed', 'verify');
         return;
       }
 
+      if (!candidateIsCurrent(candidate)) {
+        return;
+      }
       if (response.status === 401 || response.status === 403) {
         await terminalSessionCleanupUnlocked();
         return;
@@ -758,10 +799,16 @@ export function createMobileAuthCoordinator(
       try {
         data = await response.json();
       } catch {
+        if (!candidateIsCurrent(candidate)) {
+          return;
+        }
         enterCandidateFailure(candidate, 'session_verification_failed', 'verify');
         return;
       }
 
+      if (!candidateIsCurrent(candidate)) {
+        return;
+      }
       const user = parseSessionUser(data);
       if (!user) {
         enterCandidateFailure(candidate, 'session_verification_failed', 'verify');
@@ -796,7 +843,7 @@ export function createMobileAuthCoordinator(
 
   async function persistPendingCandidateUnlocked(): Promise<void> {
     const candidate = pendingCandidate;
-    if (!candidate || disposed) {
+    if (!candidate || !candidateIsCurrent(candidate)) {
       return;
     }
 
@@ -813,15 +860,24 @@ export function createMobileAuthCoordinator(
       try {
         await dependencies.sessionStore.saveRefreshToken(candidate.durableRefreshToken);
       } catch {
+        if (!candidateIsCurrent(candidate)) {
+          return;
+        }
         enterCandidateFailure(candidate, 'session_persistence_failed', 'persist');
         return;
       }
 
+      if (!candidateIsCurrent(candidate)) {
+        return;
+      }
       if (candidate.context === 'authorizationCode') {
         // Only a durable refresh credential permits transaction removal. A
         // failed Preferences cleanup remains best effort because the exchanged
         // authorization code is single-use.
         await clearTransaction();
+        if (!candidateIsCurrent(candidate)) {
+          return;
+        }
       }
     }
 
@@ -838,7 +894,7 @@ export function createMobileAuthCoordinator(
       state.phase === 'awaitingCallback' ||
       (state.phase === 'error' && state.errorCode === 'interrupted');
 
-    if (disposed || !initialized || active || pendingCandidate || !isActiveCallbackPhase) {
+    if (unavailable() || !initialized || active || pendingCandidate || !isActiveCallbackPhase) {
       return false;
     }
 
@@ -860,22 +916,37 @@ export function createMobileAuthCoordinator(
       try {
         loaded = await dependencies.transactionStore.load();
       } catch {
+        if (unavailable()) {
+          return false;
+        }
         transitions.enterOAuthProgress('exchangingCode');
         await closeBrowser();
+        if (unavailable()) {
+          return false;
+        }
         await failCallback('interrupted');
         return true;
       }
     }
 
+    if (unavailable()) {
+      return false;
+    }
     if (loaded.kind === 'missing' || loaded.kind === 'corrupt') {
       transitions.enterOAuthProgress('exchangingCode');
       await closeBrowser();
+      if (unavailable()) {
+        return true;
+      }
       await failCallback(parsed.kind === 'malformed' ? 'malformed_callback' : 'interrupted');
       return true;
     }
     if (loaded.kind === 'expired') {
       transitions.enterOAuthProgress('exchangingCode');
       await closeBrowser();
+      if (unavailable()) {
+        return true;
+      }
       await failCallback('transaction_expired');
       return true;
     }
@@ -894,6 +965,9 @@ export function createMobileAuthCoordinator(
 
     transitions.enterOAuthProgress('exchangingCode');
     await closeBrowser();
+    if (unavailable()) {
+      return true;
+    }
 
     if (parsed.kind === 'providerError') {
       await failCallback(parsed.error === 'access_denied' ? 'cancelled' : 'provider_error');
@@ -908,10 +982,16 @@ export function createMobileAuthCoordinator(
         }),
       );
     } catch {
+      if (unavailable()) {
+        return true;
+      }
       await failCallback('code_exchange_failed');
       return true;
     }
 
+    if (unavailable()) {
+      return true;
+    }
     if (response.status < 200 || response.status >= 300) {
       await failCallback('code_exchange_failed');
       return true;
@@ -998,8 +1078,14 @@ export function createMobileAuthCoordinator(
     refreshToken: string,
     context: 'restore' | 'refresh',
     expectedSubject?: string,
+    refreshOwner?: ActiveSession,
+    refreshGeneration?: number,
   ): Promise<void> {
-    if (disposed) {
+    const refreshIsCurrent = () =>
+      !unavailable() &&
+      (context !== 'refresh' ||
+        (refreshOwner === active && refreshGeneration === activeBundleGeneration));
+    if (!refreshIsCurrent()) {
       return;
     }
 
@@ -1019,10 +1105,16 @@ export function createMobileAuthCoordinator(
         }),
       );
     } catch {
+      if (!refreshIsCurrent()) {
+        return;
+      }
       enterRefreshFailure(context);
       return;
     }
 
+    if (!refreshIsCurrent()) {
+      return;
+    }
     if (response.status < 200 || response.status >= 300) {
       if (isTerminalRefreshStatus(response.status)) {
         await terminalSessionCleanupUnlocked();
@@ -1048,6 +1140,12 @@ export function createMobileAuthCoordinator(
         durableRefreshToken: returnedRefreshToken ?? refreshToken,
         ...(returnedRefreshToken === undefined ? {} : { returnedRefreshToken }),
         context,
+        ...(context === 'refresh'
+          ? {
+              refreshOwner: refreshOwner!,
+              refreshGeneration: refreshGeneration!,
+            }
+          : {}),
       };
       pendingSubject = subject;
     } catch {
@@ -1062,6 +1160,9 @@ export function createMobileAuthCoordinator(
     let durableRefreshToken = refreshToken ?? restoreRefreshToken;
     if (!durableRefreshToken) {
       const loaded = await loadRefreshTokenSettled();
+      if (unavailable()) {
+        return;
+      }
       if (loaded.kind === 'corrupt') {
         await terminalSessionCleanupUnlocked();
         return;
@@ -1082,15 +1183,26 @@ export function createMobileAuthCoordinator(
     await refreshCandidateUnlocked(durableRefreshToken, 'restore');
   }
 
-  async function refreshActiveSessionUnlocked(): Promise<void> {
-    const current = active;
-    if (!current || disposed) {
+  async function refreshActiveSessionUnlocked(
+    current = active,
+    generation = activeBundleGeneration,
+  ): Promise<void> {
+    if (!current || unavailable() || active !== current || activeBundleGeneration !== generation) {
       return;
     }
-    await refreshCandidateUnlocked(current.bundle.refreshToken, 'refresh', current.user.userId);
+    await refreshCandidateUnlocked(
+      current.bundle.refreshToken,
+      'refresh',
+      current.user.userId,
+      current,
+      generation,
+    );
   }
 
   function resumeStoredTransactionUnlocked(loaded: SettledTransaction): void {
+    if (unavailable()) {
+      return;
+    }
     if (loaded.kind === 'unavailable') {
       transitions.enterOAuthError('configuration_error');
       return;
@@ -1140,11 +1252,20 @@ export function createMobileAuthCoordinator(
       appUrlHandle = undefined;
       appStateHandle = undefined;
       browserFinishedHandle = undefined;
+      if (unavailable()) {
+        return;
+      }
       transitions.enterOAuthError('configuration_error');
       return;
     }
 
+    if (unavailable()) {
+      return;
+    }
     const transaction = await loadTransactionSettled();
+    if (unavailable()) {
+      return;
+    }
     if (launchUrl && isMatchingLaunchCallback(launchUrl.url, transaction)) {
       await completeCallbackUnlocked(launchUrl.url, transaction.transaction);
       await refreshTokenResultPromise;
@@ -1152,6 +1273,9 @@ export function createMobileAuthCoordinator(
     }
 
     const refreshTokenResult = await refreshTokenResultPromise;
+    if (unavailable()) {
+      return;
+    }
     if (refreshTokenResult.kind === 'corrupt') {
       await terminalSessionCleanupUnlocked();
       return;
@@ -1164,6 +1288,9 @@ export function createMobileAuthCoordinator(
       restoreRefreshToken = refreshTokenResult.refreshToken;
       if (transaction.kind === 'unavailable' || transaction.transaction.kind !== 'missing') {
         await clearTransaction();
+        if (unavailable()) {
+          return;
+        }
       }
       await restoreSessionUnlocked(refreshTokenResult.refreshToken);
       return;
@@ -1173,6 +1300,9 @@ export function createMobileAuthCoordinator(
   }
 
   async function performInstallationResetUnlocked(): Promise<void> {
+    if (unavailable()) {
+      return;
+    }
     cleanupContext = { kind: 'installationReset' };
     transitions.enterOperation({
       phase: 'initializing',
@@ -1183,9 +1313,18 @@ export function createMobileAuthCoordinator(
     });
     try {
       await dependencies.sessionStore.clearRefreshToken();
+      if (unavailable()) {
+        return;
+      }
       await dependencies.installationStore.markCurrentInstallation();
     } catch {
+      if (unavailable()) {
+        return;
+      }
       transitions.enterCleanupFailure();
+      return;
+    }
+    if (unavailable()) {
       return;
     }
     cleanupContext = undefined;
@@ -1197,7 +1336,7 @@ export function createMobileAuthCoordinator(
   }
 
   async function initializeUnlocked(): Promise<void> {
-    if (disposed || initialized) {
+    if (unavailable() || initialized) {
       return;
     }
     initialized = true;
@@ -1230,14 +1369,30 @@ export function createMobileAuthCoordinator(
       appUrlHandle = undefined;
       appStateHandle = undefined;
       browserFinishedHandle = undefined;
+      if (unavailable()) {
+        return;
+      }
       transitions.enterOAuthError('configuration_error');
       return;
     }
 
+    if (unavailable()) {
+      await removeListener(appUrlHandle);
+      await removeListener(appStateHandle);
+      await removeListener(browserFinishedHandle);
+      appUrlHandle = undefined;
+      appStateHandle = undefined;
+      browserFinishedHandle = undefined;
+      return;
+    }
     const installationMarkerPromise = dependencies.installationStore.isCurrentInstallationMarked();
     const refreshTokenResultPromise = loadRefreshTokenSettled();
     const [installationMarkerResult] = await Promise.allSettled([installationMarkerPromise]);
 
+    if (unavailable()) {
+      await refreshTokenResultPromise;
+      return;
+    }
     if (installationMarkerResult.status === 'rejected') {
       await refreshTokenResultPromise;
       cleanupContext = { kind: 'installationReset' };
@@ -1265,7 +1420,7 @@ export function createMobileAuthCoordinator(
           state.errorCode !== null &&
           RESTARTABLE_OAUTH_ERRORS.has(state.errorCode)));
 
-    if (disposed || !canStartSignIn) {
+    if (unavailable() || !canStartSignIn) {
       return;
     }
 
@@ -1283,39 +1438,133 @@ export function createMobileAuthCoordinator(
     try {
       const transaction = createOAuthTransaction(dependencies.crypto, dependencies.now());
       const challenge = await createPkceChallenge(transaction.codeVerifier, dependencies.crypto);
+      if (unavailable()) {
+        return;
+      }
       authorizationUrl = buildAuthorizationUrl(dependencies.config, transaction, challenge);
       await dependencies.transactionStore.replace(transaction);
     } catch {
+      if (unavailable()) {
+        return;
+      }
       transitions.enterOAuthError('configuration_error');
       return;
     }
 
+    if (unavailable()) {
+      return;
+    }
     try {
       await dependencies.browser.open({ url: authorizationUrl });
     } catch {
+      if (unavailable()) {
+        return;
+      }
       await clearTransaction();
       transitions.enterOAuthError('browser_launch_failed');
       return;
     }
 
+    if (unavailable()) {
+      return;
+    }
     transitions.enterOAuthProgress('awaitingCallback');
   }
 
   async function handleBrowserFinishedUnlocked(): Promise<void> {
-    if (disposed || state.phase !== 'awaitingCallback') {
+    if (unavailable() || state.phase !== 'awaitingCallback') {
       return;
     }
 
     transitions.enterOAuthError('cancelled');
     await clearTransaction();
-    if (isDevelopment) {
+    if (!unavailable() && isDevelopment) {
       console.info(
         'browser_closed_before_callback — verify the deployed Cognito client ID and redirect URI configuration.',
       );
     }
   }
 
+  function eraseSessionMaterial(): void {
+    active = undefined;
+    pendingCandidate = undefined;
+    pendingSubject = undefined;
+    restoreRefreshToken = undefined;
+    automaticRetryUsed = false;
+  }
+
+  async function finishSignOutCleanupUnlocked(): Promise<void> {
+    cleanupContext = { kind: 'signOut' };
+    cancelActiveSessionTimers();
+    activeBundleGeneration += 1;
+
+    let cleanupSucceeded = false;
+    try {
+      await dependencies.sessionStore.clearRefreshToken();
+      await dependencies.transactionStore.clear();
+      cleanupSucceeded = true;
+    } catch {
+      // Cleanup failures publish only the stable retry context below.
+    }
+
+    eraseSessionMaterial();
+    if (!cleanupSucceeded) {
+      transitions.enterCleanupFailure();
+      return;
+    }
+
+    cleanupContext = undefined;
+    transitions.enterSignedOut();
+  }
+
+  function canSignOutOrStartOver(): boolean {
+    if (unavailable()) {
+      return false;
+    }
+    return (
+      state.phase === 'authenticated' ||
+      (state.operation === 'idle' &&
+        state.sessionUsable === false &&
+        state.retryAction !== null &&
+        ['restore', 'refresh', 'persist', 'verify'].includes(state.retryAction))
+    );
+  }
+
+  function signOut(): Promise<void> {
+    if (signOutPromise !== undefined) {
+      return signOutPromise;
+    }
+    if (!canSignOutOrStartOver()) {
+      return Promise.resolve();
+    }
+
+    cancelActiveSessionTimers();
+    activeBundleGeneration += 1;
+    automaticRetryUsed = false;
+    transitions.enterOperation({
+      phase: 'signedOut',
+      operation: 'signingOut',
+      sessionUsable: false,
+      notice: null,
+      user: null,
+    });
+
+    const cleanup = serialize(finishSignOutCleanupUnlocked);
+    let tracked!: Promise<void>;
+    tracked = cleanup.finally(() => {
+      if (signOutPromise === tracked) {
+        signOutPromise = undefined;
+      }
+    });
+    signOutPromise = tracked;
+    return tracked;
+  }
+
   async function retryCleanupUnlocked(): Promise<void> {
+    if (cleanupContext?.kind === 'signOut') {
+      await finishSignOutCleanupUnlocked();
+      return;
+    }
     if (cleanupContext?.kind === 'installationReset') {
       await performInstallationResetUnlocked();
       return;
@@ -1327,7 +1576,7 @@ export function createMobileAuthCoordinator(
 
   async function retryCurrentOperationUnlocked(): Promise<void> {
     const retryAction = state.retryAction;
-    if (disposed || retryAction === null || state.operation !== 'idle') {
+    if (unavailable() || retryAction === null || state.operation !== 'idle') {
       return;
     }
 
@@ -1352,6 +1601,9 @@ export function createMobileAuthCoordinator(
   }
 
   function retryCurrentOperation(): Promise<void> {
+    if (unavailable()) {
+      return Promise.resolve();
+    }
     if (refreshPromise !== undefined) {
       cancelAutomaticRetryTimer();
       return refreshPromise;
@@ -1391,13 +1643,30 @@ export function createMobileAuthCoordinator(
     transitions.enterSignedOut();
   }
 
+  function dispose(): Promise<void> {
+    if (disposed) {
+      return Promise.resolve();
+    }
+    if (disposalRequested) {
+      return operationTail;
+    }
+    disposalRequested = true;
+    cancelActiveSessionTimers();
+    activeBundleGeneration += 1;
+    return serialize(disposeUnlocked);
+  }
+
   const coordinator: MobileAuthCoordinator = {
     state: publicState,
-    initialize: () => serialize(initializeUnlocked),
-    startSignIn: () => serialize(startSignInUnlocked),
-    completeCallback: (url) => serialize(() => completeCallbackUnlocked(url).then(() => undefined)),
+    initialize: () => (unavailable() ? Promise.resolve() : serialize(initializeUnlocked)),
+    startSignIn: () => (unavailable() ? Promise.resolve() : serialize(startSignInUnlocked)),
+    completeCallback: (url) =>
+      unavailable()
+        ? Promise.resolve()
+        : serialize(() => completeCallbackUnlocked(url).then(() => undefined)),
     retryCurrentOperation,
-    dispose: () => serialize(disposeUnlocked),
+    signOut,
+    dispose,
   };
 
   return coordinator;

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -791,26 +791,46 @@ export function createMobileAuthCoordinator(
     }
   }
 
+  // An expired candidate must not be verified or promoted directly. The
+  // expired ID token would either elicit a 401 from /auth/session (which
+  // terminal cleanup treats as proof the durable refresh token is unusable,
+  // destroying a still-valid credential) or trip the live-bundle invariant
+  // in enterAuthenticated() (via applyState → assertMobileAuthState) after
+  // active and recovery state have been mutated. Discard the expired
+  // candidate and reissue the grant through its durable refresh token.
+  //
+  // For a refresh candidate the durable token may be a rotated R2 that was
+  // already persisted while active still holds R1. refreshActiveSessionUnlocked()
+  // would send active.bundle.refreshToken (R1); once R1's rotation grace
+  // ends Cognito returns invalid_grant and terminal cleanup deletes the
+  // valid persisted R2. Rebuild the grant here with the candidate's durable
+  // token while retaining the active owner, generation, and expected-subject
+  // guards (refreshCandidateUnlocked's refreshIsCurrent enforces them).
+  async function reissueExpiredCandidateUnlocked(candidate: PendingCandidate): Promise<void> {
+    const durableRefreshToken = candidate.durableRefreshToken;
+    pendingCandidate = undefined;
+    pendingSubject = undefined;
+    if (candidate.context === 'refresh') {
+      await refreshCandidateUnlocked(
+        durableRefreshToken,
+        'refresh',
+        candidate.refreshOwner.user.userId,
+        candidate.refreshOwner,
+        candidate.generation,
+      );
+    } else {
+      await restoreSessionUnlocked(durableRefreshToken);
+    }
+  }
+
   async function verifyCandidateSessionUnlocked(): Promise<void> {
     const candidate = pendingCandidate;
     if (!candidate || !candidateIsCurrent(candidate)) {
       return;
     }
 
-    // An expired candidate must not be verified directly: the expired ID
-    // token would elicit a 401 from /auth/session, which terminal cleanup
-    // treats as proof the durable refresh token is unusable — destroying a
-    // still-valid credential. Discard the expired candidate and obtain a
-    // fresh one through the refresh grant instead.
     if (candidate.bundle.expiresAt <= dependencies.now()) {
-      const durableRefreshToken = candidate.durableRefreshToken;
-      pendingCandidate = undefined;
-      pendingSubject = undefined;
-      if (candidate.context === 'refresh') {
-        await refreshActiveSessionUnlocked();
-      } else {
-        await restoreSessionUnlocked(durableRefreshToken);
-      }
+      await reissueExpiredCandidateUnlocked(candidate);
       return;
     }
 
@@ -888,6 +908,19 @@ export function createMobileAuthCoordinator(
 
       if (pendingSubject !== undefined && user.userId !== pendingSubject) {
         await terminalSessionCleanupUnlocked();
+        return;
+      }
+
+      // Recheck expiry immediately before promotion, before mutating active
+      // or clearing the pending recovery data. The candidate may have
+      // expired during the /auth/session request or response-body read;
+      // enterAuthenticated() indirectly invokes the live-bundle invariant
+      // (applyState → assertMobileAuthState with now()), so a candidate that
+      // expires mid-flight can throw after active has been replaced and
+      // pendingCandidate cleared. scheduleActiveSessionTimers() runs only
+      // after that call and therefore cannot provide zero-delay recovery.
+      if (candidate.bundle.expiresAt <= dependencies.now()) {
+        await reissueExpiredCandidateUnlocked(candidate);
         return;
       }
 
@@ -1147,7 +1180,10 @@ export function createMobileAuthCoordinator(
 
   // RFC 6749 §5.2 requires token-endpoint errors to use HTTP 400 with an
   // `error` parameter. Only `invalid_grant` establishes that the refresh
-  // token itself is revoked or otherwise unusable; other 400 errors
+  // token itself is unusable for this grant — Cognito returns it for a
+  // revoked token but also for some app-client attribute-permission
+  // failures, so it does not uniquely prove revocation; it does prove the
+  // credential cannot be redeemed and must be discarded. Other 400 errors
   // (`invalid_client`, `invalid_request`, `unauthorized_client`,
   // `unsupported_grant_type`) indicate client/config faults that don't
   // invalidate the credential. A 401/403 from a gateway or WAF in front of

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -46,14 +46,23 @@ type ListenerHandle = {
   remove(): Promise<void>;
 };
 
-type PendingCandidate = {
+type PendingCandidateBase = {
   bundle: OAuthTokenBundleBase;
   durableRefreshToken: string;
+  // Captured at candidate creation so candidateIsCurrent can reject any
+  // candidate (not just refresh) whose owning generation was invalidated by
+  // sign-out, disposal, or an intervening session reset.
+  generation: number;
   returnedRefreshToken?: string;
-  context: 'authorizationCode' | 'restore' | 'refresh';
-  refreshOwner?: ActiveSession;
-  refreshGeneration?: number;
 };
+
+type PendingCandidate =
+  | (PendingCandidateBase & { context: 'authorizationCode' })
+  | (PendingCandidateBase & { context: 'restore' })
+  | (PendingCandidateBase & {
+      context: 'refresh';
+      refreshOwner: ActiveSession;
+    });
 
 type ActiveSession = {
   bundle: OAuthTokenBundleBase & { refreshToken: string };
@@ -674,6 +683,15 @@ export function createMobileAuthCoordinator(
     }
   }
 
+  async function removeListenerHandles(): Promise<void> {
+    await removeListener(appUrlHandle);
+    await removeListener(appStateHandle);
+    await removeListener(browserFinishedHandle);
+    appUrlHandle = undefined;
+    appStateHandle = undefined;
+    browserFinishedHandle = undefined;
+  }
+
   async function clearTransaction(): Promise<void> {
     try {
       await dependencies.transactionStore.clear();
@@ -683,12 +701,13 @@ export function createMobileAuthCoordinator(
   }
 
   function candidateIsCurrent(candidate: PendingCandidate): boolean {
-    return (
-      !unavailable() &&
-      (candidate.context !== 'refresh' ||
-        (candidate.refreshOwner === active &&
-          candidate.refreshGeneration === activeBundleGeneration))
-    );
+    if (unavailable() || candidate.generation !== activeBundleGeneration) {
+      return false;
+    }
+    if (candidate.context === 'refresh') {
+      return candidate.refreshOwner === active;
+    }
+    return true;
   }
 
   async function failCallback(errorCode: MobileAuthErrorCode): Promise<void> {
@@ -1038,12 +1057,13 @@ export function createMobileAuthCoordinator(
     }
 
     let bundle: AuthorizationCodeTokenBundle;
+    let authorizationCodeSubject: string;
     try {
       bundle = parseAuthorizationCodeTokenResponse(
         parseTransportData(response.data),
         dependencies.now(),
       );
-      validateAuthorizationCodeIdTokenClaims(bundle.idToken, {
+      authorizationCodeSubject = validateAuthorizationCodeIdTokenClaims(bundle.idToken, {
         config: dependencies.config,
         transaction,
         now: dependencies.now(),
@@ -1058,27 +1078,25 @@ export function createMobileAuthCoordinator(
       bundle: candidateBundle,
       durableRefreshToken: refreshToken,
       context: 'authorizationCode',
+      generation: activeBundleGeneration,
     };
-    pendingSubject = undefined;
+    pendingSubject = authorizationCodeSubject;
     await persistPendingCandidateUnlocked();
     return true;
   }
 
-  function classifyRefreshTokenLoad(
-    result: PromiseSettledResult<string | null>,
-  ): SettledRefreshToken {
-    if (result.status === 'fulfilled') {
-      return { kind: 'loaded', refreshToken: result.value };
-    }
-    if (result.reason instanceof MobileSessionStoreError && result.reason.code === 'corrupt') {
-      return { kind: 'corrupt' };
-    }
-    return { kind: 'unavailable' };
-  }
-
   async function loadRefreshTokenSettled(): Promise<SettledRefreshToken> {
-    const [result] = await Promise.allSettled([dependencies.sessionStore.loadRefreshToken()]);
-    return classifyRefreshTokenLoad(result!);
+    try {
+      return {
+        kind: 'loaded',
+        refreshToken: await dependencies.sessionStore.loadRefreshToken(),
+      };
+    } catch (reason) {
+      if (reason instanceof MobileSessionStoreError && reason.code === 'corrupt') {
+        return { kind: 'corrupt' };
+      }
+      return { kind: 'unavailable' };
+    }
   }
 
   async function loadTransactionSettled(): Promise<SettledTransaction> {
@@ -1185,18 +1203,26 @@ export function createMobileAuthCoordinator(
     }
 
     const { refreshToken: returnedRefreshToken, ...bundle } = refreshed;
-    pendingCandidate = {
-      bundle,
-      durableRefreshToken: returnedRefreshToken ?? refreshToken,
-      ...(returnedRefreshToken === undefined ? {} : { returnedRefreshToken }),
-      context,
-      ...(context === 'refresh'
-        ? {
-            refreshOwner: refreshOwner!,
-            refreshGeneration: refreshGeneration!,
-          }
-        : {}),
-    };
+    const durableRefreshToken = returnedRefreshToken ?? refreshToken;
+    const generation = activeBundleGeneration;
+    if (context === 'refresh') {
+      pendingCandidate = {
+        bundle,
+        durableRefreshToken,
+        generation,
+        context,
+        refreshOwner: refreshOwner!,
+        ...(returnedRefreshToken === undefined ? {} : { returnedRefreshToken }),
+      };
+    } else {
+      pendingCandidate = {
+        bundle,
+        durableRefreshToken,
+        generation,
+        context,
+        ...(returnedRefreshToken === undefined ? {} : { returnedRefreshToken }),
+      };
+    }
     pendingSubject = subject;
 
     await persistPendingCandidateUnlocked();
@@ -1339,12 +1365,7 @@ export function createMobileAuthCoordinator(
     }
 
     if (launchUrlResult.status === 'rejected') {
-      await removeListener(appUrlHandle);
-      await removeListener(appStateHandle);
-      await removeListener(browserFinishedHandle);
-      appUrlHandle = undefined;
-      appStateHandle = undefined;
-      browserFinishedHandle = undefined;
+      await removeListenerHandles();
       if (unavailable()) {
         return;
       }
@@ -1427,12 +1448,7 @@ export function createMobileAuthCoordinator(
         void serialize(handleBrowserFinishedUnlocked);
       });
     } catch {
-      await removeListener(appUrlHandle);
-      await removeListener(appStateHandle);
-      await removeListener(browserFinishedHandle);
-      appUrlHandle = undefined;
-      appStateHandle = undefined;
-      browserFinishedHandle = undefined;
+      await removeListenerHandles();
       if (unavailable()) {
         return;
       }
@@ -1441,12 +1457,7 @@ export function createMobileAuthCoordinator(
     }
 
     if (unavailable()) {
-      await removeListener(appUrlHandle);
-      await removeListener(appStateHandle);
-      await removeListener(browserFinishedHandle);
-      appUrlHandle = undefined;
-      appStateHandle = undefined;
-      browserFinishedHandle = undefined;
+      await removeListenerHandles();
       return;
     }
     let installationMarked: boolean;
@@ -1701,12 +1712,7 @@ export function createMobileAuthCoordinator(
     }
     disposed = true;
     cancelActiveSessionTimers();
-    await removeListener(appUrlHandle);
-    await removeListener(appStateHandle);
-    await removeListener(browserFinishedHandle);
-    appUrlHandle = undefined;
-    appStateHandle = undefined;
-    browserFinishedHandle = undefined;
+    await removeListenerHandles();
     clearActiveSession();
     pendingCandidate = undefined;
     pendingSubject = undefined;

--- a/apps/vela-mobile/src/test/secret-leak-helpers.ts
+++ b/apps/vela-mobile/src/test/secret-leak-helpers.ts
@@ -1,0 +1,167 @@
+import { expect, vi } from 'vitest';
+import { MOBILE_OAUTH_TRANSACTION_KEY } from '../auth/mobile-auth-contract';
+
+/**
+ * Shared secret-leak regression helpers. The sentinel lists and assertions
+ * live here so a single source of truth governs every mobile auth secret-leak
+ * test (coordinator, gate, and boot). Add a new secret surface here once,
+ * rather than duplicating it across three test files.
+ */
+
+export const SECRET_SENTINELS = [
+  'SECRET-access-token',
+  'SECRET-id-token',
+  'SECRET-refresh-token',
+  'SECRET-rotated-refresh-token',
+] as const;
+
+export const LOG_AND_DOM_SENTINELS = [
+  ...SECRET_SENTINELS,
+  'SECRET-authorization-url',
+  'SECRET-callback-code',
+  'SECRET-code-verifier',
+  'SECRET-nonce',
+  'SECRET-claim-email',
+] as const;
+
+export const NON_SCHEMA_STORAGE_SENTINELS = [
+  'SECRET-callback-code',
+  'SECRET-claim-email',
+  'SECRET-raw-request',
+  'SECRET-raw-response',
+  'SECRET-native-exception',
+] as const;
+
+export function searchable(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function storageSnapshot(storage: Storage): string {
+  return Array.from({ length: storage.length }, (_, index) => {
+    const key = storage.key(index) ?? '';
+    return `${key}=${storage.getItem(key) ?? ''}`;
+  }).join('\n');
+}
+
+export function captureConsoleCalls(): {
+  calls: () => unknown[][];
+  restore: () => void;
+} {
+  const spies = (['debug', 'info', 'log', 'warn', 'error'] as const).map((method) =>
+    vi.spyOn(console, method).mockImplementation(() => undefined),
+  );
+  return {
+    calls: () =>
+      spies.flatMap((spy) =>
+        spy.mock.calls.map((call) =>
+          call.map((value) =>
+            value instanceof Error ? { ...value, name: value.name, message: value.message } : value,
+          ),
+        ),
+      ),
+    restore: () => {
+      for (const spy of spies) spy.mockRestore();
+    },
+  };
+}
+
+/**
+ * Creates the secret-leak assertions. The preference-write schema check uses
+ * the supplied installation key (derived from the OAuth config by each caller)
+ * to verify that non-transaction preference writes target only the installation
+ * marker. Callers that never produce preference writes (gate, boot) may pass a
+ * placeholder key.
+ */
+export function createSecretLeakAssertions(options: { installationKey: string }): {
+  expectNoSecretLeak: (input: {
+    consoleCalls: unknown[][];
+    preferenceCalls: unknown[][];
+    renderedText?: string;
+  }) => void;
+  expectApprovedPreferenceWrites: (preferenceCalls: unknown[][]) => void;
+} {
+  const installationKey = options.installationKey;
+
+  function expectApprovedPreferenceWrites(preferenceCalls: unknown[][]): void {
+    for (const call of preferenceCalls) {
+      expect(call).toHaveLength(1);
+      const options = call[0];
+      expect(options).toEqual(
+        expect.objectContaining({
+          key: expect.any(String),
+          value: expect.any(String),
+        }),
+      );
+      const { key, value } = options as { key: string; value: string };
+      expect(Object.keys(options as object).sort()).toEqual(['key', 'value']);
+
+      if (key === MOBILE_OAUTH_TRANSACTION_KEY) {
+        let parsed: unknown = null;
+        try {
+          parsed = JSON.parse(value);
+        } catch {
+          expect.fail('OAuth transaction Preferences value must be valid JSON');
+        }
+        expect(parsed).toEqual(
+          expect.objectContaining({
+            state: expect.any(String),
+            codeVerifier: expect.any(String),
+            nonce: expect.any(String),
+            createdAt: expect.any(Number),
+          }),
+        );
+        const transaction = parsed as Record<string, unknown>;
+        expect(Object.keys(transaction).sort()).toEqual([
+          'codeVerifier',
+          'createdAt',
+          'nonce',
+          'state',
+        ]);
+        expect((transaction.state as string).length).toBeGreaterThan(0);
+        expect((transaction.codeVerifier as string).length).toBeGreaterThan(0);
+        expect((transaction.nonce as string).length).toBeGreaterThan(0);
+        expect(Number.isFinite(transaction.createdAt)).toBe(true);
+        continue;
+      }
+
+      expect(key).toBe(installationKey);
+      expect(value).toBe('1');
+    }
+  }
+
+  function expectNoSecretLeak(input: {
+    consoleCalls: unknown[][];
+    preferenceCalls: unknown[][];
+    renderedText?: string;
+  }): void {
+    const logsAndDom = [
+      searchable(input.consoleCalls),
+      input.renderedText ?? document.body.textContent ?? '',
+    ].join('\n');
+    const browserAndPreferenceStorage = [
+      searchable(input.preferenceCalls),
+      storageSnapshot(window.localStorage),
+      storageSnapshot(window.sessionStorage),
+    ].join('\n');
+
+    for (const secret of LOG_AND_DOM_SENTINELS) {
+      expect(logsAndDom).not.toContain(secret);
+    }
+    expect(logsAndDom).not.toContain('SECRET-');
+    for (const secret of SECRET_SENTINELS) {
+      expect(browserAndPreferenceStorage).not.toContain(secret);
+    }
+    for (const secret of NON_SCHEMA_STORAGE_SENTINELS) {
+      expect(browserAndPreferenceStorage).not.toContain(secret);
+    }
+    expectApprovedPreferenceWrites(input.preferenceCalls);
+    expect(storageSnapshot(window.localStorage)).toBe('');
+    expect(storageSnapshot(window.sessionStorage)).toBe('');
+  }
+
+  return { expectNoSecretLeak, expectApprovedPreferenceWrites };
+}

--- a/apps/vela-mobile/vitest.config.ts
+++ b/apps/vela-mobile/vitest.config.ts
@@ -60,6 +60,10 @@ export default defineConfig({
         __dirname,
         './src-capacitor/node_modules/@capacitor/preferences',
       ),
+      '@aparajita/capacitor-secure-storage': resolve(
+        __dirname,
+        './src-capacitor/node_modules/@aparajita/capacitor-secure-storage',
+      ),
     },
   },
 });

--- a/docs/superpowers/plans/2026-07-29-mobile-cognito-session-persistence.md
+++ b/docs/superpowers/plans/2026-07-29-mobile-cognito-session-persistence.md
@@ -21,8 +21,10 @@ remain unchanged.
 
 ## Global Constraints
 
+- `$REPO_ROOT` is the repository root (the directory containing `apps/`,
+  `packages/`, `docs/`). All `cd` commands below are relative to it.
 - Work on branch `codex/hpa-206-mobile-session-persistence` in
-  `/Users/chanwaichan/workspace/Vela`.
+  `$REPO_ROOT`.
 - Treat
   `docs/superpowers/specs/2026-07-29-mobile-cognito-session-persistence-design.md`
   as the accepted behavioral contract.
@@ -124,7 +126,7 @@ KeychainAccess.afterFirstUnlockThisDeviceOnly)`, and
 - [ ] Confirm the accepted documents are the only uncommitted files:
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela
+cd $REPO_ROOT
 rtk git status --short
 ```
 
@@ -206,7 +208,7 @@ export function createUnsupportedMobileSessionStore(): MobileSessionStore;
 - [ ] **Step 1: Pin and synchronize the plugin**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile/src-capacitor
+cd $REPO_ROOT/apps/vela-mobile/src-capacitor
 rtk bun add --exact @aparajita/capacitor-secure-storage@7.1.6
 rtk bunx cap sync ios
 ```
@@ -304,7 +306,7 @@ make zero plugin calls.
 - [ ] **Step 3: Run the focused test to verify it fails**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bunx vitest run src/auth/mobile-session-store.test.ts
 ```
 
@@ -376,7 +378,7 @@ Add this alias to both `quasar.config.ts` and `vitest.config.ts`:
 - [ ] **Step 6: Verify the adapter and native metadata**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bunx vitest run src/auth/mobile-session-store.test.ts
 rtk bun run typecheck
 rtk git diff -- src-capacitor/ios/App/PrivacyInfo.xcprivacy
@@ -387,7 +389,7 @@ Expected: focused tests and typecheck PASS; the privacy-manifest diff is empty.
 - [ ] **Step 7: Commit**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela
+cd $REPO_ROOT
 rtk git add \
   apps/vela-mobile/src/auth/mobile-session-store.ts \
   apps/vela-mobile/src/auth/mobile-session-store.test.ts \
@@ -481,7 +483,7 @@ rejections.
 - [ ] **Step 2: Run the focused test to verify it fails**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bunx vitest run src/auth/mobile-installation-store.test.ts
 ```
 
@@ -523,12 +525,12 @@ export function createMobileInstallationStore(
 - [ ] **Step 4: Verify and commit**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bunx vitest run \
   src/auth/mobile-installation-store.test.ts \
   src/auth/oauth-transaction-store.test.ts
 rtk bun run typecheck
-cd /Users/chanwaichan/workspace/Vela
+cd $REPO_ROOT
 rtk git add \
   apps/vela-mobile/src/auth/mobile-installation-store.ts \
   apps/vela-mobile/src/auth/mobile-installation-store.test.ts
@@ -726,7 +728,7 @@ it.each([
 - [ ] **Step 3: Run the focused test to verify it fails**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bunx vitest run \
   src/auth/mobile-oauth.test.ts \
   src/services/mobile-auth.test.ts
@@ -816,10 +818,10 @@ Split the callback transport and validation stages so the stable mapping is:
 - [ ] **Step 6: Verify and commit**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bunx vitest run src/auth/mobile-oauth.test.ts src/services/mobile-auth.test.ts
 rtk bun run typecheck
-cd /Users/chanwaichan/workspace/Vela
+cd $REPO_ROOT
 rtk git add \
   apps/vela-mobile/src/auth/mobile-auth-contract.ts \
   apps/vela-mobile/src/auth/mobile-oauth.ts \
@@ -955,7 +957,7 @@ refresh-failure assertion that proves `phase`, `errorCode`, and
 - [ ] **Step 3: Run the coordinator and component suites to verify failure**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bunx vitest run \
   src/services/mobile-auth.test.ts \
   src/components/mobile/MobileAuthGate.test.ts \
@@ -1081,13 +1083,13 @@ Add a component test proving `phase: authenticated` with
 - [ ] **Step 6: Verify and commit**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bunx vitest run \
   src/services/mobile-auth.test.ts \
   src/components/mobile/MobileAuthGate.test.ts \
   src/App.test.ts
 rtk bun run typecheck
-cd /Users/chanwaichan/workspace/Vela
+cd $REPO_ROOT
 rtk git add \
   apps/vela-mobile/src/auth/mobile-auth-contract.ts \
   apps/vela-mobile/src/services/mobile-auth.ts \
@@ -1183,7 +1185,7 @@ it('clears retained Keychain state before writing a missing install marker', asy
   installationStore.isCurrentInstallationMarked.mockResolvedValue(false);
   await coordinator.initialize();
 
-  expect(order).toContainSequence([
+  expectOrderedCalls(order, [
     'installation:isMarked',
     'session:clear',
     'installation:mark',
@@ -1209,7 +1211,7 @@ it('fails closed when first-install cleanup cannot complete', async () => {
 
 it('persists the callback refresh token before API verification', async () => {
   await completeSuccessfulCallback();
-  expect(order).toContainSequence([
+  expectOrderedCalls(order, [
     'session:save:refresh-token',
     'fetch:/auth/session',
     'state:authenticated',
@@ -1224,7 +1226,7 @@ callback refresh token, persistence failure retaining the candidate, API
 - [ ] **Step 3: Run focused tests to verify failure**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bunx vitest run \
   src/boot/mobile-auth.test.ts \
   src/services/mobile-auth.test.ts
@@ -1345,14 +1347,14 @@ before publishing `session_unusable`; deletion failure publishes
 - [ ] **Step 7: Verify and commit**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bunx vitest run \
   src/boot/mobile-auth.test.ts \
   src/services/mobile-auth.test.ts \
   src/auth/mobile-session-store.test.ts \
   src/auth/mobile-installation-store.test.ts
 rtk bun run typecheck
-cd /Users/chanwaichan/workspace/Vela
+cd $REPO_ROOT
 rtk git add \
   apps/vela-mobile/src/services/mobile-auth.ts \
   apps/vela-mobile/src/services/mobile-auth.test.ts \
@@ -1457,7 +1459,7 @@ it('restores and verifies before publishing a usable session', async () => {
   sessionStore.loadRefreshToken.mockResolvedValue('durable-token');
   await coordinator.initialize();
 
-  expect(order).toContainSequence([
+  expectOrderedCalls(order, [
     'session:load',
     'token:refresh',
     'candidate:validate',
@@ -1543,7 +1545,7 @@ API request is made.
 - [ ] **Step 4: Run the coordinator suite to verify failure**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bunx vitest run src/services/mobile-auth.test.ts
 ```
 
@@ -1645,14 +1647,14 @@ total selector.
 - [ ] **Step 8: Verify and commit**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bunx vitest run \
   src/services/mobile-auth.test.ts \
   src/auth/mobile-oauth.test.ts \
   src/components/mobile/MobileAuthGate.test.ts \
   src/App.test.ts
 rtk bun run typecheck
-cd /Users/chanwaichan/workspace/Vela
+cd $REPO_ROOT
 rtk git add \
   apps/vela-mobile/src/auth/mobile-auth-contract.ts \
   apps/vela-mobile/src/services/mobile-auth.ts \
@@ -1801,7 +1803,7 @@ deadline replacement, and injected-clock-only cases.
 - [ ] **Step 4: Run the coordinator suite to verify failure**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bunx vitest run src/services/mobile-auth.test.ts
 ```
 
@@ -1862,10 +1864,10 @@ diagnostics-only.
 - [ ] **Step 8: Verify and commit**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bunx vitest run src/services/mobile-auth.test.ts
 rtk bun run typecheck
-cd /Users/chanwaichan/workspace/Vela
+cd $REPO_ROOT
 rtk git add \
   apps/vela-mobile/src/services/mobile-auth.ts \
   apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -1974,7 +1976,7 @@ Sign out makes no Cognito token/logout request and does not open the browser.
 - [ ] **Step 3: Run the coordinator suite to verify failure**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bunx vitest run \
   src/services/mobile-auth.test.ts \
   src/components/mobile/MobileAuthGate.test.ts \
@@ -2042,13 +2044,13 @@ out. Terminal-session retry clears Keychain and finishes signed out with
 - [ ] **Step 6: Verify and commit**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bunx vitest run \
   src/services/mobile-auth.test.ts \
   src/components/mobile/MobileAuthGate.test.ts \
   src/App.test.ts
 rtk bun run typecheck
-cd /Users/chanwaichan/workspace/Vela
+cd $REPO_ROOT
 rtk git add \
   apps/vela-mobile/src/auth/mobile-auth-contract.ts \
   apps/vela-mobile/src/services/mobile-auth.ts \
@@ -2102,7 +2104,6 @@ export type MobileAuthGateView =
       kind: 'blocking_session_failure';
       errorCode: MobileAuthErrorCode;
       retryAction: Exclude<MobileAuthRetryAction, 'cleanup'>;
-      allowStartOver: true;
     }
   | { kind: 'signed_out'; notice: 'session_unusable' | null }
   | { kind: 'cleanup_failure' }
@@ -2137,7 +2138,6 @@ it.each([
       kind: 'blocking_session_failure',
       errorCode: 'session_refresh_failed',
       retryAction: 'refresh',
-      allowStartOver: true,
     },
   ],
   [
@@ -2181,7 +2181,7 @@ errors, and configuration error.
 - [ ] **Step 2: Run the selector test to verify failure**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bunx vitest run src/components/mobile/mobile-auth-gate-view.test.ts
 ```
 
@@ -2391,14 +2391,14 @@ routing and surface behavior.
 - [ ] **Step 8: Verify and commit**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bunx vitest run \
   src/components/mobile/mobile-auth-gate-view.test.ts \
   src/components/mobile/MobileAuthGate.test.ts \
   src/pages/MorePage.test.ts \
   src/App.test.ts
 rtk bun run typecheck
-cd /Users/chanwaichan/workspace/Vela
+cd $REPO_ROOT
 rtk git add \
   apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.ts \
   apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.test.ts \
@@ -2595,7 +2595,7 @@ the shared store between coordinator instances.
 - [ ] **Step 3: Run the complete mobile unit suite**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bun run test:unit
 ```
 
@@ -2604,7 +2604,7 @@ Expected: all mobile unit and component tests PASS.
 - [ ] **Step 4: Run coverage, typecheck, lint, and production build**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+cd $REPO_ROOT/apps/vela-mobile
 rtk bun run test:coverage
 rtk bun run typecheck
 rtk bun run lint
@@ -2620,9 +2620,9 @@ Expected:
 - [ ] **Step 5: Re-run native synchronization and inspect generated files**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile/src-capacitor
+cd $REPO_ROOT/apps/vela-mobile/src-capacitor
 rtk bunx cap sync ios
-cd /Users/chanwaichan/workspace/Vela
+cd $REPO_ROOT
 rtk git diff --check
 rtk git diff -- \
   apps/vela-mobile/src-capacitor/ios/App/Podfile.lock \
@@ -2641,7 +2641,7 @@ Expected:
 - [ ] **Step 6: Run relevant root regressions**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela
+cd $REPO_ROOT
 rtk bun run test --filter=@vela/mobile
 rtk bun run typecheck --filter=@vela/mobile
 ```
@@ -2651,7 +2651,7 @@ Expected: both filtered Turbo commands PASS.
 - [ ] **Step 7: Commit the verification additions**
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela
+cd $REPO_ROOT
 rtk git add \
   apps/vela-mobile/src/services/mobile-auth.test.ts \
   apps/vela-mobile/src/boot/mobile-auth.test.ts \
@@ -2686,7 +2686,7 @@ closure gate. Do not replace the live-provider result with a mock-only claim.
 - [ ] Run:
 
 ```bash
-cd /Users/chanwaichan/workspace/Vela
+cd $REPO_ROOT
 rtk git diff main...HEAD --check
 rtk git status --short
 ```

--- a/docs/superpowers/plans/2026-07-29-mobile-cognito-session-persistence.md
+++ b/docs/superpowers/plans/2026-07-29-mobile-cognito-session-persistence.md
@@ -1,0 +1,2700 @@
+# Secure Mobile Cognito Session Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist only the Cognito refresh token in the iOS Keychain, restore
+and verify the mobile session before protected content mounts, refresh it safely
+while the app is active, and make local sign-out survive relaunch.
+
+**Architecture:** Extend the existing HPA-205 mobile auth coordinator as the
+single lifecycle owner. Isolate native storage and non-secret installation
+metadata behind narrow adapters, keep token parsing/validation pure, model
+session work with orthogonal public state, and derive the gate UI through one
+total selector. The web app, browser extension, and API authentication contract
+remain unchanged.
+
+**Tech Stack:** TypeScript 5.6, Vue 3, Quasar 2, Capacitor 7,
+`@aparajita/capacitor-secure-storage` 7.1.6, Vitest 3, Vue Test Utils, Bun.
+
+## Global Constraints
+
+- Work on branch `codex/hpa-206-mobile-session-persistence` in
+  `/Users/chanwaichan/workspace/Vela`.
+- Treat
+  `docs/superpowers/specs/2026-07-29-mobile-cognito-session-persistence-design.md`
+  as the accepted behavioral contract.
+- Keep `apps/vela-mobile/src/services/mobile-auth.ts` as the sole mobile
+  Cognito lifecycle owner.
+- Persist exactly one non-empty refresh-token string. Access and ID tokens stay
+  in process memory.
+- Pin `@aparajita/capacitor-secure-storage` exactly to `7.1.6`.
+- Call the typed plugin methods as
+  `SecureStorage.get(key, false, false)`,
+  `SecureStorage.set(key, token, false, false,
+KeychainAccess.afterFirstUnlockThisDeviceOnly)`, and
+  `SecureStorage.remove(key, false)`.
+- Never call the secure-storage plugin outside native iOS. Its browser
+  `localStorage` fallback must remain unreachable.
+- Store only the token-free OAuth transaction and the non-secret installation
+  marker in Capacitor Preferences.
+- Preserve HPA-205 PKCE, `state`, nonce, exact callback-schema, callback-first,
+  and home-first navigation behavior.
+- Protected content may mount only when `sessionUsable` is true and navigation
+  to the authenticated home route has succeeded.
+- Keep the existing 15-second auth network timeout, use only the injected
+  `now()` clock, refresh 60 seconds before access-token expiry, and allow one
+  five-second soft-failure retry when the remaining lifetime exceeds 20
+  seconds.
+- Coalesce all timer, resume, and manual refresh-grant triggers into one queued
+  or in-flight grant.
+- Do not add remote revocation, global sign-out, background polling, Android
+  Keystore support, or a public access-token API.
+- Do not log tokens, authorization URLs, callback codes, verifier values,
+  decoded claims, raw responses, request objects, or native/plugin exceptions.
+- Maintain at least the package's configured 95% line coverage.
+- The current mobile Cognito refresh-token lifetime is 30 days from issuance,
+  not a sliding inactivity window; no CDK change is required.
+
+## File Structure
+
+### New files
+
+- `apps/vela-mobile/src/auth/mobile-session-store.ts` — Vela-owned refresh-token
+  storage interface, Keychain adapter, error normalization, and unsupported
+  adapter.
+- `apps/vela-mobile/src/auth/mobile-session-store.test.ts` — exact plugin-call,
+  namespacing, platform-gate, and error-normalization tests.
+- `apps/vela-mobile/src/auth/mobile-installation-store.ts` — non-secret,
+  environment-scoped first-install marker over Capacitor Preferences.
+- `apps/vela-mobile/src/auth/mobile-installation-store.test.ts` — marker
+  namespacing and exact Preferences-call tests.
+- `apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.ts` — total
+  state-to-view selector with an `invalid_state` fallback.
+- `apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.test.ts` —
+  selector matrix and invalid-tuple tests.
+- `apps/vela-mobile/src/pages/MorePage.test.ts` — mobile Sign out action tests.
+
+### Existing files to modify
+
+- `apps/vela-mobile/src/auth/mobile-auth-contract.ts` — flow-specific token
+  bundles, orthogonal auth state, lifecycle listener overload, and coordinator
+  methods.
+- `apps/vela-mobile/src/auth/mobile-oauth.ts` — authorization-code and refresh
+  request builders, response parsers, and nonce-specific validators.
+- `apps/vela-mobile/src/auth/mobile-oauth.test.ts` — protocol and claim tests.
+- `apps/vela-mobile/src/services/mobile-auth.ts` — atomic state transitions,
+  candidate promotion, restore/refresh/retry/sign-out/disposal orchestration.
+- `apps/vela-mobile/src/services/mobile-auth.test.ts` — coordinator state,
+  ordering, timers, cleanup, and secret-regression coverage.
+- `apps/vela-mobile/src/boot/mobile-auth.ts` — runtime adapter selection and
+  dependency injection.
+- `apps/vela-mobile/src/boot/mobile-auth.test.ts` — native iOS versus
+  unsupported-runtime wiring.
+- `apps/vela-mobile/src/components/mobile/MobileAuthGate.vue` — exhaustive gate
+  rendering, retry/start-over actions, notices, and diagnostics bypass.
+- `apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts` — component
+  visibility, copy, focus, bypass, and action tests.
+- `apps/vela-mobile/src/pages/MorePage.vue` — accessible Sign out button and
+  progress state.
+- `apps/vela-mobile/src/App.test.ts` — expanded auth-state fixture and
+  protected-content invariant.
+- `apps/vela-mobile/quasar.config.ts` — secure-storage package alias.
+- `apps/vela-mobile/vitest.config.ts` — secure-storage test alias.
+- `apps/vela-mobile/src-capacitor/package.json` — exact native dependency.
+- `apps/vela-mobile/src-capacitor/bun.lock` — resolved package lock.
+- `apps/vela-mobile/src-capacitor/ios/App/Podfile.lock` — synchronized native
+  pod resolution.
+
+### Files to inspect but not change unless generated sync requires it
+
+- `apps/vela-mobile/src-capacitor/ios/App/PrivacyInfo.xcprivacy` — verify the
+  plugin introduces no missing required-reason declaration.
+- `apps/vela-mobile/src-capacitor/ios/App/App/Info.plist` — preserve the HPA-205
+  callback scheme unchanged.
+- `packages/cdk/lib/auth-stack.ts` — confirm the existing mobile client and
+  30-day default; do not add a CDK change.
+- `apps/vela-api/src/middleware/auth.ts` — confirm it continues accepting web
+  and mobile client IDs; do not modify it.
+
+## Execution Preflight
+
+- [ ] Confirm the accepted documents are the only uncommitted files:
+
+```bash
+cd /Users/chanwaichan/workspace/Vela
+rtk git status --short
+```
+
+Expected before this plan is committed:
+
+```text
+ M docs/superpowers/specs/2026-07-29-mobile-cognito-session-persistence-design.md
+?? docs/superpowers/plans/2026-07-29-mobile-cognito-session-persistence.md
+```
+
+- [ ] Commit the accepted design and implementation plan:
+
+```bash
+rtk git add \
+  docs/superpowers/specs/2026-07-29-mobile-cognito-session-persistence-design.md \
+  docs/superpowers/plans/2026-07-29-mobile-cognito-session-persistence.md
+rtk git commit -m "docs: approve mobile session persistence design"
+```
+
+---
+
+### Task 1: Pin the Native Dependency and Add the Keychain Adapter
+
+**Files:**
+
+- Create:
+  `apps/vela-mobile/src/auth/mobile-session-store.ts`
+- Create:
+  `apps/vela-mobile/src/auth/mobile-session-store.test.ts`
+- Modify:
+  `apps/vela-mobile/src-capacitor/package.json`
+- Modify:
+  `apps/vela-mobile/src-capacitor/bun.lock`
+- Modify:
+  `apps/vela-mobile/src-capacitor/ios/App/Podfile.lock`
+- Modify:
+  `apps/vela-mobile/quasar.config.ts`
+- Modify:
+  `apps/vela-mobile/vitest.config.ts`
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+export type MobileSessionStore = {
+  loadRefreshToken(): Promise<string | null>;
+  saveRefreshToken(refreshToken: string): Promise<void>;
+  clearRefreshToken(): Promise<void>;
+};
+
+export type MobileSessionStoreErrorCode = 'corrupt' | 'unavailable' | 'unsupported_platform';
+
+export class MobileSessionStoreError extends Error {
+  readonly code: MobileSessionStoreErrorCode;
+}
+
+export function createMobileSessionKey(config: {
+  userPoolId: string;
+  mobileClientId: string;
+}): string;
+
+export type MobileRuntimeAdapter = {
+  isNativePlatform(): boolean;
+  getPlatform(): string;
+};
+
+export function createIosKeychainSessionStore(options: {
+  secureStorage: Pick<SecureStoragePlugin, 'get' | 'set' | 'remove'>;
+  runtime: MobileRuntimeAdapter;
+  config: Pick<MobileOAuthConfig, 'userPoolId' | 'mobileClientId'>;
+}): MobileSessionStore;
+
+export function createUnsupportedMobileSessionStore(): MobileSessionStore;
+```
+
+- Consumed by Tasks 5–8 through `MobileAuthCoordinatorDependencies`.
+
+- [ ] **Step 1: Pin and synchronize the plugin**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile/src-capacitor
+rtk bun add --exact @aparajita/capacitor-secure-storage@7.1.6
+rtk bunx cap sync ios
+```
+
+Expected:
+
+- `package.json` contains
+  `"@aparajita/capacitor-secure-storage": "7.1.6"`;
+- `bun.lock` resolves version `7.1.6`;
+- `Podfile.lock` includes the secure-storage pod;
+- the command completes without changing the registered OAuth URL scheme.
+
+- [ ] **Step 2: Add the failing adapter tests**
+
+```ts
+import {
+  KeychainAccess,
+  StorageError,
+  StorageErrorType,
+} from '@aparajita/capacitor-secure-storage';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  MobileSessionStoreError,
+  createIosKeychainSessionStore,
+  createMobileSessionKey,
+} from './mobile-session-store';
+
+const config = {
+  userPoolId: 'ca-central-1_pool',
+  mobileClientId: 'mobile-client',
+};
+
+it('uses the exact environment key and non-synchronizing typed calls', async () => {
+  const secureStorage = {
+    get: vi.fn().mockResolvedValue('refresh-token'),
+    set: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(true),
+  };
+  const store = createIosKeychainSessionStore({
+    secureStorage,
+    runtime: {
+      isNativePlatform: () => true,
+      getPlatform: () => 'ios',
+    },
+    config,
+  });
+  const key = 'vela:mobile:cognito:ca-central-1_pool:mobile-client:refresh:v1';
+
+  await expect(store.loadRefreshToken()).resolves.toBe('refresh-token');
+  await store.saveRefreshToken('rotated-token');
+  await store.clearRefreshToken();
+
+  expect(createMobileSessionKey(config)).toBe(key);
+  expect(secureStorage.get).toHaveBeenCalledWith(key, false, false);
+  expect(secureStorage.set).toHaveBeenCalledWith(
+    key,
+    'rotated-token',
+    false,
+    false,
+    KeychainAccess.afterFirstUnlockThisDeviceOnly,
+  );
+  expect(secureStorage.remove).toHaveBeenCalledWith(key, false);
+});
+
+it.each([
+  [new StorageError('bad json', StorageErrorType.invalidData), 'corrupt'],
+  [new StorageError('native failure', StorageErrorType.osError), 'unavailable'],
+  [new Error('bridge failure'), 'unavailable'],
+] as const)('normalizes %p without exposing its message', async (failure, code) => {
+  const store = createIosKeychainSessionStore({
+    secureStorage: {
+      get: vi.fn().mockRejectedValue(failure),
+      set: vi.fn(),
+      remove: vi.fn(),
+    },
+    runtime: {
+      isNativePlatform: () => true,
+      getPlatform: () => 'ios',
+    },
+    config,
+  });
+
+  await expect(store.loadRefreshToken()).rejects.toMatchObject({
+    name: 'MobileSessionStoreError',
+    code,
+    message: code,
+  } satisfies Partial<MobileSessionStoreError>);
+});
+```
+
+Add cases for `null`, empty/whitespace/non-string values, save and remove
+failures, browser, Android, and unknown platforms. Assert unsupported platforms
+make zero plugin calls.
+
+- [ ] **Step 3: Run the focused test to verify it fails**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bunx vitest run src/auth/mobile-session-store.test.ts
+```
+
+Expected: FAIL because `./mobile-session-store` does not exist.
+
+- [ ] **Step 4: Implement the adapter**
+
+```ts
+import {
+  KeychainAccess,
+  StorageError,
+  StorageErrorType,
+  type SecureStoragePlugin,
+} from '@aparajita/capacitor-secure-storage';
+import type { MobileOAuthConfig } from './mobile-auth-contract';
+
+export type MobileSessionStore = {
+  loadRefreshToken(): Promise<string | null>;
+  saveRefreshToken(refreshToken: string): Promise<void>;
+  clearRefreshToken(): Promise<void>;
+};
+
+export type MobileSessionStoreErrorCode = 'corrupt' | 'unavailable' | 'unsupported_platform';
+
+export class MobileSessionStoreError extends Error {
+  constructor(readonly code: MobileSessionStoreErrorCode) {
+    super(code);
+    this.name = 'MobileSessionStoreError';
+  }
+}
+
+export function createMobileSessionKey(
+  config: Pick<MobileOAuthConfig, 'userPoolId' | 'mobileClientId'>,
+): string {
+  return `vela:mobile:cognito:${config.userPoolId}:${config.mobileClientId}:refresh:v1`;
+}
+
+function normalizeFailure(error: unknown): MobileSessionStoreError {
+  if (error instanceof MobileSessionStoreError) return error;
+  if (error instanceof StorageError && error.code === StorageErrorType.invalidData) {
+    return new MobileSessionStoreError('corrupt');
+  }
+  return new MobileSessionStoreError('unavailable');
+}
+
+function assertNativeIos(runtime: { isNativePlatform(): boolean; getPlatform(): string }): void {
+  if (!runtime.isNativePlatform() || runtime.getPlatform() !== 'ios') {
+    throw new MobileSessionStoreError('unsupported_platform');
+  }
+}
+```
+
+Implement the three methods with `assertNativeIos()` before every plugin call,
+the exact typed arguments from the global constraints, and sanitized failure
+normalization. `loadRefreshToken()` returns `null` only for a plugin `null`
+result; it maps non-string or blank values to `corrupt`.
+
+- [ ] **Step 5: Add module aliases**
+
+Add this alias to both `quasar.config.ts` and `vitest.config.ts`:
+
+```ts
+'@aparajita/capacitor-secure-storage': resolve(
+  __dirname,
+  'src-capacitor/node_modules/@aparajita/capacitor-secure-storage',
+),
+```
+
+- [ ] **Step 6: Verify the adapter and native metadata**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bunx vitest run src/auth/mobile-session-store.test.ts
+rtk bun run typecheck
+rtk git diff -- src-capacitor/ios/App/PrivacyInfo.xcprivacy
+```
+
+Expected: focused tests and typecheck PASS; the privacy-manifest diff is empty.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela
+rtk git add \
+  apps/vela-mobile/src/auth/mobile-session-store.ts \
+  apps/vela-mobile/src/auth/mobile-session-store.test.ts \
+  apps/vela-mobile/src-capacitor/package.json \
+  apps/vela-mobile/src-capacitor/bun.lock \
+  apps/vela-mobile/src-capacitor/ios/App/Podfile.lock \
+  apps/vela-mobile/quasar.config.ts \
+  apps/vela-mobile/vitest.config.ts
+rtk git commit -m "feat(mobile): add secure session storage adapter"
+```
+
+---
+
+### Task 2: Add the Non-Secret Installation Marker
+
+**Files:**
+
+- Create:
+  `apps/vela-mobile/src/auth/mobile-installation-store.ts`
+- Create:
+  `apps/vela-mobile/src/auth/mobile-installation-store.test.ts`
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+export type MobileInstallationStore = {
+  isCurrentInstallationMarked(): Promise<boolean>;
+  markCurrentInstallation(): Promise<void>;
+};
+
+export function createMobileInstallationKey(config: {
+  userPoolId: string;
+  mobileClientId: string;
+}): string;
+
+export function createMobileInstallationStore(
+  preferences: Pick<OAuthTransactionPreferences, 'get' | 'set'>,
+  config: Pick<MobileOAuthConfig, 'userPoolId' | 'mobileClientId'>,
+): MobileInstallationStore;
+```
+
+- Consumed by Task 5 initialization.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createMobileInstallationKey,
+  createMobileInstallationStore,
+} from './mobile-installation-store';
+
+const config = {
+  userPoolId: 'ca-central-1_pool',
+  mobileClientId: 'mobile-client',
+};
+
+it('uses an environment-scoped non-secret marker', async () => {
+  const preferences = {
+    get: vi.fn().mockResolvedValue({ value: null }),
+    set: vi.fn().mockResolvedValue(undefined),
+  };
+  const store = createMobileInstallationStore(preferences, config);
+  const key = 'vela:mobile:cognito:ca-central-1_pool:mobile-client:installation:v1';
+
+  await expect(store.isCurrentInstallationMarked()).resolves.toBe(false);
+  await store.markCurrentInstallation();
+
+  expect(createMobileInstallationKey(config)).toBe(key);
+  expect(preferences.get).toHaveBeenCalledWith({ key });
+  expect(preferences.set).toHaveBeenCalledWith({ key, value: '1' });
+});
+
+it.each([null, '', '0', 'unexpected'])('treats %p as unmarked', async (value) => {
+  const store = createMobileInstallationStore(
+    {
+      get: vi.fn().mockResolvedValue({ value }),
+      set: vi.fn(),
+    },
+    config,
+  );
+  await expect(store.isCurrentInstallationMarked()).resolves.toBe(false);
+});
+```
+
+Add a `'1'` marked case and exact propagation tests for Preferences read/write
+rejections.
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bunx vitest run src/auth/mobile-installation-store.test.ts
+```
+
+Expected: FAIL because `./mobile-installation-store` does not exist.
+
+- [ ] **Step 3: Implement the marker adapter**
+
+```ts
+import type { MobileOAuthConfig } from './mobile-auth-contract';
+import type { OAuthTransactionPreferences } from './oauth-transaction-store';
+
+export type MobileInstallationStore = {
+  isCurrentInstallationMarked(): Promise<boolean>;
+  markCurrentInstallation(): Promise<void>;
+};
+
+export function createMobileInstallationKey(
+  config: Pick<MobileOAuthConfig, 'userPoolId' | 'mobileClientId'>,
+): string {
+  return `vela:mobile:cognito:${config.userPoolId}:${config.mobileClientId}:installation:v1`;
+}
+
+export function createMobileInstallationStore(
+  preferences: Pick<OAuthTransactionPreferences, 'get' | 'set'>,
+  config: Pick<MobileOAuthConfig, 'userPoolId' | 'mobileClientId'>,
+): MobileInstallationStore {
+  const key = createMobileInstallationKey(config);
+  return {
+    async isCurrentInstallationMarked() {
+      return (await preferences.get({ key })).value === '1';
+    },
+    async markCurrentInstallation() {
+      await preferences.set({ key, value: '1' });
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Verify and commit**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bunx vitest run \
+  src/auth/mobile-installation-store.test.ts \
+  src/auth/oauth-transaction-store.test.ts
+rtk bun run typecheck
+cd /Users/chanwaichan/workspace/Vela
+rtk git add \
+  apps/vela-mobile/src/auth/mobile-installation-store.ts \
+  apps/vela-mobile/src/auth/mobile-installation-store.test.ts
+rtk git commit -m "feat(mobile): add installation reset marker"
+```
+
+Expected: both Preferences-backed store suites PASS.
+
+---
+
+### Task 3: Split Authorization-Code and Refresh Protocol Primitives
+
+**Files:**
+
+- Modify:
+  `apps/vela-mobile/src/auth/mobile-auth-contract.ts`
+- Modify:
+  `apps/vela-mobile/src/auth/mobile-oauth.ts`
+- Modify:
+  `apps/vela-mobile/src/auth/mobile-oauth.test.ts`
+- Modify:
+  `apps/vela-mobile/src/services/mobile-auth.ts`
+- Modify:
+  `apps/vela-mobile/src/services/mobile-auth.test.ts`
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+export type OAuthTokenBundleBase = {
+  accessToken: string;
+  idToken: string;
+  expiresAt: number;
+};
+
+export type AuthorizationCodeTokenBundle = OAuthTokenBundleBase & {
+  refreshToken: string;
+};
+
+export type RefreshedTokenBundle = OAuthTokenBundleBase & {
+  refreshToken?: string;
+};
+
+export function buildAuthorizationCodeTokenRequest(
+  config: MobileOAuthConfig,
+  transaction: OAuthTransaction,
+  code: string,
+  options?: { timeoutMs?: number },
+): MobileTokenRequest;
+
+export function buildRefreshTokenRequest(
+  config: MobileOAuthConfig,
+  refreshToken: string,
+  options?: { timeoutMs?: number },
+): MobileTokenRequest;
+
+export function parseAuthorizationCodeTokenResponse(
+  value: unknown,
+  now: number,
+): AuthorizationCodeTokenBundle;
+
+export function parseRefreshTokenResponse(value: unknown, now: number): RefreshedTokenBundle;
+
+export function validateAuthorizationCodeIdTokenClaims(
+  idToken: string,
+  expected: {
+    config: MobileOAuthConfig;
+    transaction: OAuthTransaction;
+    now: number;
+  },
+): void;
+
+export function validateRefreshedIdTokenClaims(
+  idToken: string,
+  expected: {
+    config: MobileOAuthConfig;
+    now: number;
+    expectedSubject?: string;
+  },
+): string;
+```
+
+- Task 3 updates the existing callback caller to the renamed authorization-code
+  functions so the branch stays green.
+- Tasks 6 and 7 consume the refresh functions.
+
+- [ ] **Step 1: Add failing request and parser tests**
+
+```ts
+it('builds the exact refresh-token public-client request', () => {
+  const request = buildRefreshTokenRequest(config, 'refresh-token', {
+    timeoutMs: 15_000,
+  });
+  expect(request).toEqual({
+    url: `https://${config.oauthDomain}/oauth2/token`,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    data: new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: config.mobileClientId,
+      refresh_token: 'refresh-token',
+    }).toString(),
+    timeoutMs: 15_000,
+  });
+  expect(request.data).not.toContain('client_secret');
+});
+
+it('requires a refresh token from authorization-code success', () => {
+  expect(() =>
+    parseAuthorizationCodeTokenResponse(
+      { access_token: 'access', id_token: 'id', expires_in: 3600 },
+      1_000,
+    ),
+  ).toThrow('Invalid token response');
+});
+
+it('permits refresh-token omission from refresh success', () => {
+  expect(
+    parseRefreshTokenResponse({ access_token: 'access', id_token: 'id', expires_in: 3600 }, 1_000),
+  ).toEqual({
+    accessToken: 'access',
+    idToken: 'id',
+    expiresAt: 3_601_000,
+  });
+});
+```
+
+In `src/services/mobile-auth.test.ts`, add the coordinator classification
+regression:
+
+```ts
+it('maps a successful callback response without a refresh token to token validation failure', async () => {
+  const harness = makeHarness();
+  await harness.coordinator.initialize();
+  await harness.coordinator.startSignIn();
+  const transaction = harness.preferences.transaction();
+  harness.tokenTransport.result = {
+    status: 200,
+    data: {
+      access_token: 'access',
+      id_token: idToken(transaction),
+      expires_in: 3_600,
+    },
+  };
+
+  harness.app.emit(callback(transaction));
+  await harness.flush();
+  expect(harness.coordinator.state.errorCode).toBe('token_validation_failed');
+});
+```
+
+- [ ] **Step 2: Add failing nonce and subject tests**
+
+```ts
+it('validates a refreshed ID token without nonce and returns its subject', () => {
+  const idToken = makeIdToken({
+    token_use: 'id',
+    aud: config.mobileClientId,
+    iss: expectedIssuer,
+    sub: 'user-1',
+    exp: 3_600,
+  });
+  expect(
+    validateRefreshedIdTokenClaims(idToken, {
+      config,
+      now: 1_000,
+      expectedSubject: 'user-1',
+    }),
+  ).toBe('user-1');
+});
+
+it.each([
+  ['missing subject', undefined, undefined],
+  ['empty subject', '', undefined],
+  ['subject mismatch', 'user-2', 'user-1'],
+] as const)('rejects %s', (_label, subject, expectedSubject) => {
+  const idToken = makeIdToken({
+    token_use: 'id',
+    aud: config.mobileClientId,
+    iss: expectedIssuer,
+    sub: subject,
+    exp: 3_600,
+  });
+  expect(() =>
+    validateRefreshedIdTokenClaims(idToken, {
+      config,
+      now: 1_000,
+      ...(expectedSubject ? { expectedSubject } : {}),
+    }),
+  ).toThrow('Invalid ID token');
+});
+```
+
+- [ ] **Step 3: Run the focused test to verify it fails**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bunx vitest run \
+  src/auth/mobile-oauth.test.ts \
+  src/services/mobile-auth.test.ts
+```
+
+Expected: FAIL because the refresh-specific exports do not exist and the
+coordinator still classifies the missing refresh token as code exchange.
+
+- [ ] **Step 4: Implement one shared base parser and validator**
+
+Keep one private parser that accepts `requireRefreshToken: boolean`, and one
+private claim validator that accepts `expectedNonce?: string` and
+`expectedSubject?: string`. The public wrappers must be:
+
+```ts
+export function parseAuthorizationCodeTokenResponse(
+  value: unknown,
+  now: number,
+): AuthorizationCodeTokenBundle {
+  const parsed = parseTokenResponseBase(value, now, true);
+  if (!parsed.refreshToken) return invalidTokenResponse();
+  return { ...parsed, refreshToken: parsed.refreshToken };
+}
+
+export function parseRefreshTokenResponse(value: unknown, now: number): RefreshedTokenBundle {
+  return parseTokenResponseBase(value, now, false);
+}
+
+export function validateAuthorizationCodeIdTokenClaims(
+  idToken: string,
+  expected: AuthorizationCodeClaimExpectation,
+): void {
+  validateIdTokenClaimsBase(idToken, {
+    config: expected.config,
+    now: expected.now,
+    expectedNonce: expected.transaction.nonce,
+  });
+}
+
+export function validateRefreshedIdTokenClaims(
+  idToken: string,
+  expected: RefreshedClaimExpectation,
+): string {
+  return validateIdTokenClaimsBase(idToken, expected);
+}
+```
+
+The base validator requires a non-empty `sub` in both flows. Only the
+authorization-code wrapper supplies a nonce. Add `sub: 'user-123'` to the
+default JWT claims produced by the existing `idToken()` helper in
+`mobile-auth.test.ts` so all preserved callback fixtures satisfy the stronger
+shared contract.
+
+- [ ] **Step 5: Rename the existing callback call sites**
+
+In `mobile-auth.ts`, replace:
+
+```ts
+buildTokenRequest;
+parseTokenResponse;
+validateIdTokenClaims;
+```
+
+with:
+
+```ts
+buildAuthorizationCodeTokenRequest;
+parseAuthorizationCodeTokenResponse;
+validateAuthorizationCodeIdTokenClaims;
+```
+
+Replace the removed `OAuthTokenBundle` import and coordinator variable with:
+
+```ts
+import type { AuthorizationCodeTokenBundle } from '../auth/mobile-auth-contract';
+
+let tokenBundle: AuthorizationCodeTokenBundle | undefined;
+```
+
+Split the callback transport and validation stages so the stable mapping is:
+
+- request rejection or non-2xx response → `code_exchange_failed`;
+- successful 2xx response with an invalid schema, including a missing refresh
+  token → `token_validation_failed`;
+- ID-token claim failure → `token_validation_failed`.
+
+- [ ] **Step 6: Verify and commit**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bunx vitest run src/auth/mobile-oauth.test.ts src/services/mobile-auth.test.ts
+rtk bun run typecheck
+cd /Users/chanwaichan/workspace/Vela
+rtk git add \
+  apps/vela-mobile/src/auth/mobile-auth-contract.ts \
+  apps/vela-mobile/src/auth/mobile-oauth.ts \
+  apps/vela-mobile/src/auth/mobile-oauth.test.ts \
+  apps/vela-mobile/src/services/mobile-auth.ts \
+  apps/vela-mobile/src/services/mobile-auth.test.ts
+rtk git commit -m "feat(mobile): add Cognito refresh protocol primitives"
+```
+
+Expected: protocol and existing coordinator suites PASS; typecheck PASS.
+
+---
+
+### Task 4: Introduce Orthogonal Auth State and Atomic Transitions
+
+**Files:**
+
+- Modify:
+  `apps/vela-mobile/src/auth/mobile-auth-contract.ts`
+- Modify:
+  `apps/vela-mobile/src/services/mobile-auth.ts`
+- Modify:
+  `apps/vela-mobile/src/services/mobile-auth.test.ts`
+- Modify:
+  `apps/vela-mobile/src/components/mobile/MobileAuthGate.vue`
+- Modify:
+  `apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts`
+- Modify:
+  `apps/vela-mobile/src/App.test.ts`
+
+**Interfaces:**
+
+- Produces the accepted `MobileAuthOperation`, `MobileAuthRetryAction`,
+  `MobileAuthNotice`, expanded `MobileAuthErrorCode`, and expanded
+  `MobileAuthState`.
+- Produces
+  `assertMobileAuthState(state: MobileAuthState, context: MobileAuthStateAssertionContext): void`,
+  which validates the approved state invariant table and throws
+  `Error('invalid_mobile_auth_state')` before an invalid tuple is published.
+- Preserves the existing `retrySessionVerification()` contract through Task 4;
+  Task 6 replaces it atomically with `retryCurrentOperation()` alongside the
+  generalized retry behavior.
+
+- [ ] **Step 1: Add the expanded public types**
+
+```ts
+export type MobileAuthRetryAction = 'restore' | 'refresh' | 'persist' | 'verify' | 'cleanup';
+
+export type MobileAuthOperation =
+  | 'idle'
+  | 'restoring'
+  | 'refreshing'
+  | 'persisting'
+  | 'verifying'
+  | 'signingOut'
+  | 'cleaningUp';
+
+export type MobileAuthNotice = 'session_unusable' | 'cleanup_incomplete' | null;
+
+export type MobileAuthState = {
+  phase: MobileAuthPhase;
+  operation: MobileAuthOperation;
+  sessionUsable: boolean;
+  errorCode: MobileAuthErrorCode | null;
+  retryAction: MobileAuthRetryAction | null;
+  notice: MobileAuthNotice;
+  user: MobileAuthUser | null;
+};
+
+export type MobileAuthStateAssertionContext = {
+  activeBundle: OAuthTokenBundleBase | null;
+  now: number;
+};
+```
+
+Append these error codes:
+
+```ts
+| 'session_restore_failed'
+| 'session_refresh_failed'
+| 'session_persistence_failed'
+| 'session_cleanup_failed'
+| 'unsupported_platform'
+```
+
+Add the `appStateChange` overload to `MobileAppAdapter` without changing the
+existing `appUrlOpen` signature.
+
+- [ ] **Step 2: Add failing invariant tests**
+
+```ts
+it('publishes the complete authenticated tuple after verification', async () => {
+  const coordinator = createCoordinator();
+  await authenticate(coordinator);
+
+  expect(coordinator.state).toEqual({
+    phase: 'authenticated',
+    operation: 'idle',
+    sessionUsable: true,
+    errorCode: null,
+    retryAction: null,
+    notice: null,
+    user: { userId: 'user-1', email: null },
+  });
+});
+
+it('rejects invalid published state tuples with a stable internal error', () => {
+  expect(() =>
+    assertMobileAuthState(
+      {
+        phase: 'signedOut',
+        operation: 'idle',
+        sessionUsable: true,
+        errorCode: null,
+        retryAction: null,
+        notice: null,
+        user: null,
+      },
+      {
+        activeBundle: null,
+        now,
+      },
+    ),
+  ).toThrow('invalid_mobile_auth_state');
+});
+```
+
+Export `assertMobileAuthState()` from `mobile-auth-contract.ts` so the invalid
+tuple test exercises the production validator directly. Task 7 adds the real
+refresh-failure assertion that proves `phase`, `errorCode`, and
+`sessionUsable` remain orthogonal.
+
+- [ ] **Step 3: Run the coordinator and component suites to verify failure**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bunx vitest run \
+  src/services/mobile-auth.test.ts \
+  src/components/mobile/MobileAuthGate.test.ts \
+  src/App.test.ts
+```
+
+Expected: FAIL because state fixtures and coordinator transitions lack the new
+fields.
+
+- [ ] **Step 4: Replace implicit mutators with full-state transitions**
+
+Initialize every field:
+
+```ts
+const state = reactive<MobileAuthState>({
+  phase: 'initializing',
+  operation: 'idle',
+  sessionUsable: false,
+  errorCode: null,
+  retryAction: null,
+  notice: null,
+  user: null,
+});
+```
+
+Replace `setPhase()` and `setError()` with:
+
+```ts
+function applyState(next: MobileAuthState): void {
+  assertMobileAuthState(next, {
+    activeBundle: tokenBundle ?? null,
+    now: dependencies.now(),
+  });
+  Object.assign(state, next);
+}
+
+function enterOAuthProgress(phase: MobileAuthPhase): void {
+  applyState({
+    phase,
+    operation: 'idle',
+    sessionUsable: false,
+    errorCode: null,
+    retryAction: null,
+    notice: null,
+    user: null,
+  });
+}
+
+function enterOAuthError(errorCode: MobileAuthErrorCode): void {
+  applyState({
+    phase: 'error',
+    operation: 'idle',
+    sessionUsable: false,
+    errorCode,
+    retryAction: null,
+    notice: null,
+    user: null,
+  });
+}
+
+function enterAuthenticated(user: MobileAuthUser): void {
+  applyState({
+    phase: 'authenticated',
+    operation: 'idle',
+    sessionUsable: true,
+    errorCode: null,
+    retryAction: null,
+    notice: null,
+    user,
+  });
+}
+```
+
+Implement `assertMobileAuthState()` as one fail-closed predicate covering the
+six approved invariants: usable sessions require an authenticated phase,
+non-null user, null notice, and an unexpired active bundle; error phase requires
+an error code; retry requires idle plus an error code; both notice shapes require
+their exact signed-out tuples. Operation transitions remain named full-state
+constructors so they never implicitly erase user, candidate, or notice state.
+
+Add full-state constructors for signed out, session failure, operation
+progress, terminal notice, and cleanup failure. Do not accept
+`Partial<MobileAuthState>` in a production transition helper.
+
+- [ ] **Step 5: Update every fixture and fail the gate closed**
+
+Every `MobileAuthState` literal in `MobileAuthGate.test.ts` and `App.test.ts`
+must include:
+
+```ts
+operation: 'idle',
+sessionUsable: false,
+retryAction: null,
+notice: null,
+```
+
+Authenticated fixtures set `sessionUsable: true`.
+
+In `MobileAuthGate.vue`, make protected-content visibility capability-based
+immediately:
+
+```ts
+const contentVisible = computed(
+  () => diagnosticBypass.value || (state.sessionUsable && authenticatedLandingReady.value),
+);
+```
+
+Until Task 9 installs the total selector, type the existing presentation table
+as `Partial<Record<MobileAuthErrorCode, ErrorPresentation>>` and use this exact
+fail-closed fallback for codes that the HPA-205 table does not own:
+
+```ts
+const SESSION_STATE_FALLBACK: ErrorPresentation = {
+  heading: 'Vela cannot use this session',
+  message: 'Vela could not safely continue with the current session.',
+  action: null,
+};
+```
+
+Add a component test proving `phase: authenticated` with
+`sessionUsable: false` never mounts the protected slot.
+
+- [ ] **Step 6: Verify and commit**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bunx vitest run \
+  src/services/mobile-auth.test.ts \
+  src/components/mobile/MobileAuthGate.test.ts \
+  src/App.test.ts
+rtk bun run typecheck
+cd /Users/chanwaichan/workspace/Vela
+rtk git add \
+  apps/vela-mobile/src/auth/mobile-auth-contract.ts \
+  apps/vela-mobile/src/services/mobile-auth.ts \
+  apps/vela-mobile/src/services/mobile-auth.test.ts \
+  apps/vela-mobile/src/components/mobile/MobileAuthGate.vue \
+  apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts \
+  apps/vela-mobile/src/App.test.ts
+rtk git commit -m "refactor(mobile): model auth session state explicitly"
+```
+
+Expected: focused suites and typecheck PASS with all HPA-205 behavior preserved.
+
+---
+
+### Task 5: Wire Native Stores and Make OAuth Completion Durable
+
+**Files:**
+
+- Modify:
+  `apps/vela-mobile/src/services/mobile-auth.ts`
+- Modify:
+  `apps/vela-mobile/src/services/mobile-auth.test.ts`
+- Modify:
+  `apps/vela-mobile/src/boot/mobile-auth.ts`
+- Modify:
+  `apps/vela-mobile/src/boot/mobile-auth.test.ts`
+
+**Interfaces:**
+
+- `MobileAuthCoordinatorDependencies` gains:
+
+```ts
+sessionStore: MobileSessionStore;
+installationStore: MobileInstallationStore;
+isNativeIos: boolean;
+```
+
+- Produces the retained candidate shape used by persistence and verification:
+
+```ts
+type PendingCandidate = {
+  bundle: OAuthTokenBundleBase;
+  durableRefreshToken: string;
+  returnedRefreshToken?: string;
+  context: 'authorizationCode' | 'restore' | 'refresh';
+};
+
+type CleanupContext = { kind: 'terminalSession' } | { kind: 'installationReset' };
+```
+
+- Consumes Task 1's Keychain/unsupported stores and Task 2's installation store.
+- Produces persistence-before-verification for new OAuth callbacks and a
+  fail-closed unsupported runtime.
+
+- [ ] **Step 1: Add failing boot-selection tests**
+
+Mock `Capacitor`, `SecureStorage`, and both factories. Add:
+
+```ts
+it('injects Keychain storage only on native iOS', () => {
+  mocks.isNativePlatform.mockReturnValue(true);
+  mocks.getPlatform.mockReturnValue('ios');
+  runBoot({ app: { provide: vi.fn() } });
+
+  expect(mocks.createIosStore).toHaveBeenCalledWith({
+    secureStorage: mocks.secureStorage,
+    runtime: mocks.capacitor,
+    config: {
+      userPoolId: config.auth.userPoolId,
+      mobileClientId: config.auth.mobileClientId,
+    },
+  });
+  expect(mocks.createUnsupportedStore).not.toHaveBeenCalled();
+});
+
+it.each([
+  [false, 'web'],
+  [true, 'android'],
+] as const)('injects the unsupported store for native=%s platform=%s', (isNative, platform) => {
+  mocks.isNativePlatform.mockReturnValue(isNative);
+  mocks.getPlatform.mockReturnValue(platform);
+  runBoot({ app: { provide: vi.fn() } });
+
+  expect(mocks.createUnsupportedStore).toHaveBeenCalledOnce();
+  expect(mocks.createIosStore).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Add failing installation-reset and callback-persistence tests**
+
+```ts
+it('clears retained Keychain state before writing a missing install marker', async () => {
+  installationStore.isCurrentInstallationMarked.mockResolvedValue(false);
+  await coordinator.initialize();
+
+  expect(order).toContainSequence([
+    'installation:isMarked',
+    'session:clear',
+    'installation:mark',
+    'app:getLaunchUrl',
+  ]);
+});
+
+it('fails closed when first-install cleanup cannot complete', async () => {
+  installationStore.isCurrentInstallationMarked.mockResolvedValue(false);
+  sessionStore.clearRefreshToken.mockRejectedValue(new Error('SECRET-keychain'));
+  await coordinator.initialize();
+
+  expect(coordinator.state).toMatchObject({
+    phase: 'signedOut',
+    operation: 'idle',
+    sessionUsable: false,
+    errorCode: 'session_cleanup_failed',
+    retryAction: 'cleanup',
+    notice: 'cleanup_incomplete',
+  });
+  expect(app.getLaunchUrl).not.toHaveBeenCalled();
+});
+
+it('persists the callback refresh token before API verification', async () => {
+  await completeSuccessfulCallback();
+  expect(order).toContainSequence([
+    'session:save:refresh-token',
+    'fetch:/auth/session',
+    'state:authenticated',
+  ]);
+});
+```
+
+Add marker read/write failures, crash-safe clear-before-mark retry, missing
+callback refresh token, persistence failure retaining the candidate, API
+401/403 cleanup, and secret-sentinel assertions.
+
+- [ ] **Step 3: Run focused tests to verify failure**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bunx vitest run \
+  src/boot/mobile-auth.test.ts \
+  src/services/mobile-auth.test.ts
+```
+
+Expected: FAIL because boot does not select stores and the coordinator does not
+persist callback refresh tokens.
+
+- [ ] **Step 4: Wire the runtime adapters**
+
+In `boot/mobile-auth.ts`, import:
+
+```ts
+import { SecureStorage } from '@aparajita/capacitor-secure-storage';
+import { Capacitor, CapacitorHttp } from '@capacitor/core';
+import { createMobileInstallationStore } from '../auth/mobile-installation-store';
+import {
+  createIosKeychainSessionStore,
+  createUnsupportedMobileSessionStore,
+} from '../auth/mobile-session-store';
+```
+
+Use:
+
+```ts
+const isNativeIos = Capacitor.isNativePlatform() && Capacitor.getPlatform() === 'ios';
+const sessionStore = isNativeIos
+  ? createIosKeychainSessionStore({
+      secureStorage: SecureStorage,
+      runtime: Capacitor,
+      config: {
+        userPoolId: config.auth.userPoolId,
+        mobileClientId: config.auth.mobileClientId,
+      },
+    })
+  : createUnsupportedMobileSessionStore();
+const installationStore = createMobileInstallationStore(Preferences, {
+  userPoolId: config.auth.userPoolId,
+  mobileClientId: config.auth.mobileClientId,
+});
+```
+
+Inject `sessionStore`, `installationStore`, and `isNativeIos`. Keychain
+accessibility remains owned entirely by the session-store adapter.
+
+- [ ] **Step 5: Enforce platform and installation preconditions**
+
+At initialization:
+
+1. validate config;
+2. if `isNativeIos` is false, publish `unsupported_platform` and stop before
+   Preferences or plugin calls;
+3. register native listeners;
+4. read the installation marker;
+5. if absent, clear the session store and then mark the installation;
+6. on any reset failure, enter `cleanup_incomplete` and stop before launch URL,
+   transaction, or credential inspection.
+
+The coordinator's `startSignIn()` guard must use the accepted positive allowlist
+and check `isNativeIos`:
+
+```ts
+const RESTARTABLE_OAUTH_ERRORS = new Set<MobileAuthErrorCode>([
+  'browser_launch_failed',
+  'cancelled',
+  'interrupted',
+  'transaction_expired',
+  'malformed_callback',
+  'provider_error',
+  'code_exchange_failed',
+  'token_validation_failed',
+  'session_unauthorized',
+]);
+
+const canStartSignIn =
+  dependencies.isNativeIos &&
+  state.operation === 'idle' &&
+  ((state.phase === 'signedOut' &&
+    state.retryAction === null &&
+    (state.notice === null || state.notice === 'session_unusable')) ||
+    (state.phase === 'error' &&
+      state.errorCode !== null &&
+      RESTARTABLE_OAUTH_ERRORS.has(state.errorCode)));
+```
+
+All other tuples reject sign-in without touching Preferences, Keychain, or the
+browser.
+
+Retain `{ kind: 'installationReset' }` for marker/reset failure and
+`{ kind: 'terminalSession' }` for failed deletion of an API-rejected callback
+credential.
+
+- [ ] **Step 6: Persist callback candidates before verification**
+
+After authorization-code response validation:
+
+```ts
+const { refreshToken, ...candidateBundle } = bundle;
+pendingCandidate = {
+  bundle: candidateBundle,
+  durableRefreshToken: refreshToken,
+  context: 'authorizationCode',
+};
+enterOperation('persisting');
+await dependencies.sessionStore.saveRefreshToken(refreshToken);
+enterOperation('verifying');
+await verifyCandidateSessionUnlocked();
+```
+
+On save failure, keep the candidate in memory and publish
+`session_persistence_failed` with `retryAction: persist`. On API success,
+promote the candidate atomically by assigning the process-local `tokenBundle`
+with its durable refresh token, clearing `pendingCandidate`, and only then
+entering authenticated state. On API 401/403, clear the saved refresh token
+before publishing `session_unusable`; deletion failure publishes
+`cleanup_incomplete`.
+
+- [ ] **Step 7: Verify and commit**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bunx vitest run \
+  src/boot/mobile-auth.test.ts \
+  src/services/mobile-auth.test.ts \
+  src/auth/mobile-session-store.test.ts \
+  src/auth/mobile-installation-store.test.ts
+rtk bun run typecheck
+cd /Users/chanwaichan/workspace/Vela
+rtk git add \
+  apps/vela-mobile/src/services/mobile-auth.ts \
+  apps/vela-mobile/src/services/mobile-auth.test.ts \
+  apps/vela-mobile/src/boot/mobile-auth.ts \
+  apps/vela-mobile/src/boot/mobile-auth.test.ts
+rtk git commit -m "feat(mobile): persist verified OAuth sessions"
+```
+
+Expected: focused suites and typecheck PASS.
+
+---
+
+### Task 6: Restore Durable Sessions and Generalize Retry
+
+**Files:**
+
+- Modify:
+  `apps/vela-mobile/src/auth/mobile-auth-contract.ts`
+- Modify:
+  `apps/vela-mobile/src/services/mobile-auth.ts`
+- Modify:
+  `apps/vela-mobile/src/services/mobile-auth.test.ts`
+- Modify:
+  `apps/vela-mobile/src/components/mobile/MobileAuthGate.vue`
+- Modify:
+  `apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts`
+- Modify:
+  `apps/vela-mobile/src/App.test.ts`
+
+**Interfaces:**
+
+- Replaces:
+
+```ts
+retrySessionVerification(): Promise<void>;
+```
+
+with:
+
+```ts
+retryCurrentOperation(): Promise<void>;
+```
+
+Task 8 adds `signOut()` to the interface and implements it in the same task, so
+the public contract is introduced only with working behavior.
+
+- Produces cold restore, candidate retry, terminal cleanup, all five retry
+  dispatch branches, and durable-token precedence.
+
+- [ ] **Step 1: Add failing cold-launch precedence tests**
+
+```ts
+function refreshedIdToken(overrides: Record<string, unknown> = {}): string {
+  return `${base64UrlJson({ alg: 'none' })}.${base64UrlJson({
+    token_use: 'id',
+    aud: config.mobileClientId,
+    iss: `https://cognito-idp.${config.region}.amazonaws.com/${config.userPoolId}`,
+    sub: 'user-123',
+    exp: 2_000,
+    ...overrides,
+  })}.unsigned`;
+}
+
+function prepareSuccessfulRefresh(
+  harness: ReturnType<typeof makeHarness>,
+  options: { subject?: string; rotatedRefreshToken?: string } = {},
+): void {
+  harness.tokenTransport.result = {
+    status: 200,
+    data: {
+      access_token: 'SECRET-refreshed-access-token',
+      id_token: refreshedIdToken({ sub: options.subject ?? 'user-123' }),
+      expires_in: 3_600,
+      ...(options.rotatedRefreshToken ? { refresh_token: options.rotatedRefreshToken } : {}),
+    },
+  };
+}
+
+it('lets a matching callback win without starting a parallel restore', async () => {
+  app.launchUrl = { url: matchingCallbackUrl };
+  sessionStore.loadRefreshToken.mockResolvedValue('durable-token');
+  await coordinator.initialize();
+
+  expect(tokenTransport.requests).toHaveLength(1);
+  expect(tokenTransport.requests[0]?.data).toContain('grant_type=authorization_code');
+  expect(tokenTransport.requests[0]?.data).not.toContain('grant_type=refresh_token');
+});
+
+it('lets a durable token outrank a residual transaction', async () => {
+  transactionStore.load.mockResolvedValue({
+    kind: 'active',
+    transaction,
+  });
+  sessionStore.loadRefreshToken.mockResolvedValue('durable-token');
+  await coordinator.initialize();
+
+  expect(transactionStore.clear).toHaveBeenCalled();
+  expect(tokenTransport.requests[0]?.data).toContain('grant_type=refresh_token');
+});
+
+it('restores and verifies before publishing a usable session', async () => {
+  sessionStore.loadRefreshToken.mockResolvedValue('durable-token');
+  await coordinator.initialize();
+
+  expect(order).toContainSequence([
+    'session:load',
+    'token:refresh',
+    'candidate:validate',
+    'fetch:/auth/session',
+    'state:authenticated',
+  ]);
+  expect(coordinator.state.sessionUsable).toBe(true);
+});
+```
+
+Add missing token, active transaction without token, expired/corrupt residual
+transaction fallthrough, rare load rejection, rotated-token persistence,
+subject mismatch, and API verification cases. Include a transaction-store read
+rejection with a valid durable token and assert restoration still proceeds.
+
+- [ ] **Step 2: Add failing terminal-versus-retryable tests**
+
+```ts
+import { MobileSessionStoreError } from '../auth/mobile-session-store';
+
+it.each([
+  [400, { error: 'invalid_grant' }],
+  [401, { error: 'unauthorized' }],
+  [403, { error: 'forbidden' }],
+] as const)('clears terminal refresh failures with status %s', async (status, data) => {
+  tokenTransport.respond({ status, data });
+  await coordinator.initialize();
+  expect(sessionStore.clearRefreshToken).toHaveBeenCalledOnce();
+  expect(coordinator.state.notice).toBe('session_unusable');
+});
+
+it.each([429, 500, 503])('preserves the durable token for retryable status %s', async (status) => {
+  tokenTransport.respond({ status, data: {} });
+  await coordinator.initialize();
+  expect(sessionStore.clearRefreshToken).not.toHaveBeenCalled();
+  expect(coordinator.state).toMatchObject({
+    errorCode: 'session_restore_failed',
+    retryAction: 'restore',
+  });
+});
+
+it('clears a corrupt local token before showing the terminal notice', async () => {
+  sessionStore.loadRefreshToken.mockRejectedValue(new MobileSessionStoreError('corrupt'));
+  await coordinator.initialize();
+
+  expect(sessionStore.clearRefreshToken).toHaveBeenCalledOnce();
+  expect(coordinator.state).toMatchObject({
+    phase: 'signedOut',
+    sessionUsable: false,
+    errorCode: null,
+    retryAction: null,
+    notice: 'session_unusable',
+  });
+});
+```
+
+Also cover network/timeout failures, malformed 2xx responses, API 401/403, API
+429/5xx, corrupt-token deletion failure entering `cleanup_incomplete`, and
+sanitized messages.
+
+- [ ] **Step 3: Add failing retry-dispatch tests**
+
+```ts
+it.each([
+  ['restore', 'token:refresh'],
+  ['persist', 'session:save'],
+  ['verify', 'fetch:/auth/session'],
+  ['cleanup', 'session:clear'],
+] as const)(
+  'dispatches %s without repeating completed work',
+  async (retryAction, expectedOperation) => {
+    arrangeRetryableState(retryAction);
+    await coordinator.retryCurrentOperation();
+    expect(order).toContain(expectedOperation);
+  },
+);
+```
+
+For `persist`, assert no token request is made. For `verify`, assert neither
+token request nor Keychain save is repeated. For `cleanup`, assert no token or
+API request is made.
+
+- [ ] **Step 4: Run the coordinator suite to verify failure**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bunx vitest run src/services/mobile-auth.test.ts
+```
+
+Expected: FAIL because durable restore and generalized retry are absent.
+
+- [ ] **Step 5: Implement cold restore and candidate promotion**
+
+Retain Task 5's `PendingCandidate` and represent verified ownership explicitly:
+
+```ts
+type ActiveSession = {
+  bundle: OAuthTokenBundleBase & { refreshToken: string };
+  user: MobileAuthUser;
+};
+```
+
+Replace the Task 4 `tokenBundle` owner with
+`let active: ActiveSession | undefined`, update `applyState()` to pass
+`active?.bundle ?? null` to the invariant validator, and assign `active` before
+publishing the authenticated tuple. Candidates remain separate until that
+promotion point.
+
+The restore path must:
+
+1. load the durable token, mapping missing to ordinary signed out, corrupt to
+   terminal cleanup, and unavailable to retryable restore;
+2. build the refresh request with the 15-second timeout;
+3. classify terminal versus retryable transport outcomes;
+4. parse and validate the refreshed claims;
+5. persist a returned rotation before verification;
+6. verify `/api/auth/session`;
+7. promote one complete `ActiveSession`.
+
+No public state may expose `sessionUsable: true` before step 7.
+
+Task 6 consumes Task 5's `CleanupContext`: installation-reset cleanup clears
+Keychain, writes the marker, and resumes initialization; terminal-session
+cleanup clears Keychain and publishes `notice: session_unusable`.
+
+- [ ] **Step 6: Implement exact cold-launch precedence**
+
+After installation reset:
+
+1. consume only a matching launch callback with an active transaction;
+2. otherwise capture transaction state and load the durable token independently;
+3. if a token exists, clear any residual transaction best-effort and restore;
+4. without a token, keep the existing active/expired/corrupt transaction
+   recovery semantics;
+5. without either, enter ordinary signed out.
+
+Do not return on a transaction-store read failure before attempting the
+Keychain load. A durable token may still restore; only a transaction dependency
+failure with no restorable durable credential becomes
+`configuration_error`. A Keychain operational failure remains
+`session_restore_failed` even when residual transaction state exists.
+
+- [ ] **Step 7: Implement generalized retry and update fixtures**
+
+`retryCurrentOperation()` reads only `state.retryAction` and retained internal
+state. Capture the action before the named retry transition clears public
+error/retry fields:
+
+```ts
+const retryAction = state.retryAction;
+if (retryAction === null || state.operation !== 'idle') return;
+
+switch (retryAction) {
+  case 'restore':
+    enterRetryOperation('restore');
+    await restoreSessionUnlocked();
+    return;
+  case 'refresh':
+    enterRetryOperation('refresh');
+    await refreshActiveSessionUnlocked();
+    return;
+  case 'persist':
+    enterRetryOperation('persist');
+    await persistCandidateUnlocked();
+    return;
+  case 'verify':
+    enterRetryOperation('verify');
+    await verifyCandidateSessionUnlocked();
+    return;
+  case 'cleanup':
+    enterRetryOperation('cleanup');
+    await retryCleanupUnlocked();
+    return;
+}
+```
+
+`refreshActiveSessionUnlocked()` uses the same candidate pipeline without
+timers or coalescing; Task 7 puts this branch behind the single-flight
+scheduler. Update all coordinator fixtures from `retrySessionVerification` to
+`retryCurrentOperation`. In `MobileAuthGate.vue`, replace the narrow retry
+handler's coordinator call with `retryCurrentOperation()` while retaining the
+existing HPA-205 presentation; Task 9 replaces that presentation with the
+total selector.
+
+- [ ] **Step 8: Verify and commit**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bunx vitest run \
+  src/services/mobile-auth.test.ts \
+  src/auth/mobile-oauth.test.ts \
+  src/components/mobile/MobileAuthGate.test.ts \
+  src/App.test.ts
+rtk bun run typecheck
+cd /Users/chanwaichan/workspace/Vela
+rtk git add \
+  apps/vela-mobile/src/auth/mobile-auth-contract.ts \
+  apps/vela-mobile/src/services/mobile-auth.ts \
+  apps/vela-mobile/src/services/mobile-auth.test.ts \
+  apps/vela-mobile/src/components/mobile/MobileAuthGate.vue \
+  apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts \
+  apps/vela-mobile/src/App.test.ts
+rtk git commit -m "feat(mobile): restore durable Cognito sessions"
+```
+
+Expected: focused suites and typecheck PASS.
+
+---
+
+### Task 7: Add Proactive Refresh, Resume Recovery, and Expiry Closure
+
+**Files:**
+
+- Modify:
+  `apps/vela-mobile/src/services/mobile-auth.ts`
+- Modify:
+  `apps/vela-mobile/src/services/mobile-auth.test.ts`
+
+**Interfaces:**
+
+- Consumes the Task 6 active-session and candidate pipeline.
+- Routes proactive, resume, automatic, and manual triggers through the Task 6
+  refresh branch.
+- Adds:
+
+```ts
+export const MOBILE_AUTH_REFRESH_LEAD_MS = 60_000;
+export const MOBILE_AUTH_SOFT_RETRY_DELAY_MS = 5_000;
+```
+
+- [ ] **Step 1: Extend the fake app for `appStateChange`**
+
+```ts
+class FakeApp implements MobileAppAdapter {
+  urlListener?: (event: { url: string }) => void;
+  stateListener?: (event: { isActive: boolean }) => void;
+
+  async addListener(
+    eventName: 'appUrlOpen' | 'appStateChange',
+    listener: ((event: { url: string }) => void) | ((event: { isActive: boolean }) => void),
+  ): Promise<ListenerHandle> {
+    if (eventName === 'appUrlOpen') {
+      this.urlListener = listener as (event: { url: string }) => void;
+    } else {
+      this.stateListener = listener as (event: { isActive: boolean }) => void;
+    }
+    return { remove: vi.fn().mockResolvedValue(undefined) };
+  }
+}
+```
+
+Extend `HarnessOptions` with `now?: () => number` and inject
+`options.now ?? (() => NOW)` into the coordinator. Every fake-timer test sets
+`vi.setSystemTime(NOW)` and passes `now: () => Date.now()`; production code
+continues to read only `dependencies.now()`.
+
+- [ ] **Step 2: Add failing timer and resume tests**
+
+```ts
+it('refreshes exactly 60 seconds before access expiry', async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  await authenticateWithExpiry(NOW + 3_600_000);
+  await vi.advanceTimersByTimeAsync(3_539_999);
+  expect(refreshRequests()).toHaveLength(0);
+  await vi.advanceTimersByTimeAsync(1);
+  expect(refreshRequests()).toHaveLength(1);
+});
+
+it('coalesces resume, automatic timer, and manual retry into one grant', async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  await authenticateWithExpiry(NOW + 120_000);
+  failNextRefreshWithNetworkError();
+  await vi.advanceTimersByTimeAsync(60_000);
+
+  holdNextRefreshResponse();
+  const manualRetry = coordinator.retryCurrentOperation();
+  app.emitState(true);
+  await vi.advanceTimersByTimeAsync(5_000);
+
+  expect(refreshRequests()).toHaveLength(2);
+  releaseRefreshResponse();
+  await manualRetry;
+});
+
+it('rechecks ownership at the serialized queue head', async () => {
+  blockEarlierOperation();
+  app.emitState(true);
+  app.emitState(false);
+  releaseEarlierOperation();
+  await flushPromises();
+  expect(refreshRequests()).toHaveLength(0);
+});
+```
+
+- [ ] **Step 3: Add failing soft-failure and expiry tests**
+
+```ts
+it('retries one soft failure after five seconds with enough lifetime', async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  await authenticateWithExpiry(NOW + 61_000);
+  failNextTwoRefreshesWithNetworkError();
+  await vi.advanceTimersByTimeAsync(1_000);
+  expect(coordinator.state.sessionUsable).toBe(true);
+
+  await vi.advanceTimersByTimeAsync(4_999);
+  expect(refreshRequests()).toHaveLength(1);
+  await vi.advanceTimersByTimeAsync(1);
+  expect(refreshRequests()).toHaveLength(2);
+
+  await vi.advanceTimersByTimeAsync(5_000);
+  expect(refreshRequests()).toHaveLength(2);
+});
+
+it('closes the gate at exact old-token expiry after a soft failure', async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  await authenticateWithExpiry(NOW + 61_000);
+  failNextTwoRefreshesWithNetworkError();
+  await vi.advanceTimersByTimeAsync(1_000);
+  await vi.advanceTimersByTimeAsync(5_000);
+
+  await vi.advanceTimersByTimeAsync(54_999);
+  expect(coordinator.state.sessionUsable).toBe(true);
+  await vi.advanceTimersByTimeAsync(1);
+  expect(coordinator.state).toMatchObject({
+    phase: 'authenticated',
+    sessionUsable: false,
+    errorCode: 'session_refresh_failed',
+    retryAction: 'refresh',
+  });
+});
+```
+
+Add inactive cancellation, active rescheduling, too-little-lifetime,
+manual-cancels-auto, candidate persistence/verification retry, successful
+deadline replacement, and injected-clock-only cases.
+
+- [ ] **Step 4: Run the coordinator suite to verify failure**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bunx vitest run src/services/mobile-auth.test.ts
+```
+
+Expected: FAIL because lifecycle timers and coalescing do not exist.
+
+- [ ] **Step 5: Implement refresh scheduling and single flight**
+
+Use separate handles for:
+
+```ts
+let proactiveRefreshTimer: ReturnType<typeof setTimeout> | undefined;
+let accessExpiryTimer: ReturnType<typeof setTimeout> | undefined;
+let automaticRetryTimer: ReturnType<typeof setTimeout> | undefined;
+let refreshPromise: Promise<void> | undefined;
+let activeBundleGeneration = 0;
+let appIsActive = true;
+```
+
+Schedule the foreground timer with:
+
+```ts
+const delay = Math.max(
+  0,
+  active.bundle.expiresAt - dependencies.now() - MOBILE_AUTH_REFRESH_LEAD_MS,
+);
+```
+
+A zero delay queues immediately. Resume recomputes the same delay, refreshing
+only when expired or within the lead window and otherwise installing a new
+timer.
+
+`queueRefresh()` sets `refreshPromise` before calling `serialize()`, captures the
+bundle generation, re-checks app activity/session ownership/due time at queue
+head, and clears the promise in `finally`.
+
+- [ ] **Step 6: Implement the bounded automatic retry**
+
+After a retryable in-session `refresh`, `persist`, or `verify` failure:
+
+```ts
+const enoughLifetime =
+  active.bundle.expiresAt - dependencies.now() >
+  MOBILE_AUTH_SOFT_RETRY_DELAY_MS + MOBILE_AUTH_NETWORK_TIMEOUT_MS;
+```
+
+Schedule exactly one automatic retry when active and `enoughLifetime` is true.
+Cancel it on manual retry, backgrounding, promotion, expiry, terminal cleanup,
+sign-out, or disposal.
+
+- [ ] **Step 7: Register and remove the lifecycle listener**
+
+Register `appStateChange` beside `appUrlOpen`. `isActive: false` cancels the
+foreground refresh/automatic-retry timers. `isActive: true` synchronously
+re-evaluates old-token expiry, then queues or schedules refresh. Keep
+`capacitor-lifecycle.ts` unchanged because its `resume` listener remains
+diagnostics-only.
+
+- [ ] **Step 8: Verify and commit**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bunx vitest run src/services/mobile-auth.test.ts
+rtk bun run typecheck
+cd /Users/chanwaichan/workspace/Vela
+rtk git add \
+  apps/vela-mobile/src/services/mobile-auth.ts \
+  apps/vela-mobile/src/services/mobile-auth.test.ts
+rtk git commit -m "feat(mobile): refresh active Cognito sessions"
+```
+
+Expected: coordinator suite and typecheck PASS.
+
+---
+
+### Task 8: Implement Local Sign-Out, Start Over, and Cleanup Retry
+
+**Files:**
+
+- Modify:
+  `apps/vela-mobile/src/auth/mobile-auth-contract.ts`
+- Modify:
+  `apps/vela-mobile/src/services/mobile-auth.ts`
+- Modify:
+  `apps/vela-mobile/src/services/mobile-auth.test.ts`
+- Modify:
+  `apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts`
+- Modify:
+  `apps/vela-mobile/src/App.test.ts`
+
+**Interfaces:**
+
+- Adds and implements `MobileAuthCoordinator.signOut(): Promise<void>`.
+- Extends cleanup retry ownership to failed Sign out.
+- `dispose()` remains teardown-only and never calls session or Preferences
+  cleanup.
+
+- [ ] **Step 1: Add failing sign-out tests**
+
+```ts
+it('hides content before asynchronous durable cleanup', async () => {
+  await authenticate();
+  sessionStore.clearRefreshToken.mockReturnValue(clearGate.promise);
+  const result = coordinator.signOut();
+
+  expect(coordinator.state).toMatchObject({
+    operation: 'signingOut',
+    sessionUsable: false,
+  });
+  expect(clearGate.settled).toBe(false);
+
+  clearGate.resolve();
+  await result;
+});
+
+it.each(['restore', 'refresh', 'persist', 'verify'] as const)(
+  'allows start-over cleanup from blocking %s recovery',
+  async (retryAction) => {
+    arrangeBlockingRetry(retryAction);
+    await coordinator.signOut();
+    expect(sessionStore.clearRefreshToken).toHaveBeenCalledOnce();
+    expect(transactionStore.clear).toHaveBeenCalledOnce();
+    expect(coordinator.state).toMatchObject({
+      phase: 'signedOut',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: null,
+      retryAction: null,
+      notice: null,
+      user: null,
+    });
+  },
+);
+```
+
+- [ ] **Step 2: Add failing cleanup and disposal tests**
+
+```ts
+it('reports incomplete cleanup without claiming sign-out success', async () => {
+  await authenticate();
+  sessionStore.clearRefreshToken.mockRejectedValue(new Error('SECRET-delete-failure'));
+  await coordinator.signOut();
+
+  expect(coordinator.state).toMatchObject({
+    phase: 'signedOut',
+    operation: 'idle',
+    sessionUsable: false,
+    errorCode: 'session_cleanup_failed',
+    retryAction: 'cleanup',
+    notice: 'cleanup_incomplete',
+    user: null,
+  });
+  expect(JSON.stringify(coordinator.state)).not.toContain('SECRET');
+});
+
+it('dispose waits behind sign-out but never deletes durable state itself', async () => {
+  const signOut = coordinator.signOut();
+  const dispose = coordinator.dispose();
+  await signOut;
+  await dispose;
+  expect(sessionStore.clearRefreshToken).toHaveBeenCalledOnce();
+});
+```
+
+Add cleanup retry success/failure, duplicate sign-out suppression, timer
+cancellation, pending candidate erasure, installation-marker retention, and
+post-disposal no-op cases. Add a resolved `signOut` mock to the typed
+coordinator fixtures in `MobileAuthGate.test.ts` and `App.test.ts`. Assert local
+Sign out makes no Cognito token/logout request and does not open the browser.
+
+- [ ] **Step 3: Run the coordinator suite to verify failure**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bunx vitest run \
+  src/services/mobile-auth.test.ts \
+  src/components/mobile/MobileAuthGate.test.ts \
+  src/App.test.ts
+```
+
+Expected: FAIL because `signOut()` and cleanup retry are incomplete.
+
+- [ ] **Step 4: Implement sign-out eligibility and cleanup**
+
+Use a positive predicate:
+
+```ts
+let signOutPromise: Promise<void> | undefined;
+
+function canSignOutOrStartOver(): boolean {
+  if (disposed) return false;
+  return (
+    state.phase === 'authenticated' ||
+    (state.operation === 'idle' &&
+      state.sessionUsable === false &&
+      state.retryAction !== null &&
+      ['restore', 'refresh', 'persist', 'verify'].includes(state.retryAction))
+  );
+}
+```
+
+At the public call, return `signOutPromise` immediately when one already
+exists. Otherwise validate the predicate, synchronously suppress new refresh
+work and close the gate, assign the serialized cleanup promise before returning
+it, and clear the single-flight field in `finally`.
+
+Add `disposalRequested` beside `disposed`. The public `dispose()` sets it before
+joining the serialized queue; every other public entry point and every queue-head
+ownership check treats either flag as unavailable. The queued disposer removes
+listeners and timers and clears process memory, but never calls either durable
+store.
+
+Inside the serialized cleanup:
+
+1. cancel all three timer classes and invalidate bundle generation;
+2. clear Keychain and PKCE transaction;
+3. erase active and pending token material;
+4. enter ordinary signed out only after Keychain deletion succeeds;
+5. otherwise enter `cleanup_incomplete`.
+
+Do not remove the installation marker.
+
+- [ ] **Step 5: Implement cleanup retry**
+
+Extend the retained cleanup context:
+
+```ts
+type CleanupContext =
+  | { kind: 'signOut' }
+  | { kind: 'terminalSession' }
+  | { kind: 'installationReset' };
+```
+
+Installation-reset retry must clear Keychain, mark the installation, and resume
+initialization. Sign-out retry clears Keychain and finishes ordinary signed
+out. Terminal-session retry clears Keychain and finishes signed out with
+`notice: session_unusable`.
+
+- [ ] **Step 6: Verify and commit**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bunx vitest run \
+  src/services/mobile-auth.test.ts \
+  src/components/mobile/MobileAuthGate.test.ts \
+  src/App.test.ts
+rtk bun run typecheck
+cd /Users/chanwaichan/workspace/Vela
+rtk git add \
+  apps/vela-mobile/src/auth/mobile-auth-contract.ts \
+  apps/vela-mobile/src/services/mobile-auth.ts \
+  apps/vela-mobile/src/services/mobile-auth.test.ts \
+  apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts \
+  apps/vela-mobile/src/App.test.ts
+rtk git commit -m "feat(mobile): add durable local sign-out"
+```
+
+Expected: coordinator suite and typecheck PASS.
+
+---
+
+### Task 9: Render the Exhaustive Gate and Add Sign-Out UI
+
+**Files:**
+
+- Create:
+  `apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.ts`
+- Create:
+  `apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.test.ts`
+- Create:
+  `apps/vela-mobile/src/pages/MorePage.test.ts`
+- Modify:
+  `apps/vela-mobile/src/components/mobile/MobileAuthGate.vue`
+- Modify:
+  `apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts`
+- Modify:
+  `apps/vela-mobile/src/pages/MorePage.vue`
+- Modify:
+  `apps/vela-mobile/src/App.test.ts`
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+export type AuthenticatedLandingState = 'pending' | 'ready' | 'failed';
+
+export type MobileAuthGateView =
+  | {
+      kind: 'content';
+      retry: {
+        errorCode: MobileAuthErrorCode;
+        action: Exclude<MobileAuthRetryAction, 'cleanup'>;
+      } | null;
+    }
+  | { kind: 'progress'; operation: MobileAuthOperation; phase: MobileAuthPhase }
+  | { kind: 'landing_failure' }
+  | {
+      kind: 'blocking_session_failure';
+      errorCode: MobileAuthErrorCode;
+      retryAction: Exclude<MobileAuthRetryAction, 'cleanup'>;
+      allowStartOver: true;
+    }
+  | { kind: 'signed_out'; notice: 'session_unusable' | null }
+  | { kind: 'cleanup_failure' }
+  | { kind: 'unsupported' }
+  | { kind: 'oauth_error'; errorCode: MobileAuthErrorCode }
+  | { kind: 'invalid_state' };
+
+export function selectMobileAuthGateView(
+  state: Readonly<MobileAuthState>,
+  landingState: AuthenticatedLandingState,
+): MobileAuthGateView;
+```
+
+- `MobileAuthGate.vue` consumes only this selector plus the development
+  diagnostics bypass.
+
+- [ ] **Step 1: Write the failing selector matrix**
+
+```ts
+it.each([
+  [
+    {
+      phase: 'authenticated',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: 'session_refresh_failed',
+      retryAction: 'refresh',
+      notice: null,
+      user,
+    },
+    {
+      kind: 'blocking_session_failure',
+      errorCode: 'session_refresh_failed',
+      retryAction: 'refresh',
+      allowStartOver: true,
+    },
+  ],
+  [
+    {
+      phase: 'signedOut',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: null,
+      retryAction: null,
+      notice: 'session_unusable',
+      user: null,
+    },
+    { kind: 'signed_out', notice: 'session_unusable' },
+  ],
+] as const)('maps state to an explicit gate view', (state, expected) => {
+  expect(selectMobileAuthGateView(state, 'ready')).toEqual(expected);
+});
+
+it('fails closed for an unmatched tuple', () => {
+  expect(
+    selectMobileAuthGateView(
+      {
+        phase: 'signedOut',
+        operation: 'idle',
+        sessionUsable: true,
+        errorCode: null,
+        retryAction: null,
+        notice: null,
+        user: null,
+      },
+      'ready',
+    ),
+  ).toEqual({ kind: 'invalid_state' });
+});
+```
+
+Cover every operation, soft banner, landing pending/failure, cleanup,
+unsupported, ordinary signed out, terminal notice, all restartable HPA-205
+errors, and configuration error.
+
+- [ ] **Step 2: Run the selector test to verify failure**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bunx vitest run src/components/mobile/mobile-auth-gate-view.test.ts
+```
+
+Expected: FAIL because the selector does not exist.
+
+- [ ] **Step 3: Implement the total selector**
+
+Use explicit precedence:
+
+1. reject invariant-breaking tuples as `invalid_state`;
+2. return `unsupported` and `cleanup_failure`;
+3. return blocking progress when `sessionUsable` is false and either
+   `operation` is non-idle or the error-free phase is an HPA-205 OAuth progress
+   phase;
+4. return content/content-banner when usable and landing is ready;
+5. return landing pending/failure while authenticated;
+6. return blocking session retry when unusable;
+7. return ordinary/terminal signed out;
+8. return existing HPA-205 error;
+9. return `invalid_state`.
+
+Never return `undefined` and never select from translated copy.
+
+- [ ] **Step 4: Add failing component action and bypass tests**
+
+```ts
+it('renders retry and start-over for an expired refresh failure', async () => {
+  const { wrapper, coordinator } = await mountGate({
+    phase: 'authenticated',
+    operation: 'idle',
+    sessionUsable: false,
+    errorCode: 'session_refresh_failed',
+    retryAction: 'refresh',
+    notice: null,
+    user,
+  });
+  expect(wrapper.find('[data-testid="protected-slot"]').exists()).toBe(false);
+  expect(wrapper.findAll('button').map((button) => button.text())).toEqual([
+    'Retry',
+    'Sign out and start over',
+  ]);
+  await wrapper.findAll('button')[1]?.trigger('click');
+  expect(coordinator.signOut).toHaveBeenCalledOnce();
+});
+
+it('allows marked development diagnostics for unsupported browser boot', async () => {
+  const { wrapper } = await mountGate(
+    {
+      phase: 'error',
+      operation: 'idle',
+      sessionUsable: false,
+      errorCode: 'unsupported_platform',
+      retryAction: null,
+      notice: null,
+      user: null,
+    },
+    { path: '/diagnostics' },
+  );
+  expect(wrapper.get('[data-testid="protected-slot"]').exists()).toBe(true);
+});
+```
+
+Add non-blocking banner, cleanup-only retry, terminal notice, progress
+`aria-live`, invalid-state, action deduplication, and focus-return tests.
+
+- [ ] **Step 5: Rewrite `MobileAuthGate.vue` around the selector**
+
+Keep:
+
+```ts
+const contentVisible = computed(() => diagnosticBypass.value || gateView.value.kind === 'content');
+```
+
+Use one template branch per `gateView.kind`. The
+`blocking_session_failure` branch calls `retryCurrentOperation()` and
+`signOut()`. `cleanup_failure` calls only `retryCurrentOperation()`.
+`unsupported` and `invalid_state` have no action.
+
+Watch entry into `invalid_state` and emit exactly
+`console.error('mobile_auth_invalid_state')` once per entry. Never serialize the
+state tuple into that diagnostic.
+
+Use these exact HPA-206 strings:
+
+```ts
+const OPERATION_COPY: Partial<Record<MobileAuthOperation, string>> = {
+  restoring: 'Restoring your Vela session…',
+  refreshing: 'Refreshing your Vela session…',
+  persisting: 'Securing your Vela session…',
+  verifying: 'Verifying your Vela session…',
+  signingOut: 'Signing out…',
+  cleaningUp: 'Finishing secure sign-out…',
+};
+
+const SESSION_UNUSABLE_COPY =
+  'Your Vela session is no longer usable. Continue with Google to sign in again.';
+const CLEANUP_INCOMPLETE_COPY =
+  'Vela could not finish secure sign-out. Your session may return if you close and reopen the app before cleanup succeeds.';
+```
+
+Progress uses `role="status"` and `aria-live="polite"`; failures and notices use
+`role="alert"`. A successful background refresh produces no live-region
+announcement.
+
+Update `shouldBypassMobileAuth()` to require development mode, route metadata,
+`operation: idle`, and one of:
+
+```ts
+const ordinarySignedOut =
+  state.phase === 'signedOut' &&
+  state.operation === 'idle' &&
+  state.sessionUsable === false &&
+  state.errorCode === null &&
+  state.retryAction === null &&
+  state.notice === null &&
+  state.user === null;
+
+const bypassableBootError =
+  state.phase === 'error' &&
+  state.operation === 'idle' &&
+  state.sessionUsable === false &&
+  (state.errorCode === 'configuration_error' || state.errorCode === 'unsupported_platform') &&
+  state.retryAction === null &&
+  state.notice === null &&
+  state.user === null;
+
+ordinarySignedOut || bypassableBootError;
+```
+
+- [ ] **Step 6: Add the More-page Sign out test**
+
+```ts
+function createCoordinatorStub(
+  overrides: Partial<MobileAuthCoordinator> = {},
+): MobileAuthCoordinator {
+  return {
+    state: authenticatedState,
+    initialize: vi.fn().mockResolvedValue(undefined),
+    startSignIn: vi.fn().mockResolvedValue(undefined),
+    completeCallback: vi.fn().mockResolvedValue(undefined),
+    retryCurrentOperation: vi.fn().mockResolvedValue(undefined),
+    signOut: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+it('calls the mobile coordinator once and exposes progress', async () => {
+  const signOut = deferred<void>();
+  const coordinator = createCoordinatorStub({
+    state: authenticatedState,
+    signOut: vi.fn(() => signOut.promise),
+  });
+  const wrapper = mount(MorePage, {
+    global: {
+      provide: {
+        [MOBILE_AUTH_KEY as symbol]: coordinator,
+      },
+      stubs: {
+        DevelopmentDiagnosticsEntry: true,
+      },
+    },
+  });
+
+  const button = wrapper.get('[aria-label="Sign out of Vela"]');
+  await button.trigger('click');
+  expect(button.attributes('disabled')).toBeDefined();
+  expect(coordinator.signOut).toHaveBeenCalledOnce();
+  signOut.resolve();
+  await flushPromises();
+});
+```
+
+- [ ] **Step 7: Implement the More-page button**
+
+Inject `MOBILE_AUTH_KEY`, require it as `MobileAuthGate` does, and add:
+
+```vue
+<q-btn
+  aria-label="Sign out of Vela"
+  color="negative"
+  outline
+  :loading="signOutPending"
+  :disable="signOutPending"
+  label="Sign out"
+  @click="handleSignOut"
+/>
+```
+
+Use a local duplicate-click guard:
+
+```ts
+async function handleSignOut(): Promise<void> {
+  if (signOutPending.value) return;
+  signOutPending.value = true;
+  try {
+    await coordinator.signOut();
+  } finally {
+    signOutPending.value = false;
+  }
+}
+```
+
+The handler calls only `coordinator.signOut()`. The gate owns all post-sign-out
+routing and surface behavior.
+
+- [ ] **Step 8: Verify and commit**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bunx vitest run \
+  src/components/mobile/mobile-auth-gate-view.test.ts \
+  src/components/mobile/MobileAuthGate.test.ts \
+  src/pages/MorePage.test.ts \
+  src/App.test.ts
+rtk bun run typecheck
+cd /Users/chanwaichan/workspace/Vela
+rtk git add \
+  apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.ts \
+  apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.test.ts \
+  apps/vela-mobile/src/components/mobile/MobileAuthGate.vue \
+  apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts \
+  apps/vela-mobile/src/pages/MorePage.vue \
+  apps/vela-mobile/src/pages/MorePage.test.ts \
+  apps/vela-mobile/src/App.test.ts
+rtk git commit -m "feat(mobile): add session recovery and sign-out UI"
+```
+
+Expected: selector, component, page, and App suites PASS; typecheck PASS.
+
+---
+
+### Task 10: Close Security Regressions and Run the Full Verification Ladder
+
+**Files:**
+
+- Modify:
+  `apps/vela-mobile/src/services/mobile-auth.test.ts`
+- Modify:
+  `apps/vela-mobile/src/boot/mobile-auth.test.ts`
+- Modify:
+  `apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts`
+- Modify only if generated sync requires it:
+  `apps/vela-mobile/src-capacitor/ios/App/Podfile.lock`
+
+**Interfaces:**
+
+- No new production interface.
+- Produces whole-feature leakage, relaunch, uninstall-reset, and regression
+  evidence.
+
+- [ ] **Step 1: Add the cross-boundary sentinel test**
+
+```ts
+const SECRET_SENTINELS = [
+  'SECRET-access-token',
+  'SECRET-id-token',
+  'SECRET-refresh-token',
+  'SECRET-rotated-refresh-token',
+] as const;
+
+const LOG_AND_DOM_SENTINELS = [
+  ...SECRET_SENTINELS,
+  'SECRET-authorization-url',
+  'SECRET-callback-code',
+  'SECRET-code-verifier',
+  'SECRET-nonce',
+  'SECRET-claim-email',
+] as const;
+
+function searchable(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function storageSnapshot(storage: Storage): string {
+  return Array.from({ length: storage.length }, (_, index) => {
+    const key = storage.key(index) ?? '';
+    return `${key}=${storage.getItem(key) ?? ''}`;
+  }).join('\n');
+}
+
+function expectNoSecretLeak(input: {
+  consoleCalls: unknown[][];
+  preferenceCalls: unknown[][];
+  renderedText?: string;
+}): void {
+  const logsAndDom = [
+    searchable(input.consoleCalls),
+    input.renderedText ?? document.body.textContent ?? '',
+  ].join('\n');
+  const browserAndPreferenceStorage = [
+    searchable(input.preferenceCalls),
+    storageSnapshot(window.localStorage),
+    storageSnapshot(window.sessionStorage),
+  ].join('\n');
+
+  for (const secret of LOG_AND_DOM_SENTINELS) {
+    expect(logsAndDom).not.toContain(secret);
+  }
+  for (const secret of SECRET_SENTINELS) {
+    expect(browserAndPreferenceStorage).not.toContain(secret);
+  }
+}
+```
+
+Use the sentinel values in separate callback success/failure, cold restore,
+soft refresh, rotated-token save failure, API rejection, start over, cleanup
+failure, and disposal tests. After each scenario, call `expectNoSecretLeak()`
+with the captured `console.debug/info/warn/error` calls, the Preferences
+`set()` calls, and the mounted gate text when that scenario renders UI. Keep
+the scenarios separate so a failure identifies the leaking boundary. The PKCE
+verifier and nonce remain allowed only inside the token-free Preferences
+transaction, never in logs or DOM.
+
+- [ ] **Step 2: Add simulated relaunch and reinstall tests**
+
+```ts
+class FakeSessionStore implements MobileSessionStore {
+  clearFailure: unknown;
+
+  constructor(public value: string | null) {}
+
+  readonly loadRefreshToken = vi.fn(async () => this.value);
+  readonly saveRefreshToken = vi.fn(async (value: string) => {
+    this.value = value;
+  });
+  readonly clearRefreshToken = vi.fn(async () => {
+    if (this.clearFailure) throw this.clearFailure;
+    this.value = null;
+  });
+}
+
+class FakeInstallationStore implements MobileInstallationStore {
+  constructor(public marked: boolean) {}
+
+  readonly isCurrentInstallationMarked = vi.fn(async () => this.marked);
+  readonly markCurrentInstallation = vi.fn(async () => {
+    this.marked = true;
+  });
+}
+
+it('restores after process relaunch but clears on a new installation marker', async () => {
+  const durableStore = new FakeSessionStore('refresh-token');
+  const firstRelaunch = makeHarness({
+    sessionStore: durableStore,
+    installationStore: new FakeInstallationStore(true),
+  });
+  prepareSuccessfulRefresh(firstRelaunch, { subject: 'user-123' });
+  await firstRelaunch.coordinator.initialize();
+  expect(firstRelaunch.coordinator.state.sessionUsable).toBe(true);
+
+  const reinstalled = makeHarness({
+    sessionStore: durableStore,
+    installationStore: new FakeInstallationStore(false),
+  });
+  await reinstalled.coordinator.initialize();
+  expect(durableStore.clearRefreshToken).toHaveBeenCalled();
+  expect(reinstalled.coordinator.state.phase).toBe('signedOut');
+  expect(reinstalled.coordinator.state.sessionUsable).toBe(false);
+});
+
+it('keeps successful local sign-out durable across relaunch', async () => {
+  const durableStore = new FakeSessionStore('refresh-token');
+  const first = makeHarness({
+    sessionStore: durableStore,
+    installationStore: new FakeInstallationStore(true),
+  });
+  prepareSuccessfulRefresh(first);
+  await first.coordinator.initialize();
+  await first.coordinator.signOut();
+
+  const relaunched = makeHarness({
+    sessionStore: durableStore,
+    installationStore: new FakeInstallationStore(true),
+  });
+  await relaunched.coordinator.initialize();
+  expect(relaunched.coordinator.state.phase).toBe('signedOut');
+  expect(relaunched.tokenTransport.requests).toHaveLength(0);
+});
+
+it('restores after relaunch when secure sign-out cleanup was incomplete', async () => {
+  const durableStore = new FakeSessionStore('refresh-token');
+  const first = makeHarness({
+    sessionStore: durableStore,
+    installationStore: new FakeInstallationStore(true),
+  });
+  prepareSuccessfulRefresh(first);
+  await first.coordinator.initialize();
+  durableStore.clearFailure = new Error('SECRET-delete-failure');
+  await first.coordinator.signOut();
+  expect(first.coordinator.state.notice).toBe('cleanup_incomplete');
+
+  durableStore.clearFailure = undefined;
+  const relaunched = makeHarness({
+    sessionStore: durableStore,
+    installationStore: new FakeInstallationStore(true),
+  });
+  prepareSuccessfulRefresh(relaunched);
+  await relaunched.coordinator.initialize();
+  expect(relaunched.coordinator.state.sessionUsable).toBe(true);
+});
+```
+
+These three cases are the simulated process-lifecycle contract; do not replace
+the shared store between coordinator instances.
+
+- [ ] **Step 3: Run the complete mobile unit suite**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bun run test:unit
+```
+
+Expected: all mobile unit and component tests PASS.
+
+- [ ] **Step 4: Run coverage, typecheck, lint, and production build**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile
+rtk bun run test:coverage
+rtk bun run typecheck
+rtk bun run lint
+VITE_MOBILE_API_URL=https://example.invalid/api/ rtk bun run build
+```
+
+Expected:
+
+- coverage command passes the configured 95% line threshold;
+- typecheck and lint exit zero;
+- the production build completes with mobile API URL validation active.
+
+- [ ] **Step 5: Re-run native synchronization and inspect generated files**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela/apps/vela-mobile/src-capacitor
+rtk bunx cap sync ios
+cd /Users/chanwaichan/workspace/Vela
+rtk git diff --check
+rtk git diff -- \
+  apps/vela-mobile/src-capacitor/ios/App/Podfile.lock \
+  apps/vela-mobile/src-capacitor/ios/App/PrivacyInfo.xcprivacy \
+  apps/vela-mobile/src-capacitor/ios/App/App/Info.plist
+```
+
+Expected:
+
+- sync exits zero;
+- the Podfile lock contains the pinned plugin;
+- `PrivacyInfo.xcprivacy` has no unreviewed required-reason change;
+- the custom OAuth scheme in `Info.plist` is unchanged;
+- `git diff --check` reports no whitespace errors.
+
+- [ ] **Step 6: Run relevant root regressions**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela
+rtk bun run test --filter=@vela/mobile
+rtk bun run typecheck --filter=@vela/mobile
+```
+
+Expected: both filtered Turbo commands PASS.
+
+- [ ] **Step 7: Commit the verification additions**
+
+```bash
+cd /Users/chanwaichan/workspace/Vela
+rtk git add \
+  apps/vela-mobile/src/services/mobile-auth.test.ts \
+  apps/vela-mobile/src/boot/mobile-auth.test.ts \
+  apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts \
+  apps/vela-mobile/src-capacitor/ios/App/Podfile.lock
+rtk git commit -m "test(mobile): verify secure session persistence"
+```
+
+If `Podfile.lock` has no final sync delta, omit it from `git add`.
+
+- [ ] **Step 8: Record the interactive iOS closure gate**
+
+Run the accepted design's Interactive iOS Acceptance sequence on the iOS
+Simulator with a configured Cognito environment:
+
+1. sign in and prove force-terminate/relaunch restoration;
+2. uninstall without signing out, reinstall, and prove the former user does
+   not restore;
+3. invalidate the Cognito session with `admin-user-global-sign-out` and prove
+   the terminal notice;
+4. sign in again, use More → Sign out, relaunch, and prove signed-out
+   persistence;
+5. inspect device logs and WebView storage for credential leakage.
+
+Record any missing Google/Cognito credentials or signing limitation as an open
+closure gate. Do not replace the live-provider result with a mock-only claim.
+
+## Final Whole-Branch Review
+
+- [ ] Re-read every accepted decision and failure row in the design and map it
+      to a task/test above.
+- [ ] Run:
+
+```bash
+cd /Users/chanwaichan/workspace/Vela
+rtk git diff main...HEAD --check
+rtk git status --short
+```
+
+- [ ] Review `main...HEAD` for unrelated changes, secret-bearing fixtures,
+      direct plugin calls outside `mobile-session-store.ts`, tokens written to
+      Preferences/browser storage, and direct `Date.now()` calls in refresh logic.
+- [ ] Run the full verification ladder from Task 10 once more after any review
+      fix.
+- [ ] Keep the branch and worktree available for the outstanding native
+      interactive gate; do not merge automatically.

--- a/docs/superpowers/specs/2026-07-29-mobile-cognito-session-persistence-design.md
+++ b/docs/superpowers/specs/2026-07-29-mobile-cognito-session-persistence-design.md
@@ -1,0 +1,509 @@
+# HPA-206: Secure Mobile Cognito Session Persistence and Relaunch Restoration
+
+**Date:** 2026-07-29
+
+**Linear:** [HPA-206](https://linear.app/cwchanap/issue/HPA-206/mobile-mvpm1-add-secure-cognito-session-persistence-and-relaunch)
+
+**Parent:** HPA-194 — Mobile MVP M1
+
+## Goal
+
+Keep an authenticated Vela Mobile user signed in across iOS process termination
+and relaunch without placing Cognito credentials in browser storage or Capacitor
+Preferences.
+
+The app must restore the session before protected content mounts, refresh tokens
+when required, and return safely to a signed-out surface when a stored credential
+is missing or no longer usable.
+
+## Current State
+
+HPA-205 established the mobile Google OAuth authorization-code flow, PKCE
+transaction persistence, callback handling, Cognito token validation, API session
+verification, and the `MobileAuthGate`.
+
+The mobile auth coordinator currently owns the authenticated token bundle only in
+process memory. This is intentionally insufficient for HPA-206:
+
+- terminating the iOS process loses the session;
+- no refresh grant is performed;
+- no mobile sign-out operation clears a durable credential; and
+- the only persisted auth data is the short-lived, token-free PKCE transaction in
+  Capacitor Preferences.
+
+This design extends that coordinator rather than introducing a second auth owner.
+
+## Approved Decisions
+
+| Area | Decision |
+| --- | --- |
+| Durable credential | Persist only the Cognito refresh token |
+| Access and ID tokens | Keep in process memory only |
+| Native storage | Pin `@aparajita/capacitor-secure-storage@7.1.6` behind a Vela-owned interface |
+| Keychain accessibility | `afterFirstUnlockThisDeviceOnly` |
+| iCloud synchronization | Explicitly disabled with `sync: false` |
+| Platform scope | Native iOS only; never invoke the plugin's web fallback |
+| Refresh timing | About one minute before access-token expiry and again on foreground resume |
+| Suspension behavior | No background refresh polling while the app is inactive |
+| Sign-out UI | Add a visible Sign out action to the mobile More page |
+| Remote revocation | Out of scope; HPA-206 performs reliable local credential disposal |
+
+## Scope
+
+HPA-206 includes:
+
+- a mobile-only durable session-storage interface;
+- an iOS Keychain adapter;
+- secure refresh-token persistence after successful OAuth;
+- cold-launch restoration through Cognito's refresh-token grant;
+- proactive and resume-triggered refresh;
+- refresh-token rotation handling;
+- local sign-out and cleanup;
+- explicit restoration, terminal-session, and cleanup states in the auth UI;
+- tests for storage, restoration, refresh, sign-out, and secret leakage; and
+- native iOS wiring and an interactive relaunch acceptance pass.
+
+## Non-goals
+
+- biometric or passcode-gated access;
+- multiple accounts on one installation;
+- Android Keystore support;
+- general offline application-data persistence;
+- changes to web authentication or the browser extension;
+- Cognito global sign-out or token revocation; and
+- background execution solely to refresh a session while iOS has suspended Vela.
+
+## Architecture
+
+### One mobile session owner
+
+`apps/vela-mobile/src/services/mobile-auth.ts` remains the sole owner of the
+mobile Cognito lifecycle. It continues to serialize auth mutations so callback
+completion, restoration, refresh, and sign-out cannot race.
+
+The coordinator gains four responsibilities:
+
+1. restore a durable refresh token during initialization;
+2. refresh the Cognito token bundle;
+3. schedule and re-evaluate proactive refresh; and
+4. dispose of all session material during sign-out.
+
+The web app's Amplify auth store is unchanged and is not imported into the
+mobile app.
+
+### Vela-owned storage boundary
+
+The coordinator depends on a narrow interface rather than the Keychain plugin:
+
+```ts
+interface MobileSessionStore {
+  loadRefreshToken(): Promise<string | null>;
+  saveRefreshToken(refreshToken: string): Promise<void>;
+  clearRefreshToken(): Promise<void>;
+}
+```
+
+Tests use an in-memory fake. Production uses an iOS adapter backed by
+`@aparajita/capacitor-secure-storage`.
+
+The adapter owns:
+
+- the versioned, environment-specific Keychain key;
+- non-empty string validation;
+- plugin option selection;
+- normalization of a missing item to `null`; and
+- rejection of unsupported platforms before any plugin call.
+
+The adapter must not expose plugin-specific types to the coordinator.
+
+### Keychain record
+
+The Keychain value is the refresh-token string and nothing else. The key is
+versioned and scoped to the configured Cognito user pool and mobile app client,
+for example:
+
+```text
+vela:mobile:cognito:<user-pool-id>:<client-id>:refresh:v1
+```
+
+This prevents a development or staging build from restoring a production
+credential and allows a future schema migration without guessing the stored
+format.
+
+Every write uses:
+
+- `KeychainAccess.afterFirstUnlockThisDeviceOnly`; and
+- `sync: false`.
+
+`afterFirstUnlockThisDeviceOnly` makes the item available after the user first
+unlocks the device following a restart and prevents it from migrating to a new
+device. Disabling synchronization prevents the credential from being stored in
+iCloud Keychain.
+
+The adapter checks that Capacitor is running natively on iOS before calling the
+plugin. Browser, Android, and unknown platforms fail closed. This guard is
+required because the selected plugin uses `localStorage` as its web fallback.
+
+### In-memory token bundle
+
+The current `OAuthTokenBundle` remains process-local:
+
+- access token;
+- ID token;
+- expiry; and
+- the active refresh token while the process is running.
+
+Only the refresh token crosses a process boundary. Access and ID tokens are
+re-created with a refresh grant after relaunch.
+
+If Cognito returns a rotated refresh token, that token may be held temporarily
+in memory while its Keychain write is retried. It is not accepted as the
+durable session until the write succeeds.
+
+### Auth state and protected-content gate
+
+The existing `MobileAuthGate` remains the only boundary that decides whether
+protected application content can mount.
+
+The coordinator must distinguish these user-visible situations:
+
+- initial loading/restoring;
+- authenticated;
+- ordinary signed out;
+- signed out because a previous durable session became unusable;
+- retryable restoration or refresh failure; and
+- incomplete secure cleanup.
+
+The implementation may extend the phase union or add an orthogonal operation
+status, but it must preserve these invariants:
+
+1. protected content never mounts before restoration and API verification
+   succeed;
+2. a terminal credential failure ends on the sign-in surface with a clear,
+   non-secret notice;
+3. a retryable startup failure keeps protected content unmounted and offers a
+   retry;
+4. a background refresh does not flash a signed-out screen while the current
+   access token is still valid; and
+5. once no valid access token remains, protected content is hidden until refresh
+   succeeds.
+
+The HPA-205 home-first navigation invariant remains intact: restoration must
+verify the API session and establish the intended authenticated route before
+the gate mounts protected content.
+
+### Sign-out entry point
+
+The mobile More page gains an accessible Sign out button. It invokes the
+coordinator; the page does not manipulate Keychain, Preferences, or tokens
+directly.
+
+The action exposes progress and prevents duplicate submission. A failure to
+remove the Keychain credential is presented as incomplete sign-out, not as
+successful sign-out.
+
+## Data Flows
+
+### 1. Initial OAuth sign-in
+
+The HPA-205 callback flow remains responsible for exchanging the authorization
+code and validating the returned Cognito token bundle.
+
+After validation:
+
+1. require a non-empty refresh token;
+2. save the refresh token to the Keychain;
+3. keep the access and ID tokens in process memory;
+4. verify the ID token with `/api/auth/session`;
+5. establish the authenticated home route; and
+6. allow the gate to mount protected content.
+
+The durable write occurs before authentication is reported as complete. A
+Keychain write failure therefore cannot produce an authenticated UI that will
+silently disappear after relaunch.
+
+The validated candidate bundle can remain in memory to support an explicit
+retry. Tokens and raw transport responses must never be placed in an error
+message or log.
+
+### 2. Cold launch
+
+Initialization keeps HPA-205's callback and PKCE-transaction precedence:
+
+1. attach native callback and lifecycle listeners;
+2. inspect the cold-launch URL;
+3. resume a valid in-flight OAuth transaction when applicable; and
+4. only when no callback transaction is active, attempt durable-session
+   restoration.
+
+Restoration then:
+
+1. loads the refresh token from the Keychain;
+2. treats a missing item as ordinary signed out;
+3. sends the refresh-token grant to Cognito;
+4. validates the refreshed token bundle;
+5. persists a rotated refresh token, if returned;
+6. verifies the refreshed ID token with `/api/auth/session`;
+7. establishes the authenticated home route; and
+8. opens the protected-content gate.
+
+The Google sign-in browser is never opened automatically during restoration.
+
+### 3. Cognito refresh grant
+
+The refresh transport posts form-encoded data to the configured Cognito
+`/oauth2/token` endpoint:
+
+```text
+grant_type=refresh_token
+client_id=<public-mobile-client-id>
+refresh_token=<durable-refresh-token>
+```
+
+No client secret is used or bundled in the app.
+
+The refreshed ID token is validated using the same issuer, audience, token-use,
+expiry, and temporal checks as the callback flow, except that the original
+OAuth nonce is not expected on a refresh response. During an in-process refresh,
+the refreshed subject must match the current authenticated subject.
+
+The Vela API remains the signature-verification boundary. A refreshed session
+does not become authenticated until `/api/auth/session` succeeds.
+
+If Cognito returns a new refresh token:
+
+1. validate the complete candidate response;
+2. save the new refresh token to the Keychain;
+3. only after the save succeeds, replace the active in-memory bundle; and
+4. schedule from the new access-token expiry.
+
+If no refresh token is returned, retain the existing durable refresh token.
+
+### 4. Proactive refresh and resume
+
+While the app is active and authenticated, schedule one refresh for
+approximately 60 seconds before access-token expiry.
+
+When the app becomes inactive, cancel the foreground timer. Do not poll in the
+background. When the app becomes active again:
+
+1. recompute the remaining lifetime from the token's absolute expiry;
+2. refresh immediately if the token is expired or inside the one-minute window;
+3. otherwise schedule a new foreground timer; and
+4. preserve serialized ordering with callback completion and sign-out.
+
+Disposing the coordinator cancels all timers and native listeners.
+
+### 5. Local sign-out
+
+Sign-out is serialized with every other auth operation:
+
+1. prevent new refresh work and cancel the active timer;
+2. remove the durable refresh token from the Keychain;
+3. clear any token-free PKCE transaction from Preferences;
+4. erase access, ID, refresh, and pending-rotation material from process memory;
+5. navigate to the signed-out surface; and
+6. report sign-out success only after durable deletion succeeds.
+
+Process memory and the PKCE transaction should still be cleared when Keychain
+deletion fails, and protected content must be hidden. The UI then offers a
+cleanup retry because the durable credential could otherwise restore on a
+future relaunch.
+
+Remote Cognito revocation and global sign-out are deliberately separate work.
+HPA-206 guarantees local disposal on this installation.
+
+## Failure Model
+
+Failures are classified by whether retrying later with the same durable
+credential is safe.
+
+| Condition | Classification | Durable credential | User experience |
+| --- | --- | --- | --- |
+| Keychain item missing | Normal signed out | None | Show sign-in |
+| Empty or malformed Keychain value | Terminal local data | Clear it | Show sign-in with a clear session notice |
+| Cognito `invalid_grant`, revoked, expired, or otherwise non-refreshable token | Terminal remote session | Clear it | Show sign-in with a clear session notice |
+| API session verification returns 401 or 403 | Terminal session | Clear it | Show sign-in with a clear session notice |
+| Network loss, timeout, 429, or server-side 5xx | Retryable | Preserve it | Keep gate closed at startup; offer retry |
+| Keychain unavailable before first device unlock | Retryable | Preserve it | Keep gate closed; retry after unlock/foreground |
+| Initial or rotated-token Keychain write fails | Retryable persistence | Do not accept candidate as durable | Keep gate closed; retry secure save |
+| Keychain deletion fails | Retryable cleanup | May remain present | Hide protected content; show incomplete sign-out and retry |
+| Unsupported platform reaches production adapter | Configuration error | Do not access browser storage | Fail closed without invoking plugin fallback |
+
+If clearing a terminal credential also fails, the app enters the same incomplete
+secure-cleanup state as failed sign-out. It must not repeatedly attempt refresh
+with the known-bad value or claim that cleanup succeeded.
+
+At startup, every retryable failure keeps protected content unmounted. During an
+authenticated session, a retryable refresh failure may leave content mounted
+only while the current access token remains valid. Once it expires, the gate
+closes until refresh and API verification succeed.
+
+User-facing notices contain stable, translated copy rather than Cognito payloads,
+Keychain errors, tokens, claims, or raw HTTP bodies.
+
+## Security and Privacy Guarantees
+
+- Cognito access, ID, and refresh tokens never enter `localStorage`,
+  `sessionStorage`, IndexedDB, or Capacitor Preferences.
+- The secure-storage plugin's web fallback is unreachable through the production
+  adapter.
+- Only one non-empty refresh-token string is durable.
+- The Keychain item is device-bound and non-synchronizing.
+- Refresh and sign-out operations are serialized to avoid credential resurrection
+  or stale writes.
+- Logs and diagnostics emit stable event/error codes and high-level outcomes
+  only.
+- Errors, request objects, response objects, decoded claims, authorization URLs,
+  and Keychain values are never logged wholesale.
+- Existing diagnostics must not expose token values before or after this change.
+
+## Testing Strategy
+
+### Secure-storage adapter
+
+Unit tests cover:
+
+- deterministic environment and version namespacing;
+- `afterFirstUnlockThisDeviceOnly`;
+- explicit `sync: false`;
+- missing-item normalization;
+- rejection of empty or malformed values;
+- save, load, and clear error propagation;
+- native-iOS platform gating; and
+- proof that browser and Android paths never invoke the plugin.
+
+### Refresh protocol
+
+Unit tests cover:
+
+- the form-encoded public-client request;
+- response validation;
+- no-rotation and rotation responses;
+- persistence-before-acceptance for a rotated token;
+- refreshed subject continuity during an active session;
+- Cognito terminal versus retryable error classification; and
+- sanitized errors with no token or raw-body leakage.
+
+### Coordinator
+
+Unit tests cover:
+
+- missing-token startup;
+- successful relaunch restoration;
+- retryable restoration failure and retry;
+- revoked, expired, corrupt, and API-rejected sessions;
+- restoration before protected-content mounting;
+- proactive timer calculation;
+- inactive timer cancellation and resume re-evaluation;
+- expired-token gate closure;
+- operation serialization;
+- pending rotated-token save retry;
+- listener and timer disposal; and
+- preservation of callback-first and home-first behavior.
+
+### Sign-out and UI
+
+Unit and component tests cover:
+
+- the More-page Sign out action and accessible label;
+- duplicate-submission prevention and progress state;
+- timer cancellation;
+- process-memory cleanup;
+- PKCE transaction cleanup;
+- Keychain cleanup;
+- cleanup retry after deletion failure;
+- signed-out persistence after a simulated relaunch;
+- terminal-session notice copy; and
+- loading/restoring states with no protected-content flash.
+
+### Secret-leak regression tests
+
+Sentinel token values are injected through success and failure paths. Tests
+assert that they do not appear in:
+
+- captured logs;
+- rendered error or diagnostics text;
+- `localStorage`;
+- `sessionStorage`; or
+- mocked Capacitor Preferences writes.
+
+### Automated verification
+
+Before HPA-206 is considered implementation-complete:
+
+- mobile unit/component coverage remains at or above the package's 95% threshold;
+- mobile typecheck passes;
+- the mobile production build passes with its required environment injection;
+- relevant root regressions pass; and
+- native dependency installation and Capacitor iOS synchronization are verified.
+
+### Interactive iOS acceptance
+
+The closure pass uses a configured iOS build and real Cognito environment:
+
+1. sign in through Google once;
+2. force-terminate Vela and relaunch it;
+3. confirm the authenticated home screen restores without another Google prompt;
+4. invalidate the durable Cognito session and relaunch;
+5. confirm the sign-in screen shows a clear session-expired notice;
+6. sign in again, use Sign out on More, force-terminate, and relaunch;
+7. confirm Vela remains signed out; and
+8. inspect device logs and WebView storage to confirm no credential leakage.
+
+The iOS Simulator is sufficient to exercise Keychain persistence and process
+relaunch. If the Google/Cognito environment or native signing prevents the real
+provider pass, that limitation must be reported as an explicit closure gate
+rather than replaced by a mock-only claim.
+
+## Acceptance Mapping
+
+| HPA-206 acceptance criterion | Design coverage |
+| --- | --- |
+| Relaunch restores without Google prompt | Keychain refresh token + cold-launch refresh flow |
+| Revoked/non-refreshable credential returns to sign-in with clear message | Terminal failure classification, cleanup, and signed-out notice |
+| Sign out survives relaunch | Serialized Keychain deletion before success |
+| No credentials in browser storage or Preferences | Refresh-only Keychain record, native guard, leak tests |
+| Explicit loading with no protected-content flash | `MobileAuthGate` restoration invariants |
+| Web behavior unchanged | Mobile-owned coordinator and storage boundary |
+
+## Alternatives Considered
+
+### Persist the complete token bundle
+
+Rejected. Access and ID tokens are short-lived and can be recreated. Persisting
+them increases secret surface, migration complexity, and stale-token behavior
+without improving relaunch restoration.
+
+### Use Capacitor Preferences
+
+Rejected. Preferences is appropriate for the short-lived, token-free PKCE
+transaction but is not a Keychain-backed credential store.
+
+### Use the secure-storage plugin directly throughout auth code
+
+Rejected. A Vela-owned interface keeps plugin behavior, platform guards,
+namespacing, and future replacement localized and makes failure paths testable.
+
+### Rely on the plugin's web implementation during development
+
+Rejected. Its web fallback uses `localStorage`, which would violate the storage
+contract and could hide native-only integration errors.
+
+### Refresh only after an API request fails
+
+Rejected. Proactive and resume-triggered refresh gives the gate an explicit token
+lifetime and avoids making unrelated API calls responsible for session recovery.
+
+### Revoke remotely during Sign out
+
+Deferred. Local secure disposal is the HPA-206 acceptance boundary. Remote
+revocation introduces a separate network-failure contract and is not required to
+prevent relaunch restoration on the same installation.
+
+## References
+
+- [Apple: `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`](https://developer.apple.com/documentation/security/ksecattraccessibleafterfirstunlockthisdeviceonly)
+- [`@aparajita/capacitor-secure-storage` v7.1.6](https://github.com/aparajita/capacitor-secure-storage/tree/v7.1.6)
+- [Amazon Cognito token endpoint](https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html)
+- [Amazon Cognito refresh-token rotation](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-refresh-token.html#amazon-cognito-user-pools-refresh-token-rotation)

--- a/docs/superpowers/specs/2026-07-29-mobile-cognito-session-persistence-design.md
+++ b/docs/superpowers/specs/2026-07-29-mobile-cognito-session-persistence-design.md
@@ -44,7 +44,14 @@ This design extends that coordinator rather than introducing a second auth owner
 | iCloud synchronization | Explicitly disabled with `sync: false` |
 | Platform scope | Native iOS only; never invoke the plugin's web fallback |
 | Refresh timing | About one minute before access-token expiry and again on foreground resume |
+| Refresh concurrency | One refresh grant may be queued or in flight; timer, resume, and manual triggers coalesce |
+| Soft-failure retry | One automatic retry after five seconds when the old token has enough lifetime remaining |
 | Suspension behavior | No background refresh polling while the app is inactive |
+| Candidate promotion | Persist any rotation and pass `/api/auth/session` before replacing the active bundle |
+| Gate state | Orthogonal `operation`, `sessionUsable`, `retryAction`, and `notice`; phase alone never controls protected content |
+| Browser and Android bootstrap | Explicit unsupported adapter; no runtime in-memory store and no sign-in |
+| Reinstall hygiene | A non-secret, environment-scoped Preferences marker forces Keychain cleanup before the first restore decision of an installation |
+| Refresh-token lifetime | Current Cognito default: 30 days from refresh-token issuance, not a sliding inactivity window |
 | Sign-out UI | Add a visible Sign out action to the mobile More page |
 | Remote revocation | Out of scope; HPA-206 performs reliable local credential disposal |
 
@@ -55,6 +62,7 @@ HPA-206 includes:
 - a mobile-only durable session-storage interface;
 - an iOS Keychain adapter;
 - secure refresh-token persistence after successful OAuth;
+- first-install cleanup of a Keychain credential retained across uninstall;
 - cold-launch restoration through Cognito's refresh-token grant;
 - proactive and resume-triggered refresh;
 - refresh-token rotation handling;
@@ -70,6 +78,9 @@ HPA-206 includes:
 - Android Keystore support;
 - general offline application-data persistence;
 - changes to web authentication or the browser extension;
+- a general authenticated mobile API client or public token accessor; HPA-206
+  uses the ID token internally only for `/api/auth/session`, and authenticated
+  feature requests begin with HPA-207;
 - Cognito global sign-out or token revocation; and
 - background execution solely to refresh a session while iOS has suspended Vela.
 
@@ -105,8 +116,29 @@ type MobileAuthRetryAction =
   | 'verify'
   | 'cleanup';
 
+type MobileAuthOperation =
+  | 'idle'
+  | 'restoring'
+  | 'refreshing'
+  | 'persisting'
+  | 'verifying'
+  | 'signingOut'
+  | 'cleaningUp';
+
+type MobileAuthNotice = 'session_unusable' | 'cleanup_incomplete' | null;
+
+type MobileAuthState = {
+  phase: MobileAuthPhase;
+  operation: MobileAuthOperation;
+  sessionUsable: boolean;
+  errorCode: MobileAuthErrorCode | null;
+  retryAction: MobileAuthRetryAction | null;
+  notice: MobileAuthNotice;
+  user: MobileAuthUser | null;
+};
+
 type MobileAuthCoordinator = {
-  state: Readonly<MobileAuthState & { retryAction: MobileAuthRetryAction | null }>;
+  state: Readonly<MobileAuthState>;
   initialize(): Promise<void>;
   startSignIn(): Promise<void>;
   completeCallback(url: string): Promise<void>;
@@ -116,6 +148,80 @@ type MobileAuthCoordinator = {
 };
 ```
 
+The existing `MobileAuthErrorCode` union gains these stable codes:
+
+```ts
+type MobileSessionErrorCode =
+  | 'session_restore_failed'
+  | 'session_refresh_failed'
+  | 'session_persistence_failed'
+  | 'session_cleanup_failed'
+  | 'unsupported_platform';
+```
+
+`sessionUsable` is the protected-content capability. It becomes `true` only
+after local token validation and `/api/auth/session` verification succeed, and
+only while the active access token is unexpired. The coordinator sets it to
+`false` immediately when sign-out starts, when the access token reaches its
+expiry without a verified replacement, and on every terminal credential
+failure. Components never infer usability from `phase`, `operation`, or
+`errorCode`.
+
+`operation` describes work that can occur without replacing the identity
+phase. `phase` remains the HPA-205 OAuth lifecycle cursor; it is neither a pure
+identity axis nor a gate-view discriminator. Existing interactive OAuth phases
+and `phase: error` remain in the union so HPA-205 callback recovery keeps its
+current semantics. New session-operation failures do not force
+`phase: error`.
+
+The phase for each HPA-206 context is fixed:
+
+| Context | `phase` |
+| --- | --- |
+| Cold initialization, installation reset, and durable restore | `initializing` until an authenticated or signed-out outcome |
+| Existing interactive OAuth flow | Existing HPA-205 phase, including `error` for interactive or configuration failures |
+| Proactive refresh, candidate persistence, or candidate verification from an active identity | `authenticated` while the operation runs |
+| Retryable in-session failure, before or after old-token expiry | `authenticated` |
+| `signingOut` or `cleaningUp` work | Retain the originating `initializing`, `authenticated`, or cleanup-retry `signedOut` phase until the operation resolves; `operation` selects the blocking progress view |
+| Successful Sign out, completed terminal-session cleanup, or incomplete-cleanup outcome | `signedOut` |
+| Unsupported runtime detected during initialization | `error` with `unsupported_platform` |
+
+If the previously verified access token expires during a retryable failure,
+`phase` remains `authenticated` but `sessionUsable` becomes `false`; this
+preserves identity and retry context without granting protected-content access.
+Only successful or terminal cleanup transitions an identity-owning flow to
+`signedOut`. `notice` carries stable user-facing context independently from an
+operation failure:
+`session_unusable` accompanies a terminal return to signed out, while
+`cleanup_incomplete` warns that durable credential deletion did not finish.
+
+The implementation retires the current general-purpose `setPhase()` and
+`setError()` mutators. They currently clear `errorCode` and `user` as implicit
+side effects, which cannot represent orthogonal session work safely. HPA-206
+uses atomic transition helpers that write the complete public tuple and validate
+these invariants:
+
+1. `sessionUsable: true` requires `phase: authenticated`, a non-null `user`,
+   `notice: null`, and an unexpired verified active bundle.
+2. `phase: error` requires a non-null `errorCode`, but a non-null session
+   `errorCode` does not require `phase: error`.
+3. A non-null `retryAction` requires `operation: idle` and a non-null
+   `errorCode`; starting its retry clears both fields before work begins.
+4. `notice: session_unusable` requires `phase: signedOut`,
+   `sessionUsable: false`, `user: null`, and no retry action.
+5. `notice: cleanup_incomplete` requires `phase: signedOut`,
+   `sessionUsable: false`, `user: null`,
+   `errorCode: session_cleanup_failed`, and `retryAction: cleanup`.
+6. Changing `operation` never implicitly clears the current user, candidate, or
+   notice; each named transition states explicitly what it retains or erases.
+
+For example, a soft foreground-refresh failure is
+`phase: authenticated`, `operation: idle`,
+`errorCode: session_refresh_failed`, and `retryAction: refresh`.
+`sessionUsable` stays true only until the prior active bundle expires. A
+startup restore failure instead keeps `phase: initializing`, `user: null`, and
+`sessionUsable: false` with `retryAction: restore`.
+
 `retryCurrentOperation()` replaces the narrow
 `retrySessionVerification()` entry point and dispatches only to the retry action
 recorded in state. The method never infers recovery from user-facing copy.
@@ -123,14 +229,25 @@ recorded in state. The method never infers recovery from user-facing copy.
 | Method | Preconditions and effect |
 | --- | --- |
 | `initialize()` | Runs at most once before disposal; installs listeners and resolves callback, transaction, then durable-session state |
-| `startSignIn()` | Runs only from ordinary signed out or a terminal-session notice that permits a new sign-in |
-| `completeCallback(url)` | Consumes only a matching callback in an active callback phase, preserving the HPA-205 transaction guards |
+| `startSignIn()` | Uses a positive coordinator-owned allowlist: idle ordinary signed out, idle `session_unusable`, or an explicitly restartable HPA-205 interactive error; requires supported native iOS and valid configuration |
+| `completeCallback(url)` | Consumes only a matching callback during `initializing`, `openingBrowser`, `awaitingCallback`, or the existing `error` + `interrupted` recovery state, preserving the HPA-205 transaction guards |
 | `retryCurrentOperation()` | Runs only while the coordinator exposes a non-null retry action for a retryable failure |
-| `signOut()` | Runs from authenticated state, including while a background refresh status leaves the current access token valid |
+| `signOut()` | Runs from an authenticated identity or a blocking `restore`, `refresh`, `persist`, or `verify` failure so the user can discard local session material and start over |
 | `dispose()` | Idempotent teardown from any phase; queues behind earlier operations and rejects or ignores new work once disposal begins |
 
-The `MobileAuthGate` uses `retryAction` to choose whether to offer a retry.
-The More page calls only `signOut()`.
+The coordinator guard—not the presence or absence of a gate button—rejects
+`startSignIn()` from `unsupported_platform`, `configuration_error`,
+`cleanup_incomplete`, every retryable session failure, and any operation in
+progress. This positive allowlist fails closed when future states are added.
+The restartable HPA-205 error-code allowlist is exactly
+`browser_launch_failed`, `cancelled`, `interrupted`, `transaction_expired`,
+`malformed_callback`, `provider_error`, `code_exchange_failed`,
+`token_validation_failed`, and `session_unauthorized`.
+
+The `MobileAuthGate` uses an exhaustive view selector over `phase`, `operation`,
+`sessionUsable`, `errorCode`, `retryAction`, and `notice`. It does not
+reconstruct coordinator internals from translated copy. The More page and the
+blocking recovery surface call only `signOut()`.
 
 ### Vela-owned storage boundary
 
@@ -144,7 +261,7 @@ interface MobileSessionStore {
 }
 ```
 
-Tests use an in-memory fake. Production uses an iOS adapter backed by
+Tests use an in-memory fake. The native iOS runtime uses an adapter backed by
 `@aparajita/capacitor-secure-storage`.
 
 The adapter owns:
@@ -152,7 +269,7 @@ The adapter owns:
 - the versioned, environment-specific Keychain key;
 - non-empty string validation;
 - plugin option selection;
-- normalization of a missing item to `null`; and
+- normalization of a missing item to `null`;
 - normalization of plugin failures to Vela-owned `corrupt` or `unavailable`
   storage failures; and
 - rejection of unsupported platforms before any plugin call.
@@ -166,13 +283,40 @@ a distinct "device has not been unlocked yet" result. It applies this contract:
 
 - `null` means missing;
 - `invalidData` means corrupt and terminal;
-- a thrown `osError`, `unknownError`, or other operational failure means
-  unavailable and retryable.
+- a rejected Capacitor bridge call, a thrown plugin/runtime exception, or
+  future dependency behavior means unavailable and retryable.
+
+The pinned native `getData()` implementation itself does not throw
+`osError` or `unknownError`; ordinary Keychain lookup statuses collapse to
+`null`. The `unavailable` branch is a defensive Vela adapter boundary for
+bridge/runtime failures and dependency regressions, not a way to distinguish a
+pre-first-unlock Keychain status. Its production use is expected to be rare;
+most `retryAction: restore` states originate from the subsequent Cognito or API
+transport.
 
 HPA-206 does not perform pre-first-unlock background restoration. Its supported
 path is a user-launched foreground app after the device has been unlocked. A
 future requirement to distinguish a pre-unlock read from a missing item would
 require a different plugin or Vela-owned native Keychain code.
+
+### Runtime store selection
+
+`apps/vela-mobile/src/boot/mobile-auth.ts` selects the session-store
+implementation before constructing the coordinator:
+
+| Runtime | Injected session store | Mobile sign-in |
+| --- | --- | --- |
+| Native iOS | Keychain-backed `MobileSessionStore` | Allowed |
+| Native Android | Explicit unsupported-platform adapter | Disabled |
+| Browser development or production | Explicit unsupported-platform adapter | Disabled, except that the existing development-only diagnostics bypass remains available |
+| Unit and component tests | Injected in-memory fake | Test-controlled |
+
+The runtime never injects the in-memory fake. The unsupported adapter returns
+the stable, non-retryable `unsupported_platform` failure without invoking the
+secure-storage plugin. The Keychain adapter independently repeats the native-iOS
+guard so incorrect boot wiring still fails closed before a plugin call. Browser
+development therefore does not claim to complete the custom-scheme OAuth flow
+and never reaches the plugin's `localStorage` fallback.
 
 ### Keychain record
 
@@ -213,6 +357,13 @@ secureStorage.set(
 secureStorage.remove(logicalKey, false);
 ```
 
+The adapter must use the paired typed `get()` and `set()` methods, not the raw
+`getItem()` and `setItem()` methods. `set()` JSON-encodes the string and `get()`
+decodes it; mixing the two method families would surface valid stored data as
+corrupt. Passing `convertDate: false` on both typed calls is required rather
+than incidental so an opaque refresh-token string can never be converted to a
+`Date`.
+
 `afterFirstUnlockThisDeviceOnly` makes the item available after the user first
 unlocks the device following a restart and prevents it from migrating to a new
 device. Disabling synchronization prevents the credential from being stored in
@@ -221,9 +372,50 @@ iCloud Keychain.
 The adapter checks that Capacitor is running natively on iOS before calling the
 plugin. Browser, Android, and unknown platforms fail closed. This guard is
 required because the selected plugin uses `localStorage` as its web fallback.
-An unsupported Android build shows a non-retryable configuration message and
-does not offer sign-in. That is intentional until Android Keystore support
-enters scope.
+An unsupported Android build shows the non-retryable
+`unsupported_platform` message and does not offer sign-in. That is intentional
+until Android Keystore support enters scope.
+
+### Installation marker and uninstall reset
+
+iOS currently preserves an app's Keychain items when the app is uninstalled,
+while the app sandbox and Capacitor Preferences are removed. Apple documents
+Keychain preservation as current behavior rather than a permanent API
+guarantee, so HPA-206 must behave safely whether a retained item exists or not.
+
+The coordinator receives a second narrow, non-secret dependency:
+
+```ts
+interface MobileInstallationStore {
+  isCurrentInstallationMarked(): Promise<boolean>;
+  markCurrentInstallation(): Promise<void>;
+}
+```
+
+The Preferences key is versioned and scoped to the same user pool and mobile
+client as the Keychain record, for example:
+
+```text
+vela:mobile:cognito:<user-pool-id>:<client-id>:installation:v1
+```
+
+It stores only a Boolean/string sentinel—never a token, subject, email, or other
+credential. Before any Keychain load or OAuth callback acceptance on native
+iOS, initialization follows this order:
+
+1. read the installation marker;
+2. if it is absent, remove the environment-matched Keychain refresh token;
+3. write the marker only after Keychain removal succeeds; and
+4. then continue to callback, transaction, or durable-session handling.
+
+The clear-before-mark ordering is crash safe: termination between the two steps
+causes another harmless clear on the next launch. Marker read failure, Keychain
+clear failure, or marker write failure fails closed with
+`session_cleanup_failed`, `notice: cleanup_incomplete`, and
+`retryAction: cleanup`; the coordinator must not restore or begin sign-in until
+that reset succeeds. A marker that already exists permits normal restoration.
+Browser and Android unsupported adapters do not run the installation-marker
+flow.
 
 ### In-memory token bundle
 
@@ -246,9 +438,19 @@ type RefreshedTokenBundle = OAuthTokenBundleBase & {
 };
 ```
 
-The authorization-code parser requires a non-empty refresh token at the type
-boundary. A refresh response may omit it when rotation is disabled. Both shapes
-remain process-local and contain:
+The two response parsers are named and have separate contracts:
+
+- `parseAuthorizationCodeTokenResponse()` requires a non-empty refresh token.
+  A successful HTTP response that omits it or otherwise violates the response
+  schema maps to the existing terminal `token_validation_failed` callback
+  failure and requires a new sign-in.
+- `parseRefreshTokenResponse()` permits an omitted refresh token when rotation
+  is disabled. A successful HTTP response with an invalid schema produces a
+  sanitized parse failure; the coordinator preserves the durable token and maps
+  it to `session_restore_failed` plus `retryAction: restore` during startup, or
+  `session_refresh_failed` plus `retryAction: refresh` in an existing session.
+
+Both shapes remain process-local and contain:
 
 - access token;
 - ID token;
@@ -278,6 +480,16 @@ The auth coordinator registers and removes this listener. `isActive: false`
 cancels the foreground refresh timer; `isActive: true` recomputes token lifetime
 and schedules or immediately queues refresh.
 
+Serialization and refresh coalescing are separate guarantees. The coordinator
+keeps one refresh-grant promise/flag that is set synchronously before work is
+appended to the serialized queue. Timer, `appStateChange`, and manual
+refresh-retry triggers join that promise or become a no-op while it is queued or
+running. At the head of the queue, the refresh re-checks that the coordinator is
+not disposed or signing out, the app is active, the same active bundle still
+owns the schedule, and a refresh is still due. The flag is cleared in `finally`.
+Candidate `persist` and `verify` retries reuse their retained candidate and
+never issue a second grant.
+
 `apps/vela-mobile/src/boot/capacitor-lifecycle.ts` keeps its existing `resume`
 listener because that listener only records interaction-diagnostics metadata.
 It does not drive auth recovery, and its best-effort failure semantics remain
@@ -297,8 +509,64 @@ The coordinator must distinguish these user-visible situations:
 - retryable restoration or refresh failure; and
 - incomplete secure cleanup.
 
-The implementation may extend the phase union or add an orthogonal operation
-status, but it must preserve these invariants:
+The orthogonal state model above is required; implementations must not replace
+it with additional ad hoc authentication phases. The gate's slot-visibility
+predicate is:
+
+```ts
+diagnosticBypass || (state.sessionUsable && authenticatedLandingReady)
+```
+
+`authenticatedLandingReady` retains HPA-205's requirement that navigation to
+the authenticated home route succeeds before protected content mounts.
+
+The remaining UI is selected through one total, side-effect-free
+`selectMobileAuthGateView(state, landingState)` function. Its result is a
+discriminated gate-view union covering content, content with a retry banner,
+blocking progress, landing failure, blocking session failure, signed out,
+terminal-session notice, cleanup failure, unsupported runtime, existing
+HPA-205 error presentation, and `invalid_state`. The final `invalid_state`
+result is mandatory: it keeps protected content unmounted and renders a stable
+non-retryable configuration message while emitting only a sanitized diagnostic
+code. The template does not chain independent checks directly against `phase`
+and therefore cannot render an empty gate for an unrecognized tuple.
+
+| Coordinator state | `sessionUsable` | Protected slot | Gate surface and actions |
+| --- | --- | --- | --- |
+| Initializing or `operation: restoring` | `false` | Unmounted | Blocking “Restoring your Vela session…” status |
+| OAuth callback, initial persistence, or initial verification | `false` | Unmounted | Existing blocking sign-in progress; persistence uses “Securing your Vela session…” |
+| Retryable startup restore, initial persistence, or initial verification failure | `false` | Unmounted | Blocking failure; Retry plus secondary “Sign out and start over” |
+| Authenticated and idle | `true` | Mounted after home navigation | Application content |
+| Authenticated while proactively refreshing, persisting, or verifying a candidate | `true` while the old token is unexpired | Mounted | Successful background work is silent; a retryable failure adds a non-blocking retry banner |
+| Authenticated retry path after the old token expires | `false` | Unmounted | Blocking “Refreshing your Vela session…” failure; Retry plus secondary “Sign out and start over” |
+| Ordinary signed out | `false` | Unmounted | Continue with Google |
+| Signed out with `notice: session_unusable` | `false` | Unmounted | Clear non-secret session notice plus Continue with Google |
+| `operation: signingOut` or `cleaningUp` | `false` | Unmounted | “Signing out…” or “Finishing secure sign-out…” status |
+| `notice: cleanup_incomplete` | `false` | Unmounted | Cleanup warning plus `retryAction: cleanup` |
+| `errorCode: unsupported_platform` | `false` | Unmounted | Non-retryable unsupported-platform message; no sign-in action |
+
+The secondary start-over action is present on every blocking
+`restore`, `refresh`, `persist`, or `verify` failure. It calls `signOut()`; the
+gate never deletes credentials or candidates directly. It is unnecessary on a
+soft failure while content remains mounted because the More-page Sign out
+action is reachable. Cleanup failures expose only cleanup retry because the
+coordinator has already discarded the active identity.
+
+The development diagnostics bypass is extended deliberately for the new boot
+state. It remains gated by development mode and the existing route metadata,
+and is allowed only while `operation: idle` in ordinary `signedOut`,
+`configuration_error`, or `unsupported_platform`. This makes browser
+diagnostics reachable without enabling browser OAuth. It does not weaken the
+coordinator's native-platform guard or make `startSignIn()` legal from
+`unsupported_platform`.
+
+The non-blocking retry banner never contains raw Cognito, HTTP, or plugin
+details. Successful proactive refresh is not announced through `aria-live`, so
+routine refreshes do not repeatedly interrupt assistive-technology users.
+Blocking restoration and refresh copy uses `role="status"` with
+`aria-live="polite"`; failure surfaces use `role="alert"`.
+
+This concrete model preserves these invariants:
 
 1. protected content never mounts before restoration and API verification
    succeed;
@@ -311,15 +579,36 @@ status, but it must preserve these invariants:
 5. once no valid access token remains, protected content is hidden until refresh
    succeeds.
 
+After a soft refresh failure, the coordinator schedules an access-expiry
+deadline from the active bundle's absolute `expiresAt`. When that deadline
+fires, it re-evaluates with the injected `now()` and sets `sessionUsable` to
+`false` unless a verified replacement has already been promoted. This deadline
+is required because reading `now()` from a computed property alone would not
+trigger a reactive gate update.
+
+It also schedules at most one automatic retry of the recorded `refresh`,
+`persist`, or `verify` action after
+`MOBILE_AUTH_SOFT_RETRY_DELAY_MS = 5_000`. The retry is scheduled only while the
+app is active and
+`expiresAt - now() > MOBILE_AUTH_SOFT_RETRY_DELAY_MS +
+MOBILE_AUTH_NETWORK_TIMEOUT_MS`, leaving enough time for the bounded network
+path before expiry. A second retryable failure does not schedule another
+automatic attempt; the banner remains available for manual retry. A manual
+retry cancels a pending automatic timer and uses the same single-flight guard.
+Successful candidate promotion resets the allowance for the new bundle.
+Backgrounding, sign-out, disposal, terminal failure, and old-token expiry
+cancel the timer. Startup restoration failures never auto-loop.
+
 The HPA-205 home-first navigation invariant remains intact: restoration must
 verify the API session and establish the intended authenticated route before
 the gate mounts protected content.
 
 ### Sign-out entry point
 
-The mobile More page gains an accessible Sign out button. It invokes the
-coordinator; the page does not manipulate Keychain, Preferences, or tokens
-directly.
+The mobile More page gains an accessible Sign out button. Blocking session
+recovery surfaces gain a secondary “Sign out and start over” button. Both invoke
+the coordinator; neither UI owner manipulates Keychain, Preferences, candidates,
+or tokens directly.
 
 The action exposes progress and prevents duplicate submission. A failure to
 remove the Keychain credential is presented as incomplete sign-out, not as
@@ -336,10 +625,11 @@ After validation:
 
 1. require a non-empty refresh token;
 2. save the refresh token to the Keychain;
-3. keep the access and ID tokens in process memory;
-4. verify the ID token with `/api/auth/session`;
-5. establish the authenticated home route; and
-6. allow the gate to mount protected content.
+3. hold the access and ID tokens as an unaccepted in-memory candidate;
+4. verify the candidate ID token with `/api/auth/session`;
+5. promote the candidate as the active bundle and set `sessionUsable: true`;
+6. establish the authenticated home route; and
+7. allow the gate to mount protected content.
 
 The durable write occurs before authentication is reported as complete. A
 Keychain write failure therefore cannot produce an authenticated UI that will
@@ -349,15 +639,50 @@ The validated candidate bundle can remain in memory to support an explicit
 retry. Tokens and raw transport responses must never be placed in an error
 message or log.
 
+A 401 or 403 from `/api/auth/session` is terminal even though the refresh token
+was already persisted. The coordinator clears that durable token before
+returning to the signed-out `session_unusable` notice; a deletion failure enters
+`cleanup_incomplete`.
+
 ### 2. Cold launch
 
-Initialization keeps HPA-205's callback and PKCE-transaction precedence:
+Initialization keeps HPA-205's matching-callback precedence without allowing
+residual token-free PKCE state to block a durable session:
 
 1. attach native callback and lifecycle listeners;
-2. inspect the cold-launch URL;
-3. resume a valid in-flight OAuth transaction when applicable; and
-4. only when no callback transaction is active, attempt durable-session
-   restoration.
+2. complete the native-iOS installation-marker reset before reading any
+   Keychain credential or accepting an OAuth callback;
+3. inspect the cold-launch URL;
+4. consume it only when it matches an active, exact-schema, unexpired OAuth
+   transaction;
+5. when no callback is consumed, inspect both the transaction result and the
+   durable refresh token; and
+6. choose exactly one terminal initialization path from the decision table
+   below.
+
+An active transaction is one whose exact schema and TTL are valid and whose
+coordinator state can still accept a callback. A matching warm `appUrlOpen`
+event may still complete it while the interrupted/recovery surface is visible.
+An expired or corrupt result is residual; the transaction store attempts to
+remove it, and the coordinator must continue to the durable-session decision
+instead of returning early.
+
+| Cold-launch evidence after callback handling | Initialization outcome |
+| --- | --- |
+| Installation marker or required first-install cleanup is unavailable | Keep the gate closed with `session_cleanup_failed`, `notice: cleanup_incomplete`, and `retryAction: cleanup`; do not inspect or accept credentials |
+| Matching callback and active transaction | Consume the callback; do not run a parallel restore |
+| No consumed callback and a durable refresh token exists | The durable credential wins; clear any transaction best-effort and restore |
+| No durable token and an active, unexpired transaction exists | Preserve the transaction and show the existing interrupted/callback-recovery surface |
+| No durable token and the transaction is expired or corrupt | Clear it and show the existing expired/interrupted restart surface |
+| No durable token and no transaction exists | Ordinary signed out |
+| Keychain load is operationally unavailable | Keep the gate closed with `session_restore_failed` and `retryAction: restore` |
+| A required callback/transaction dependency is unavailable and no durable credential can be restored | Non-retryable configuration error |
+
+`startSignIn()` cannot run from an authenticated session, so a durable refresh
+token and an unconsumed transaction cannot represent two legitimate concurrent
+owners. In that coexistence case, the transaction is residual from best-effort
+callback cleanup and must never outrank the durable credential. A failure to
+clear that residual transaction is sanitized and does not prevent restoration.
 
 Restoration then:
 
@@ -385,6 +710,22 @@ refresh_token=<durable-refresh-token>
 
 No client secret is used or bundled in the app.
 
+`packages/cdk/lib/auth-stack.ts` does not override
+`refreshTokenValidity` for `vela-mobile-client`, so the current effective
+Cognito/CDK default is 30 days from refresh-token issuance. This is a fixed
+lifetime, not a sliding 30-day inactivity window: successful uses of the current
+non-rotating refresh token do not extend its expiry. HPA-206 therefore promises
+restoration only while that credential remains valid. After expiry, Cognito's
+terminal refresh response follows the `session_unusable` cleanup path and
+requires a new Google sign-in.
+
+Every refresh request uses the same
+`MOBILE_AUTH_NETWORK_TIMEOUT_MS` bound as authorization-code exchange and
+`/api/auth/session` verification. The token transport receives that timeout for
+both its connection and response-read bounds. Because auth work is serialized,
+this bound is mandatory: a hung refresh must not hold later sign-out work
+indefinitely.
+
 The current nonce-coupled validator is split into two public entry points backed
 by one private base validator:
 
@@ -402,17 +743,36 @@ there is no prior in-memory subject to compare.
 Separate entry points prevent a refresh-specific nonce exemption from silently
 weakening callback validation.
 
-The Vela API remains the signature-verification boundary. A refreshed session
-does not become authenticated until `/api/auth/session` succeeds.
+The Vela API remains the signature-verification boundary. A refreshed candidate
+does not become the active session until `/api/auth/session` succeeds.
 
-If Cognito returns a new refresh token:
+Cold restoration and in-session refresh use the same candidate sequence:
 
-1. validate the complete candidate response;
-2. save the new refresh token to the Keychain;
-3. only after the save succeeds, replace the active in-memory bundle; and
-4. schedule from the new access-token expiry.
+1. request and parse a refreshed candidate bundle;
+2. validate its issuer, audience, token use, temporal claims, and subject;
+3. during an in-session refresh, require the candidate subject to match the
+   current authenticated subject;
+4. if the response rotates the refresh token, save the rotated value to the
+   Keychain before accepting it; otherwise retain the existing durable refresh
+   token;
+5. call `/api/auth/session` with the candidate ID token while the prior active
+   bundle, if any, remains unchanged;
+6. only after API verification succeeds, atomically promote the candidate,
+   update the authenticated user, set `sessionUsable: true`, and schedule from
+   the candidate access-token expiry.
 
-If no refresh token is returned, retain the existing durable refresh token.
+A retryable API-verification failure retains the validated candidate separately
+for `retryAction: verify`; it does not repeat the Cognito grant. During an
+in-session refresh, the prior active bundle continues to control
+`sessionUsable` until its own `expiresAt`. If that bundle expires before
+candidate verification succeeds, the gate closes while the pending candidate
+remains available for retry. A cold restoration has no prior usable bundle, so
+its gate remains closed throughout.
+
+An API 401 or 403 for the candidate is terminal. The coordinator discards the
+candidate and active bundle, sets `sessionUsable: false`, and clears the durable
+refresh token. If that deletion fails, it enters the same
+`cleanup_incomplete` state as failed sign-out.
 
 The current CDK mobile client does not enable refresh-token rotation, so this
 branch is forward-compatible rather than active production behavior. If
@@ -428,10 +788,13 @@ not "fix" it by accepting a rotated token before durable persistence succeeds.
 While the app is active and authenticated, calculate the next refresh delay as:
 
 ```ts
-Math.max(0, expiresAt - now - 60_000);
+Math.max(0, expiresAt - now() - 60_000);
 ```
 
 A zero delay queues refresh immediately rather than creating a negative timer.
+All expiry, delay, and claim-validation calculations use the coordinator's
+injected `now()` dependency; the refresh path must not introduce a direct
+`Date.now()` call.
 
 When the app becomes inactive, cancel the foreground timer. Do not poll in the
 background. When the app becomes active again:
@@ -441,23 +804,55 @@ background. When the app becomes active again:
 3. otherwise schedule a new foreground timer; and
 4. preserve serialized ordering with callback completion and sign-out.
 
+The coordinator also owns the access-expiry deadline described by the gate
+contract. A successful refresh replaces both deadlines. A soft refresh failure
+keeps or creates the exact-expiry deadline so protected content cannot remain
+mounted after the old token expires.
+
 Disposing the coordinator cancels all timers and native listeners.
 
 ### 5. Local sign-out
 
-Sign-out is serialized with every other auth operation:
+Sign-out is serialized with every other auth operation. The same flow serves
+the More-page action and the blocking recovery surface's start-over action; it
+does not require a current `user` when the state carries `retryAction: restore`,
+`refresh`, `persist`, or `verify`:
 
-1. prevent new refresh work and cancel the active timer;
-2. remove the durable refresh token from the Keychain;
-3. clear any token-free PKCE transaction from Preferences;
-4. erase access, ID, refresh, and pending-rotation material from process memory;
-5. navigate to the signed-out surface; and
-6. report sign-out success only after durable deletion succeeds.
+1. set `operation: signingOut` and `sessionUsable: false` immediately so
+   protected content unmounts before any asynchronous cleanup;
+2. suppress new refresh work and cancel every refresh, automatic-retry, and
+   expiry timer;
+3. remove the durable refresh token from the Keychain;
+4. clear any token-free PKCE transaction from Preferences;
+5. erase access, ID, refresh, pending-candidate, and pending-rotation material
+   from process memory;
+6. atomically enter ordinary `phase: signedOut` with no error, retry, notice, or
+   user;
+7. navigate to the signed-out surface; and
+8. report sign-out success only after durable deletion succeeds.
 
 Process memory and the PKCE transaction should still be cleared when Keychain
 deletion fails, and protected content must be hidden. The UI then offers a
 cleanup retry because the durable credential could otherwise restore on a
-future relaunch.
+future relaunch. That failure atomically enters `phase: signedOut`,
+`sessionUsable: false`, `errorCode: session_cleanup_failed`,
+`retryAction: cleanup`, and `notice: cleanup_incomplete`.
+
+Local Sign out retains the non-secret installation marker. Removing it would
+only force a redundant first-install Keychain clear on the next launch.
+
+The incomplete-cleanup copy states that Vela could not finish secure sign-out
+and that the session may return if the app is closed and reopened before cleanup
+succeeds. This state is not signed-out success. If the user force-terminates the
+app, the next launch is expected to restore the still-present durable token.
+HPA-206 does not persist a separate cleanup-pending marker; that decision is
+independent of the non-secret installation marker. After relaunch the restored
+session behaves normally and the user may invoke sign-out again.
+
+Interactive acceptance steps that force-terminate after Sign out count only
+after the UI reports durable cleanup success. A cleanup error followed by a
+relaunch and restored session is the documented failure behavior, not an
+acceptance failure masquerading as successful sign-out.
 
 `signOut()` is the user action described above. `dispose()` remains
 teardown-only: it cancels timers, removes native listeners, and destroys
@@ -476,15 +871,16 @@ credential is safe.
 
 | Condition | Classification | Durable credential | User experience |
 | --- | --- | --- | --- |
+| First-install marker read/write or required Keychain reset fails | Retryable cleanup | Treat any retained credential as unsafe and do not inspect it | Keep gate closed; expose only cleanup retry |
 | Keychain read returns `null` | Normal signed out | Unknown to the adapter; plugin reports missing | Show sign-in |
 | Empty or malformed Keychain value | Terminal local data | Clear it | Show sign-in with a clear session notice |
-| Keychain load throws an operational error | Retryable storage | Preserve it | Keep gate closed; expose the `restore` retry action |
+| Keychain load rejects through the bridge/runtime boundary | Retryable storage, defensive and rare with pinned v7.1.6 | Preserve it | Keep gate closed; expose Retry plus Sign out and start over |
 | Cognito `invalid_grant`, revoked, expired, or otherwise non-refreshable token | Terminal remote session | Clear it | Show sign-in with a clear session notice |
 | API session verification returns 401 or 403 | Terminal session | Clear it | Show sign-in with a clear session notice |
-| Network loss, timeout, 429, or server-side 5xx | Retryable | Preserve it | Keep gate closed at startup; offer retry |
-| Initial or rotated-token Keychain write fails | Retryable persistence | Do not accept candidate as durable | Keep gate closed; retry secure save |
+| Network loss, timeout, 429, or server-side 5xx | Retryable | Preserve it | Keep gate closed at startup with Retry plus Start over; in-session soft failures get one bounded automatic retry |
+| Initial or rotated-token Keychain write fails | Retryable persistence | Do not accept candidate as durable | Keep gate closed when no old token is usable; offer Retry plus Start over |
 | Keychain deletion fails | Retryable cleanup | May remain present | Hide protected content; show incomplete sign-out and retry |
-| Unsupported platform reaches production adapter | Non-retryable configuration error | Do not access browser storage | Fail closed, disable sign-in, and explain the unsupported platform |
+| Unsupported platform reaches production adapter | Non-retryable unsupported runtime | Do not access browser storage | Fail closed, disable sign-in, and explain the unsupported platform |
 
 Retryable failures map to public retry actions without making UI components
 reconstruct coordinator internals:
@@ -495,7 +891,23 @@ reconstruct coordinator internals:
 | Foreground refresh transport | `refresh` |
 | Initial or rotated refresh-token write | `persist` |
 | Transient `/api/auth/session` verification | `verify` |
-| Keychain deletion during sign-out or terminal cleanup | `cleanup` |
+| First-install reset, Keychain deletion during sign-out, or terminal cleanup | `cleanup` |
+
+The public gate mapping is fixed:
+
+| Failure context | `errorCode` | `notice` | Primary action | Secondary action while blocking |
+| --- | --- | --- | --- | --- |
+| Keychain load or startup refresh transport | `session_restore_failed` | `null` | Retry current operation (`restore`) | Sign out and start over |
+| Foreground refresh transport or malformed refresh response | `session_refresh_failed` | `null` | Retry current operation (`refresh`) | Sign out and start over |
+| Initial or rotated-token Keychain write | `session_persistence_failed` | `null` | Retry current operation (`persist`) | Sign out and start over |
+| Transient API verification | Existing `session_verification_failed` | `null` | Retry current operation (`verify`) | Sign out and start over |
+| First-install reset, Keychain deletion, or terminal cleanup | `session_cleanup_failed` | `cleanup_incomplete` | Retry secure cleanup (`cleanup`) | None |
+| Revoked, expired, corrupt, non-refreshable, or API-rejected durable session after successful cleanup | `null` | `session_unusable` | Continue with Google | None |
+| Unsupported runtime | `unsupported_platform` | `null` | None | None |
+
+These codes are stable coordinator output, not direct Cognito, HTTP, or plugin
+payloads. The gate's presentation table remains exhaustive over the public
+codes and notices.
 
 If clearing a terminal credential also fails, the app enters the same incomplete
 secure-cleanup state as failed sign-out. It must not repeatedly attempt refresh
@@ -503,8 +915,11 @@ with the known-bad value or claim that cleanup succeeded.
 
 At startup, every retryable failure keeps protected content unmounted. During an
 authenticated session, a retryable refresh failure may leave content mounted
-only while the current access token remains valid. Once it expires, the gate
-closes until refresh and API verification succeed.
+only while the current access token remains valid. The gate shows its
+non-blocking retry banner during that interval. Once the expiry deadline
+re-evaluates the token as unusable, the gate closes and the same retry action
+moves to the blocking failure surface until refresh and API verification
+succeed.
 
 User-facing notices contain stable, translated copy rather than Cognito payloads,
 Keychain errors, tokens, claims, or raw HTTP bodies.
@@ -515,10 +930,16 @@ Keychain errors, tokens, claims, or raw HTTP bodies.
   `sessionStorage`, IndexedDB, or Capacitor Preferences.
 - The secure-storage plugin's web fallback is unreachable through the production
   adapter.
+- Capacitor Preferences contains only token-free PKCE data and the non-secret
+  installation marker; the marker is cleared by uninstall and is never treated
+  as proof of authentication.
 - Only one non-empty refresh-token string is durable.
 - The Keychain item is device-bound and non-synchronizing.
-- Refresh and sign-out operations are serialized to avoid credential resurrection
-  or stale writes.
+- First-install cleanup completes before any retained Keychain credential can be
+  inspected or accepted.
+- Refresh and sign-out operations are serialized, and refresh grants are
+  single-flight, to avoid credential resurrection, stale writes, or duplicate
+  rotation attempts.
 - Logs and diagnostics emit stable event/error codes and high-level outcomes
   only.
 - Errors, request objects, response objects, decoded claims, authorization URLs,
@@ -535,24 +956,50 @@ Unit tests cover:
 - leaving the plugin's default prefix unchanged while passing the complete
   logical key;
 - `afterFirstUnlockThisDeviceOnly`;
-- exact `get`, `set`, and `remove` arguments, including per-operation
-  `sync: false`;
+- exact `get`, `set`, and `remove` arguments, including
+  `convertDate: false` and per-operation `sync: false`;
+- use of the paired `get`/`set` methods rather than
+  `getItem`/`setItem`;
 - `null`-to-missing normalization and the documented inability to distinguish
   an iOS read failure collapsed to `null`;
-- normalization of `invalidData` to corrupt and thrown operational failures to
-  unavailable;
+- normalization of `invalidData` to corrupt and rejected bridge/runtime
+  failures to unavailable;
 - rejection of empty values;
 - save, load, and clear error propagation;
 - native-iOS platform gating; and
 - proof that browser and Android paths never invoke the plugin.
 
+### Installation marker
+
+Unit tests cover:
+
+- environment- and schema-specific marker namespacing;
+- an existing marker proceeding without deleting the current credential;
+- an absent marker clearing the matching Keychain item before callback,
+  transaction, or restore handling;
+- clear-before-mark ordering;
+- termination after clear but before mark being safe to repeat;
+- marker read, Keychain clear, and marker write failures entering
+  `cleanup_incomplete` without loading a credential or permitting sign-in;
+- successful cleanup retry resuming initialization; and
+- proof that marker values and keys contain no credential or user data.
+
+Boot tests prove that native iOS selects the Keychain adapter, Android and
+browser select the unsupported adapter, runtime code never selects the
+in-memory fake, and the development-only diagnostics bypass remains reachable
+from browser `unsupported_platform` without enabling browser OAuth.
+
 ### Refresh protocol
 
 Unit tests cover:
 
-- the form-encoded public-client request;
-- an authorization-code response that requires a refresh token and a refresh
-  response that permits its omission;
+- the form-encoded public-client request with
+  `MOBILE_AUTH_NETWORK_TIMEOUT_MS`;
+- `parseAuthorizationCodeTokenResponse()` requiring a refresh token and mapping
+  an omission to `token_validation_failed`;
+- `parseRefreshTokenResponse()` permitting refresh-token omission and mapping
+  malformed success responses to the startup or in-session error code and retry
+  action for that context;
 - nonce-mandatory callback validation;
 - nonce-free refresh validation with a mandatory subject;
 - no-rotation and rotation responses;
@@ -566,17 +1013,41 @@ Unit tests cover:
 Unit tests cover:
 
 - missing-token startup;
+- a residual active transaction alongside a durable token, where durable
+  restoration wins;
+- expired and corrupt residual transactions falling through to durable
+  restoration instead of returning early;
+- active transaction recovery when no durable token exists;
 - successful relaunch restoration;
 - retryable restoration failure and retry;
 - revoked, expired, corrupt, and API-rejected sessions;
 - restoration before protected-content mounting;
 - non-negative proactive timer calculation;
+- exclusive use of injected `now()` for delay, expiry, and claim calculations;
 - `appStateChange` inactive timer cancellation and active re-evaluation;
+- rapid resume/timer/manual triggers coalescing into one refresh grant while
+  queued and while in flight;
+- queue-head refresh revalidation after sign-out, disposal, bundle replacement,
+  backgrounding, or a no-longer-due expiry;
 - independence from the diagnostics-only `resume` listener;
-- expired-token gate closure;
+- exact-expiry gate closure after a soft refresh failure;
+- one five-second automatic soft-failure retry when the old-token lifetime
+  budget permits it;
+- no automatic retry when inactive, too close to expiry, during startup, or
+  after the one automatic attempt fails;
+- manual retry cancellation of a pending automatic retry;
 - operation serialization;
+- atomic full-state transitions and every published state invariant;
+- callback eligibility retaining the HPA-205 interrupted flow while session
+  error codes coexist with non-error phases;
+- the positive `startSignIn()` allowlist, including coordinator rejection from
+  `unsupported_platform`;
 - retry-action preconditions and dispatch;
 - pending rotated-token save retry;
+- persistence and API verification before candidate promotion;
+- retryable candidate verification while the old token is respectively valid
+  and expired;
+- terminal candidate verification cleanup;
 - accepted process-loss behavior for an unpersisted rotated token;
 - listener and timer disposal; and
 - preservation of callback-first and home-first behavior.
@@ -586,6 +1057,9 @@ Unit tests cover:
 Unit and component tests cover:
 
 - the More-page Sign out action and accessible label;
+- the blocking “Sign out and start over” action for `restore`, `refresh`,
+  `persist`, and `verify` failures;
+- start-over cleanup from startup without an authenticated `user`;
 - duplicate-submission prevention and progress state;
 - timer cancellation;
 - process-memory cleanup;
@@ -595,7 +1069,16 @@ Unit and component tests cover:
 - `dispose()` waiting behind queued sign-out while never deleting durable
   credentials on its own;
 - signed-out persistence after a simulated relaunch;
-- terminal-session notice copy; and
+- terminal-session notice copy;
+- cleanup copy warning that a session may restore after force-termination;
+- the complete state-to-gate visibility matrix;
+- `phase: authenticated` plus an expired soft failure selecting a blocking
+  refresh view instead of a blank gate;
+- unmatched tuples selecting the safe `invalid_state` fallback;
+- blocking “Restoring your Vela session…” and “Refreshing your Vela session…”
+  `aria-live` copy;
+- silent successful proactive refresh and a non-blocking soft-failure retry
+  banner; and
 - loading/restoring states with no protected-content flash.
 
 ### Secret-leak regression tests
@@ -616,8 +1099,17 @@ Before HPA-206 is considered implementation-complete:
 - mobile unit/component coverage remains at or above the package's 95% threshold;
 - mobile typecheck passes;
 - the mobile production build passes with its required environment injection;
-- relevant root regressions pass; and
-- native dependency installation and Capacitor iOS synchronization are verified.
+- relevant root regressions pass;
+- `@aparajita/capacitor-secure-storage` is pinned exactly to `7.1.6` in
+  `apps/vela-mobile/src-capacitor/package.json`;
+- `apps/vela-mobile/src-capacitor/bun.lock` is updated;
+- `bunx cap sync ios` is run from `apps/vela-mobile/src-capacitor`;
+- the generated CocoaPods changes and
+  `apps/vela-mobile/src-capacitor/ios/App/Podfile.lock` are reviewed; and
+- `apps/vela-mobile/src-capacitor/ios/App/PrivacyInfo.xcprivacy` and the
+  plugin's native source are checked for privacy-manifest impact. The current
+  project uses CocoaPods, not Swift Package Manager, so no SPM update is
+  expected.
 
 ### Interactive iOS acceptance
 
@@ -626,7 +1118,12 @@ The closure pass uses a configured iOS build and real Cognito environment:
 1. sign in through Google once;
 2. force-terminate Vela and relaunch it;
 3. confirm the authenticated home screen restores without another Google prompt;
-4. set `VELA_ACCEPTANCE_USER_POOL_ID` from the deployed
+4. uninstall Vela without signing out, reinstall the same configured build, and
+   relaunch it;
+5. confirm the first-install reset leaves Vela signed out and does not restore
+   the former user's retained Keychain session;
+6. sign in through Google again;
+7. set `VELA_ACCEPTANCE_USER_POOL_ID` from the deployed
    `CognitoUserPoolId` output and `VELA_ACCEPTANCE_COGNITO_USERNAME` to the
    test user's Cognito `Username`, then invalidate that user's sessions with
    administrative AWS credentials:
@@ -640,11 +1137,12 @@ The closure pass uses a configured iOS build and real Cognito environment:
    This administrative command is acceptance-test setup only; it does not add
    remote revocation to Vela's local Sign out behavior.
 
-5. force-terminate Vela and relaunch it;
-6. confirm the sign-in screen shows a clear session-expired notice;
-7. sign in again, use Sign out on More, force-terminate, and relaunch;
-8. confirm Vela remains signed out; and
-9. inspect device logs and WebView storage to confirm no credential leakage.
+8. force-terminate Vela and relaunch it;
+9. confirm the sign-in screen shows a clear session-expired notice;
+10. sign in again, use Sign out on More, wait for the UI to report successful
+   secure cleanup, then force-terminate and relaunch;
+11. confirm Vela remains signed out; and
+12. inspect device logs and WebView storage to confirm no credential leakage.
 
 The iOS Simulator is sufficient to exercise Keychain persistence and process
 relaunch. If the Google/Cognito environment or native signing prevents the real
@@ -656,6 +1154,7 @@ rather than replaced by a mock-only claim.
 | HPA-206 acceptance criterion | Design coverage |
 | --- | --- |
 | Relaunch restores without Google prompt | Keychain refresh token + cold-launch refresh flow |
+| Reinstall does not silently restore the prior user | Preferences installation marker + clear-before-mark Keychain reset |
 | Revoked/non-refreshable credential returns to sign-in with clear message | Terminal failure classification, cleanup, and signed-out notice |
 | Sign out survives relaunch | Serialized Keychain deletion before success |
 | No credentials in browser storage or Preferences | Refresh-only Keychain record, native guard, leak tests |
@@ -672,8 +1171,9 @@ without improving relaunch restoration.
 
 ### Use Capacitor Preferences
 
-Rejected. Preferences is appropriate for the short-lived, token-free PKCE
-transaction but is not a Keychain-backed credential store.
+Rejected for credentials. Preferences is appropriate for the short-lived,
+token-free PKCE transaction and the non-secret installation marker, but it is
+not a Keychain-backed credential store.
 
 ### Use the secure-storage plugin directly throughout auth code
 
@@ -699,9 +1199,11 @@ prevent relaunch restoration on the same installation.
 ## References
 
 - [Apple: `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`](https://developer.apple.com/documentation/security/ksecattraccessibleafterfirstunlockthisdeviceonly)
+- [Apple Developer Forums: Keychain behavior after uninstall](https://developer.apple.com/forums/thread/36442)
 - [`@aparajita/capacitor-secure-storage` v7.1.6](https://github.com/aparajita/capacitor-secure-storage/tree/v7.1.6)
 - [Secure-storage v7.1.6 public API and error types](https://github.com/aparajita/capacitor-secure-storage/blob/v7.1.6/src/definitions.ts)
 - [Secure-storage v7.1.6 iOS Keychain implementation](https://github.com/aparajita/capacitor-secure-storage/blob/v7.1.6/ios/Plugin/Plugin.swift)
 - [Amazon Cognito token endpoint](https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html)
+- [Amazon Cognito refresh-token lifetime](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-refresh-token.html)
 - [Amazon Cognito refresh-token rotation](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-refresh-token.html#amazon-cognito-user-pools-refresh-token-rotation)
 - [AWS CLI: `admin-user-global-sign-out`](https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/admin-user-global-sign-out.html)

--- a/docs/superpowers/specs/2026-07-29-mobile-cognito-session-persistence-design.md
+++ b/docs/superpowers/specs/2026-07-29-mobile-cognito-session-persistence-design.md
@@ -86,10 +86,51 @@ The coordinator gains four responsibilities:
 1. restore a durable refresh token during initialization;
 2. refresh the Cognito token bundle;
 3. schedule and re-evaluate proactive refresh; and
-4. dispose of all session material during sign-out.
+4. clear all session material during sign-out.
 
 The web app's Amplify auth store is unchanged and is not imported into the
 mobile app.
+
+### Coordinator surface
+
+HPA-206 makes the coordinator's new public surface explicit. The existing
+session-verification retry is generalized so the gate does not need a separate
+method for every internal recovery step:
+
+```ts
+type MobileAuthRetryAction =
+  | 'restore'
+  | 'refresh'
+  | 'persist'
+  | 'verify'
+  | 'cleanup';
+
+type MobileAuthCoordinator = {
+  state: Readonly<MobileAuthState & { retryAction: MobileAuthRetryAction | null }>;
+  initialize(): Promise<void>;
+  startSignIn(): Promise<void>;
+  completeCallback(url: string): Promise<void>;
+  retryCurrentOperation(): Promise<void>;
+  signOut(): Promise<void>;
+  dispose(): Promise<void>;
+};
+```
+
+`retryCurrentOperation()` replaces the narrow
+`retrySessionVerification()` entry point and dispatches only to the retry action
+recorded in state. The method never infers recovery from user-facing copy.
+
+| Method | Preconditions and effect |
+| --- | --- |
+| `initialize()` | Runs at most once before disposal; installs listeners and resolves callback, transaction, then durable-session state |
+| `startSignIn()` | Runs only from ordinary signed out or a terminal-session notice that permits a new sign-in |
+| `completeCallback(url)` | Consumes only a matching callback in an active callback phase, preserving the HPA-205 transaction guards |
+| `retryCurrentOperation()` | Runs only while the coordinator exposes a non-null retry action for a retryable failure |
+| `signOut()` | Runs from authenticated state, including while a background refresh status leaves the current access token valid |
+| `dispose()` | Idempotent teardown from any phase; queues behind earlier operations and rejects or ignores new work once disposal begins |
+
+The `MobileAuthGate` uses `retryAction` to choose whether to offer a retry.
+The More page calls only `signOut()`.
 
 ### Vela-owned storage boundary
 
@@ -112,9 +153,26 @@ The adapter owns:
 - non-empty string validation;
 - plugin option selection;
 - normalization of a missing item to `null`; and
+- normalization of plugin failures to Vela-owned `corrupt` or `unavailable`
+  storage failures; and
 - rejection of unsupported platforms before any plugin call.
 
 The adapter must not expose plugin-specific types to the coordinator.
+
+For pinned plugin version 7.1.6, `get()` returns `null` for a missing item and
+can also collapse an iOS Keychain read failure to `null`; its native read path
+does not expose the underlying `OSStatus`. The adapter therefore cannot promise
+a distinct "device has not been unlocked yet" result. It applies this contract:
+
+- `null` means missing;
+- `invalidData` means corrupt and terminal;
+- a thrown `osError`, `unknownError`, or other operational failure means
+  unavailable and retryable.
+
+HPA-206 does not perform pre-first-unlock background restoration. Its supported
+path is a user-launched foreground app after the device has been unlocked. A
+future requirement to distinguish a pre-unlock read from a missing item would
+require a different plugin or Vela-owned native Keychain code.
 
 ### Keychain record
 
@@ -126,14 +184,34 @@ for example:
 vela:mobile:cognito:<user-pool-id>:<client-id>:refresh:v1
 ```
 
+The adapter leaves the plugin's default `capacitor-storage_` key prefix
+unchanged and passes the complete logical key above to `get`, `set`, and
+`remove`. The effective native key is therefore:
+
+```text
+capacitor-storage_vela:mobile:cognito:<user-pool-id>:<client-id>:refresh:v1
+```
+
+The plugin has no public Keychain-service option. The adapter does not call the
+global `setKeyPrefix()` mutator.
+
 This prevents a development or staging build from restoring a production
 credential and allows a future schema migration without guessing the stored
 format.
 
-Every write uses:
+Every operation overrides synchronization explicitly:
 
-- `KeychainAccess.afterFirstUnlockThisDeviceOnly`; and
-- `sync: false`.
+```ts
+secureStorage.get(logicalKey, false, false);
+secureStorage.set(
+  logicalKey,
+  refreshToken,
+  false,
+  false,
+  KeychainAccess.afterFirstUnlockThisDeviceOnly,
+);
+secureStorage.remove(logicalKey, false);
+```
 
 `afterFirstUnlockThisDeviceOnly` makes the item available after the user first
 unlocks the device following a restart and prevents it from migrating to a new
@@ -143,10 +221,34 @@ iCloud Keychain.
 The adapter checks that Capacitor is running natively on iOS before calling the
 plugin. Browser, Android, and unknown platforms fail closed. This guard is
 required because the selected plugin uses `localStorage` as its web fallback.
+An unsupported Android build shows a non-retryable configuration message and
+does not offer sign-in. That is intentional until Android Keystore support
+enters scope.
 
 ### In-memory token bundle
 
-The current `OAuthTokenBundle` remains process-local:
+HPA-206 splits the current optional-refresh-token shape into flow-specific
+types:
+
+```ts
+type OAuthTokenBundleBase = {
+  accessToken: string;
+  idToken: string;
+  expiresAt: number;
+};
+
+type AuthorizationCodeTokenBundle = OAuthTokenBundleBase & {
+  refreshToken: string;
+};
+
+type RefreshedTokenBundle = OAuthTokenBundleBase & {
+  refreshToken?: string;
+};
+```
+
+The authorization-code parser requires a non-empty refresh token at the type
+boundary. A refresh response may omit it when rotation is disabled. Both shapes
+remain process-local and contain:
 
 - access token;
 - ID token;
@@ -159,6 +261,27 @@ re-created with a refresh grant after relaunch.
 If Cognito returns a rotated refresh token, that token may be held temporarily
 in memory while its Keychain write is retried. It is not accepted as the
 durable session until the write succeeds.
+
+### Lifecycle event ownership
+
+The injectable `MobileAppAdapter` gains an `appStateChange` listener alongside
+its existing `appUrlOpen` listener:
+
+```ts
+addListener(
+  eventName: 'appStateChange',
+  listener: (event: { isActive: boolean }) => void,
+): Promise<{ remove(): Promise<void> }>;
+```
+
+The auth coordinator registers and removes this listener. `isActive: false`
+cancels the foreground refresh timer; `isActive: true` recomputes token lifetime
+and schedules or immediately queues refresh.
+
+`apps/vela-mobile/src/boot/capacitor-lifecycle.ts` keeps its existing `resume`
+listener because that listener only records interaction-diagnostics metadata.
+It does not drive auth recovery, and its best-effort failure semantics remain
+independent from the auth coordinator.
 
 ### Auth state and protected-content gate
 
@@ -262,10 +385,22 @@ refresh_token=<durable-refresh-token>
 
 No client secret is used or bundled in the app.
 
-The refreshed ID token is validated using the same issuer, audience, token-use,
-expiry, and temporal checks as the callback flow, except that the original
-OAuth nonce is not expected on a refresh response. During an in-process refresh,
-the refreshed subject must match the current authenticated subject.
+The current nonce-coupled validator is split into two public entry points backed
+by one private base validator:
+
+- `validateAuthorizationCodeIdTokenClaims()` requires the exact nonce from the
+  active OAuth transaction; and
+- `validateRefreshedIdTokenClaims()` has no transaction or nonce parameter,
+  requires a non-empty subject, and accepts an optional expected subject for
+  continuity checks.
+
+The shared base performs issuer, audience, token-use, expiry, temporal, and
+non-empty-subject validation. During an in-process refresh, the refreshed
+subject must match the current authenticated subject. On cold restoration,
+there is no prior in-memory subject to compare.
+
+Separate entry points prevent a refresh-specific nonce exemption from silently
+weakening callback validation.
 
 The Vela API remains the signature-verification boundary. A refreshed session
 does not become authenticated until `/api/auth/session` succeeds.
@@ -279,10 +414,24 @@ If Cognito returns a new refresh token:
 
 If no refresh token is returned, retain the existing durable refresh token.
 
+The current CDK mobile client does not enable refresh-token rotation, so this
+branch is forward-compatible rather than active production behavior. If
+rotation is enabled later and the process terminates after Cognito issues a new
+refresh token but before its Keychain write succeeds, the in-memory candidate
+is lost. The prior token may work only for any configured rotation grace period;
+afterward, the next relaunch reaches the terminal-session notice and requires
+sign-in. This is an accepted security-biased edge case. The implementation must
+not "fix" it by accepting a rotated token before durable persistence succeeds.
+
 ### 4. Proactive refresh and resume
 
-While the app is active and authenticated, schedule one refresh for
-approximately 60 seconds before access-token expiry.
+While the app is active and authenticated, calculate the next refresh delay as:
+
+```ts
+Math.max(0, expiresAt - now - 60_000);
+```
+
+A zero delay queues refresh immediately rather than creating a negative timer.
 
 When the app becomes inactive, cancel the foreground timer. Do not poll in the
 background. When the app becomes active again:
@@ -310,6 +459,13 @@ deletion fails, and protected content must be hidden. The UI then offers a
 cleanup retry because the durable credential could otherwise restore on a
 future relaunch.
 
+`signOut()` is the user action described above. `dispose()` remains
+teardown-only: it cancels timers, removes native listeners, and destroys
+process-memory candidates, but it never removes the Keychain credential or the
+PKCE transaction. Both methods use the same serialized operation queue. A
+`dispose()` call queued after `signOut()` waits for sign-out cleanup before
+teardown; once disposal begins, later public auth actions are ignored.
+
 Remote Cognito revocation and global sign-out are deliberately separate work.
 HPA-206 guarantees local disposal on this installation.
 
@@ -320,15 +476,26 @@ credential is safe.
 
 | Condition | Classification | Durable credential | User experience |
 | --- | --- | --- | --- |
-| Keychain item missing | Normal signed out | None | Show sign-in |
+| Keychain read returns `null` | Normal signed out | Unknown to the adapter; plugin reports missing | Show sign-in |
 | Empty or malformed Keychain value | Terminal local data | Clear it | Show sign-in with a clear session notice |
+| Keychain load throws an operational error | Retryable storage | Preserve it | Keep gate closed; expose the `restore` retry action |
 | Cognito `invalid_grant`, revoked, expired, or otherwise non-refreshable token | Terminal remote session | Clear it | Show sign-in with a clear session notice |
 | API session verification returns 401 or 403 | Terminal session | Clear it | Show sign-in with a clear session notice |
 | Network loss, timeout, 429, or server-side 5xx | Retryable | Preserve it | Keep gate closed at startup; offer retry |
-| Keychain unavailable before first device unlock | Retryable | Preserve it | Keep gate closed; retry after unlock/foreground |
 | Initial or rotated-token Keychain write fails | Retryable persistence | Do not accept candidate as durable | Keep gate closed; retry secure save |
 | Keychain deletion fails | Retryable cleanup | May remain present | Hide protected content; show incomplete sign-out and retry |
-| Unsupported platform reaches production adapter | Configuration error | Do not access browser storage | Fail closed without invoking plugin fallback |
+| Unsupported platform reaches production adapter | Non-retryable configuration error | Do not access browser storage | Fail closed, disable sign-in, and explain the unsupported platform |
+
+Retryable failures map to public retry actions without making UI components
+reconstruct coordinator internals:
+
+| Failure context | `retryAction` |
+| --- | --- |
+| Keychain load or startup refresh transport | `restore` |
+| Foreground refresh transport | `refresh` |
+| Initial or rotated refresh-token write | `persist` |
+| Transient `/api/auth/session` verification | `verify` |
+| Keychain deletion during sign-out or terminal cleanup | `cleanup` |
 
 If clearing a terminal credential also fails, the app enters the same incomplete
 secure-cleanup state as failed sign-out. It must not repeatedly attempt refresh
@@ -365,10 +532,16 @@ Keychain errors, tokens, claims, or raw HTTP bodies.
 Unit tests cover:
 
 - deterministic environment and version namespacing;
+- leaving the plugin's default prefix unchanged while passing the complete
+  logical key;
 - `afterFirstUnlockThisDeviceOnly`;
-- explicit `sync: false`;
-- missing-item normalization;
-- rejection of empty or malformed values;
+- exact `get`, `set`, and `remove` arguments, including per-operation
+  `sync: false`;
+- `null`-to-missing normalization and the documented inability to distinguish
+  an iOS read failure collapsed to `null`;
+- normalization of `invalidData` to corrupt and thrown operational failures to
+  unavailable;
+- rejection of empty values;
 - save, load, and clear error propagation;
 - native-iOS platform gating; and
 - proof that browser and Android paths never invoke the plugin.
@@ -378,7 +551,10 @@ Unit tests cover:
 Unit tests cover:
 
 - the form-encoded public-client request;
-- response validation;
+- an authorization-code response that requires a refresh token and a refresh
+  response that permits its omission;
+- nonce-mandatory callback validation;
+- nonce-free refresh validation with a mandatory subject;
 - no-rotation and rotation responses;
 - persistence-before-acceptance for a rotated token;
 - refreshed subject continuity during an active session;
@@ -394,11 +570,14 @@ Unit tests cover:
 - retryable restoration failure and retry;
 - revoked, expired, corrupt, and API-rejected sessions;
 - restoration before protected-content mounting;
-- proactive timer calculation;
-- inactive timer cancellation and resume re-evaluation;
+- non-negative proactive timer calculation;
+- `appStateChange` inactive timer cancellation and active re-evaluation;
+- independence from the diagnostics-only `resume` listener;
 - expired-token gate closure;
 - operation serialization;
+- retry-action preconditions and dispatch;
 - pending rotated-token save retry;
+- accepted process-loss behavior for an unpersisted rotated token;
 - listener and timer disposal; and
 - preservation of callback-first and home-first behavior.
 
@@ -413,6 +592,8 @@ Unit and component tests cover:
 - PKCE transaction cleanup;
 - Keychain cleanup;
 - cleanup retry after deletion failure;
+- `dispose()` waiting behind queued sign-out while never deleting durable
+  credentials on its own;
 - signed-out persistence after a simulated relaunch;
 - terminal-session notice copy; and
 - loading/restoring states with no protected-content flash.
@@ -445,11 +626,25 @@ The closure pass uses a configured iOS build and real Cognito environment:
 1. sign in through Google once;
 2. force-terminate Vela and relaunch it;
 3. confirm the authenticated home screen restores without another Google prompt;
-4. invalidate the durable Cognito session and relaunch;
-5. confirm the sign-in screen shows a clear session-expired notice;
-6. sign in again, use Sign out on More, force-terminate, and relaunch;
-7. confirm Vela remains signed out; and
-8. inspect device logs and WebView storage to confirm no credential leakage.
+4. set `VELA_ACCEPTANCE_USER_POOL_ID` from the deployed
+   `CognitoUserPoolId` output and `VELA_ACCEPTANCE_COGNITO_USERNAME` to the
+   test user's Cognito `Username`, then invalidate that user's sessions with
+   administrative AWS credentials:
+
+   ```sh
+   aws cognito-idp admin-user-global-sign-out \
+     --user-pool-id "$VELA_ACCEPTANCE_USER_POOL_ID" \
+     --username "$VELA_ACCEPTANCE_COGNITO_USERNAME"
+   ```
+
+   This administrative command is acceptance-test setup only; it does not add
+   remote revocation to Vela's local Sign out behavior.
+
+5. force-terminate Vela and relaunch it;
+6. confirm the sign-in screen shows a clear session-expired notice;
+7. sign in again, use Sign out on More, force-terminate, and relaunch;
+8. confirm Vela remains signed out; and
+9. inspect device logs and WebView storage to confirm no credential leakage.
 
 The iOS Simulator is sufficient to exercise Keychain persistence and process
 relaunch. If the Google/Cognito environment or native signing prevents the real
@@ -505,5 +700,8 @@ prevent relaunch restoration on the same installation.
 
 - [Apple: `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`](https://developer.apple.com/documentation/security/ksecattraccessibleafterfirstunlockthisdeviceonly)
 - [`@aparajita/capacitor-secure-storage` v7.1.6](https://github.com/aparajita/capacitor-secure-storage/tree/v7.1.6)
+- [Secure-storage v7.1.6 public API and error types](https://github.com/aparajita/capacitor-secure-storage/blob/v7.1.6/src/definitions.ts)
+- [Secure-storage v7.1.6 iOS Keychain implementation](https://github.com/aparajita/capacitor-secure-storage/blob/v7.1.6/ios/Plugin/Plugin.swift)
 - [Amazon Cognito token endpoint](https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html)
 - [Amazon Cognito refresh-token rotation](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-refresh-token.html#amazon-cognito-user-pools-refresh-token-rotation)
+- [AWS CLI: `admin-user-global-sign-out`](https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/admin-user-global-sign-out.html)


### PR DESCRIPTION
## Summary

- persist only the Cognito refresh token in the native iOS Keychain using device-bound, non-synchronizing storage; access and ID tokens remain memory-only
- restore sessions across relaunch, clear retained credentials after reinstall, refresh proactively/on resume, and serialize refresh, expiry, sign-out, cleanup, and disposal paths
- add fail-closed recovery/sign-out UI plus cross-boundary leakage and fresh-process lifecycle regressions

## Why

The mobile OAuth flow previously held its session only in process memory. Relaunch lost authentication, while iOS Keychain retention across reinstall required an explicit installation boundary to prevent restoring a previous installation's credential.

## Validation

- final mobile unit suite: 39 files, 707 tests passed
- coverage ladder: 95.01% lines (configured threshold: 95%)
- mobile and root-filtered typecheck/test checks passed
- lint, formatting, production Quasar build, and `git diff --check` passed
- Capacitor iOS sync detected `@aparajita/capacitor-secure-storage` 7.1.6 with no unexpected Info.plist, PrivacyInfo.xcprivacy, Podfile.lock, CDK, or API drift
- task-scoped and whole-branch reviews completed with no remaining findings

## External closure gate

Real Google/Cognito iOS acceptance still needs configured provider credentials: sign in, relaunch restore, proactive/resume refresh, local sign-out, reinstall residue cleanup, and post-sign-out relaunch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure iOS session persistence using Keychain-backed refresh tokens.
  * Sessions can be restored across app launches, with automatic refresh and lifecycle handling.
  * Added installation tracking to safely reset retained credentials after reinstall.
  * Added sign-out controls and retry options for authentication and session recovery.
  * Improved authentication screens with clearer progress, error, cleanup, and unsupported-platform states.
* **Bug Fixes**
  * Prevented authentication secrets from appearing in logs, rendered content, or insecure storage.
* **Documentation**
  * Added design and implementation documentation for mobile session persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->