### PR TITLE
feat(mobile): show authenticated due-review count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ Both accept comma-separated lists for dev/QA overrides. **Override URIs must use
 
 The following M2 work is required before the mobile OAuth flow can complete end-to-end (out of scope for HPA-203):
 
-1. Widen the API JWT verifier to accept both web and mobile client audiences (`aws-jwt-verify` `clientId: [webId, mobileId]`).
+1. ~~Widen the API JWT verifier to accept both web and mobile client audiences.~~ **Done.** `initializeAuthVerifier()` already accepts `[webClientId, mobileClientId]` through `aws-jwt-verify` `clientId`.
 2. Wire the mobile client ID into the Capacitor build.
 3. ~~If API calls go through WKWebView, add `capacitor://localhost` to the API CORS allow-list.~~ **Done in M1 (HPA-204).** The CORS allowlist is not a security boundary for native clients — `capacitor://localhost` is shared across all Capacitor apps and the middleware passes requests with no `Origin` header. JWT verification (item #1 above) is the actual auth boundary.
 4. Implement PKCE + `state` + `nonce` in the client-side OAuth flow.

--- a/apps/vela-mobile/package.json
+++ b/apps/vela-mobile/package.json
@@ -26,7 +26,9 @@
     "clean": "rm -rf dist .quasar"
   },
   "dependencies": {
+    "@tanstack/vue-query": "^5.90.5",
     "@quasar/extras": "^1.16.4",
+    "@vela/common": "workspace:*",
     "quasar": "^2.16.0",
     "vue": "^3.4.18",
     "vue-router": "^4.3.0"

--- a/apps/vela-mobile/quasar.config.ts
+++ b/apps/vela-mobile/quasar.config.ts
@@ -16,6 +16,7 @@ export default defineConfig((ctx) => {
 
     build: {
       alias: {
+        '@vela/common': resolve(__dirname, '../../packages/common/src/index.ts'),
         '@capacitor/app': resolve(__dirname, 'src-capacitor/node_modules/@capacitor/app'),
         '@capacitor/browser': resolve(__dirname, 'src-capacitor/node_modules/@capacitor/browser'),
         '@capacitor/core': resolve(__dirname, 'src-capacitor/node_modules/@capacitor/core'),

--- a/apps/vela-mobile/src/App.test.ts
+++ b/apps/vela-mobile/src/App.test.ts
@@ -2,7 +2,11 @@ import { flushPromises, mount } from '@vue/test-utils';
 import { defineComponent, nextTick, onMounted, reactive } from 'vue';
 import { createRouter, createMemoryHistory } from 'vue-router';
 import { describe, expect, it, vi } from 'vitest';
-import type { MobileAuthCoordinator, MobileAuthState } from './auth/mobile-auth-contract';
+import {
+  MobileAuthenticatedApiRequestError,
+  type MobileAuthCoordinator,
+  type MobileAuthState,
+} from './auth/mobile-auth-contract';
 import { MOBILE_AUTH_KEY } from './services/mobile-auth';
 import App from './App.vue';
 
@@ -42,6 +46,9 @@ describe('App', () => {
       initialize: vi.fn().mockResolvedValue(undefined),
       startSignIn: vi.fn().mockResolvedValue(undefined),
       completeCallback: vi.fn().mockResolvedValue(undefined),
+      requestAuthenticatedApi: vi
+        .fn()
+        .mockRejectedValue(new MobileAuthenticatedApiRequestError('session_unavailable')),
       retryCurrentOperation: vi.fn().mockResolvedValue(undefined),
       signOut: vi.fn().mockResolvedValue(undefined),
       dispose: vi.fn().mockResolvedValue(undefined),

--- a/apps/vela-mobile/src/App.test.ts
+++ b/apps/vela-mobile/src/App.test.ts
@@ -1,4 +1,5 @@
 import { flushPromises, mount } from '@vue/test-utils';
+import { srsKeys } from '@vela/common';
 import { defineComponent, nextTick, onMounted, reactive } from 'vue';
 import { createRouter, createMemoryHistory } from 'vue-router';
 import { describe, expect, it, vi } from 'vitest';
@@ -8,6 +9,17 @@ import {
   type MobileAuthState,
 } from './auth/mobile-auth-contract';
 import { MOBILE_AUTH_KEY } from './services/mobile-auth';
+
+vi.mock('./boot/query', async () => {
+  const { QueryClient } = await import('@tanstack/vue-query');
+  return {
+    mobileQueryClient: new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    }),
+  };
+});
+
+import { mobileQueryClient } from './boot/query';
 import App from './App.vue';
 
 function deferred() {
@@ -98,6 +110,8 @@ describe('App', () => {
     expect(wrapper.find('[data-testid="review-route"]').exists()).toBe(false);
     expect(wrapper.get('[data-testid="home-route"]').text()).toBe('home');
 
+    mobileQueryClient.setQueryData(srsKeys.stats('user-1'), { due: 4 });
+
     Object.assign(state, {
       phase: 'authenticated',
       operation: 'signingOut',
@@ -108,8 +122,28 @@ describe('App', () => {
       user: { userId: 'user-1', email: null },
     });
     await nextTick();
+    await flushPromises();
 
     expect(wrapper.find('[data-testid="home-route"]').exists()).toBe(false);
     expect(wrapper.get('[role="status"]').text()).toContain('Signing out…');
+    expect(mobileQueryClient.getQueryData(srsKeys.stats('user-1'))).toBeUndefined();
+
+    Object.assign(state, {
+      phase: 'authenticated',
+      operation: 'idle',
+      sessionUsable: true,
+      user: { userId: 'user-2', email: null },
+    });
+    await flushPromises();
+    await nextTick();
+
+    expect(mountedRoutes).toEqual(['home', 'home']);
+
+    mobileQueryClient.setQueryData(srsKeys.stats('user-2'), { due: 7 });
+    wrapper.unmount();
+    Object.assign(state, { phase: 'signedOut', sessionUsable: false, user: null });
+    await flushPromises();
+
+    expect(mobileQueryClient.getQueryData(srsKeys.stats('user-2'))).toEqual({ due: 7 });
   });
 });

--- a/apps/vela-mobile/src/App.test.ts
+++ b/apps/vela-mobile/src/App.test.ts
@@ -128,18 +128,24 @@ describe('App', () => {
     expect(wrapper.get('[role="status"]').text()).toContain('Signing out…');
     expect(mobileQueryClient.getQueryData(srsKeys.stats('user-1'))).toBeUndefined();
 
+    // Reseed the prior user's data immediately before the identity changes and
+    // seed the new user's data in the same transition window, proving the
+    // isolation watcher drops only the prior user and preserves the new one.
+    mobileQueryClient.setQueryData(srsKeys.stats('user-1'), { due: 4 });
     Object.assign(state, {
       phase: 'authenticated',
       operation: 'idle',
       sessionUsable: true,
       user: { userId: 'user-2', email: null },
     });
+    mobileQueryClient.setQueryData(srsKeys.stats('user-2'), { due: 7 });
     await flushPromises();
     await nextTick();
 
     expect(mountedRoutes).toEqual(['home', 'home']);
+    expect(mobileQueryClient.getQueryData(srsKeys.stats('user-1'))).toBeUndefined();
+    expect(mobileQueryClient.getQueryData(srsKeys.stats('user-2'))).toEqual({ due: 7 });
 
-    mobileQueryClient.setQueryData(srsKeys.stats('user-2'), { due: 7 });
     wrapper.unmount();
     Object.assign(state, { phase: 'signedOut', sessionUsable: false, user: null });
     await flushPromises();

--- a/apps/vela-mobile/src/App.vue
+++ b/apps/vela-mobile/src/App.vue
@@ -5,5 +5,18 @@
 </template>
 
 <script setup lang="ts">
+import { inject, onUnmounted } from 'vue';
+import { mobileQueryClient } from './boot/query';
 import MobileAuthGate from './components/mobile/MobileAuthGate.vue';
+import { MOBILE_AUTH_KEY } from './services/mobile-auth';
+import { installMobileQueryAuthIsolation } from './services/mobile-query-auth-isolation';
+
+const coordinator = inject(MOBILE_AUTH_KEY);
+if (!coordinator) throw new Error('Mobile auth coordinator was not provided');
+
+const stopIsolation = installMobileQueryAuthIsolation({
+  state: coordinator.state,
+  queryClient: mobileQueryClient,
+});
+onUnmounted(stopIsolation);
 </script>

--- a/apps/vela-mobile/src/auth/mobile-auth-contract.ts
+++ b/apps/vela-mobile/src/auth/mobile-auth-contract.ts
@@ -109,6 +109,30 @@ export type MobileAuthState = {
   user: MobileAuthUser | null;
 };
 
+/* global HeadersInit, RequestInit */
+export type MobileAuthenticatedApiRequest = {
+  path: string;
+  init?: Omit<RequestInit, 'headers'> & { headers?: HeadersInit };
+};
+
+export type MobileAuthenticatedApiRequestErrorCode =
+  | 'invalid_request_path'
+  | 'invalid_request_headers'
+  | 'request_timeout'
+  | 'session_unavailable'
+  | 'session_changed'
+  | 'session_recovery_pending';
+
+export class MobileAuthenticatedApiRequestError extends Error {
+  constructor(
+    readonly code: MobileAuthenticatedApiRequestErrorCode,
+    options?: { cause?: unknown },
+  ) {
+    super(code, options);
+    this.name = 'MobileAuthenticatedApiRequestError';
+  }
+}
+
 export type MobileAuthStateAssertionContext = {
   activeBundle: OAuthTokenBundleBase | null;
   now: number;

--- a/apps/vela-mobile/src/auth/mobile-auth-contract.ts
+++ b/apps/vela-mobile/src/auth/mobile-auth-contract.ts
@@ -259,6 +259,7 @@ export type MobileAuthCoordinator = {
   initialize(): Promise<void>;
   startSignIn(): Promise<void>;
   completeCallback(url: string): Promise<void>;
+  requestAuthenticatedApi(request: MobileAuthenticatedApiRequest): Promise<Response>;
   retryCurrentOperation(): Promise<void>;
   signOut(): Promise<void>;
   dispose(): Promise<void>;

--- a/apps/vela-mobile/src/auth/mobile-feature-session-status.test.ts
+++ b/apps/vela-mobile/src/auth/mobile-feature-session-status.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { MobileAuthState } from './mobile-auth-contract';
+import { selectMobileFeatureSessionStatus } from './mobile-feature-session-status';
+
+const authenticated: MobileAuthState = {
+  phase: 'authenticated',
+  operation: 'idle',
+  sessionUsable: true,
+  errorCode: null,
+  retryAction: null,
+  notice: null,
+  user: { userId: 'user-1', email: null },
+};
+
+describe('selectMobileFeatureSessionStatus', () => {
+  it('returns usable for a verified idle session', () => {
+    expect(selectMobileFeatureSessionStatus(authenticated)).toEqual({
+      kind: 'usable',
+      userId: 'user-1',
+    });
+  });
+
+  it.each([
+    [{ ...authenticated, operation: 'refreshing' as const }, true],
+    [
+      {
+        ...authenticated,
+        sessionUsable: false,
+        errorCode: 'session_refresh_failed' as const,
+        retryAction: 'refresh' as const,
+      },
+      false,
+    ],
+  ])('returns recovering and preserves capability', (state, sessionUsable) => {
+    expect(selectMobileFeatureSessionStatus(state)).toEqual({
+      kind: 'recovering',
+      userId: 'user-1',
+      sessionUsable,
+    });
+  });
+
+  it.each([
+    { ...authenticated, phase: 'signedOut' as const, sessionUsable: false, user: null },
+    { ...authenticated, operation: 'signingOut' as const, sessionUsable: false },
+    { ...authenticated, operation: 'cleaningUp' as const, sessionUsable: false },
+  ])('returns unavailable for blocking auth state', (state) => {
+    expect(selectMobileFeatureSessionStatus(state)).toEqual({ kind: 'unavailable' });
+  });
+});

--- a/apps/vela-mobile/src/auth/mobile-feature-session-status.ts
+++ b/apps/vela-mobile/src/auth/mobile-feature-session-status.ts
@@ -1,0 +1,39 @@
+import type { MobileAuthState } from './mobile-auth-contract';
+
+export type MobileFeatureSessionStatus =
+  | { kind: 'usable'; userId: string }
+  | { kind: 'recovering'; userId: string; sessionUsable: boolean }
+  | { kind: 'unavailable' };
+
+export function selectMobileFeatureSessionStatus(
+  state: Readonly<MobileAuthState>,
+): MobileFeatureSessionStatus {
+  const userId = state.user?.userId;
+  if (state.phase !== 'authenticated' || !userId) {
+    return { kind: 'unavailable' };
+  }
+
+  const recovering =
+    state.operation === 'refreshing' ||
+    state.operation === 'persisting' ||
+    state.operation === 'verifying' ||
+    state.retryAction === 'refresh' ||
+    state.retryAction === 'persist' ||
+    state.retryAction === 'verify';
+
+  if (recovering) {
+    return { kind: 'recovering', userId, sessionUsable: state.sessionUsable };
+  }
+
+  if (
+    state.operation === 'idle' &&
+    state.sessionUsable &&
+    state.errorCode === null &&
+    state.retryAction === null &&
+    state.notice === null
+  ) {
+    return { kind: 'usable', userId };
+  }
+
+  return { kind: 'unavailable' };
+}

--- a/apps/vela-mobile/src/boot/boot-files.test.ts
+++ b/apps/vela-mobile/src/boot/boot-files.test.ts
@@ -5,6 +5,7 @@ describe('mobile boot files', () => {
   it('includes native lifecycle only in Capacitor mode', () => {
     expect(getMobileBootFiles({ isCapacitor: true, isDevelopment: false })).toEqual([
       'main',
+      'query',
       'mobile-auth',
       'capacitor-lifecycle',
     ]);
@@ -13,6 +14,7 @@ describe('mobile boot files', () => {
   it('includes cold entry only in development', () => {
     expect(getMobileBootFiles({ isCapacitor: false, isDevelopment: true })).toEqual([
       'main',
+      'query',
       'mobile-auth',
       'diagnostic-cold-entry',
     ]);
@@ -21,6 +23,7 @@ describe('mobile boot files', () => {
   it('orders auth before native lifecycle and cold entry in Capacitor development', () => {
     expect(getMobileBootFiles({ isCapacitor: true, isDevelopment: true })).toEqual([
       'main',
+      'query',
       'mobile-auth',
       'capacitor-lifecycle',
       'diagnostic-cold-entry',
@@ -30,6 +33,7 @@ describe('mobile boot files', () => {
   it('includes auth immediately after main in browser production', () => {
     expect(getMobileBootFiles({ isCapacitor: false, isDevelopment: false })).toEqual([
       'main',
+      'query',
       'mobile-auth',
     ]);
   });

--- a/apps/vela-mobile/src/boot/boot-files.test.ts
+++ b/apps/vela-mobile/src/boot/boot-files.test.ts
@@ -30,7 +30,7 @@ describe('mobile boot files', () => {
     ]);
   });
 
-  it('includes auth immediately after main in browser production', () => {
+  it('orders main, query, then mobile-auth in browser production', () => {
     expect(getMobileBootFiles({ isCapacitor: false, isDevelopment: false })).toEqual([
       'main',
       'query',

--- a/apps/vela-mobile/src/boot/boot-files.ts
+++ b/apps/vela-mobile/src/boot/boot-files.ts
@@ -4,6 +4,7 @@ export function getMobileBootFiles(flags: {
 }): string[] {
   return [
     'main',
+    'query',
     'mobile-auth',
     ...(flags.isCapacitor ? ['capacitor-lifecycle'] : []),
     ...(flags.isDevelopment ? ['diagnostic-cold-entry'] : []),

--- a/apps/vela-mobile/src/boot/capacitor-lifecycle.test.ts
+++ b/apps/vela-mobile/src/boot/capacitor-lifecycle.test.ts
@@ -1,17 +1,27 @@
 import type { PluginListenerHandle } from '@capacitor/core';
+import { focusManager } from '@tanstack/vue-query';
 import { describe, expect, it, vi } from 'vitest';
 import { registerCapacitorLifecycle, resetCapacitorLifecycleForTests } from './capacitor-lifecycle';
 
 describe('Capacitor lifecycle', () => {
-  it('registers one native resume listener', async () => {
+  it('registers resume diagnostics and native focus listeners once', async () => {
     resetCapacitorLifecycleForTests();
-    const addListener = vi.fn(async (_name: 'resume', listener: () => void) => {
-      listener();
+    const setFocused = vi.spyOn(focusManager, 'setFocused');
+    const addListener = vi.fn(async (name: 'resume' | 'appStateChange', listener: () => void) => {
+      if (name === 'appStateChange') {
+        (listener as (event: { isActive: boolean }) => void)({ isActive: false });
+        (listener as (event: { isActive: boolean }) => void)({ isActive: true });
+      }
       return { remove: vi.fn(async () => undefined) };
     });
     await registerCapacitorLifecycle({ addListener });
     await registerCapacitorLifecycle({ addListener });
-    expect(addListener).toHaveBeenCalledTimes(1);
+    expect(addListener).toHaveBeenCalledTimes(2);
+    expect(addListener).toHaveBeenCalledWith('resume', expect.any(Function));
+    expect(addListener).toHaveBeenCalledWith('appStateChange', expect.any(Function));
+    expect(setFocused).toHaveBeenNthCalledWith(1, false);
+    expect(setFocused).toHaveBeenNthCalledWith(2, true);
+    setFocused.mockRestore();
   });
 
   it('shares one native listener registration across concurrent callers', async () => {
@@ -20,7 +30,9 @@ describe('Capacitor lifecycle', () => {
     const pendingRegistration = new Promise<PluginListenerHandle>((resolve) => {
       resolveRegistration = resolve;
     });
-    const addListener = vi.fn((_name: 'resume', _listener: () => void) => pendingRegistration);
+    const addListener = vi.fn(
+      (_name: 'resume' | 'appStateChange', _listener: () => void) => pendingRegistration,
+    );
 
     const registrations = Promise.all([
       registerCapacitorLifecycle({ addListener }),
@@ -29,13 +41,15 @@ describe('Capacitor lifecycle', () => {
 
     expect(addListener).toHaveBeenCalledTimes(1);
     resolveRegistration!({ remove: vi.fn(async () => undefined) });
+    await Promise.resolve();
+    expect(addListener).toHaveBeenCalledTimes(2);
     await expect(registrations).resolves.toEqual([undefined, undefined]);
   });
 
   it('allows registration to retry after a failed subscription', async () => {
     resetCapacitorLifecycleForTests();
     let attempts = 0;
-    const addListener = vi.fn(async (_name: 'resume', _listener: () => void) => {
+    const addListener = vi.fn(async (_name: 'resume' | 'appStateChange', _listener: () => void) => {
       attempts += 1;
       if (attempts === 1) throw new Error('registration failed');
       return { remove: vi.fn(async () => undefined) };
@@ -45,6 +59,25 @@ describe('Capacitor lifecycle', () => {
       'registration failed',
     );
     await expect(registerCapacitorLifecycle({ addListener })).resolves.toBeUndefined();
-    expect(addListener).toHaveBeenCalledTimes(2);
+    expect(addListener).toHaveBeenCalledTimes(3);
+  });
+
+  it('removes a partial registration before allowing a retry', async () => {
+    resetCapacitorLifecycleForTests();
+    const remove = vi.fn(async () => undefined);
+    let attempts = 0;
+    const addListener = vi.fn(async (_name: 'resume' | 'appStateChange', _listener: () => void) => {
+      attempts += 1;
+      if (attempts === 2) throw new Error('app state registration failed');
+      return { remove };
+    });
+
+    await expect(registerCapacitorLifecycle({ addListener })).rejects.toThrow(
+      'app state registration failed',
+    );
+    expect(remove).toHaveBeenCalledOnce();
+
+    await expect(registerCapacitorLifecycle({ addListener })).resolves.toBeUndefined();
+    expect(addListener).toHaveBeenCalledTimes(4);
   });
 });

--- a/apps/vela-mobile/src/boot/capacitor-lifecycle.test.ts
+++ b/apps/vela-mobile/src/boot/capacitor-lifecycle.test.ts
@@ -1,12 +1,19 @@
 import type { PluginListenerHandle } from '@capacitor/core';
 import { focusManager } from '@tanstack/vue-query';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { registerCapacitorLifecycle, resetCapacitorLifecycleForTests } from './capacitor-lifecycle';
 
 describe('Capacitor lifecycle', () => {
+  let setFocused: ReturnType<typeof vi.spyOn> | undefined;
+
+  afterEach(() => {
+    setFocused?.mockRestore();
+    setFocused = undefined;
+  });
+
   it('registers resume diagnostics and native focus listeners once', async () => {
     resetCapacitorLifecycleForTests();
-    const setFocused = vi.spyOn(focusManager, 'setFocused');
+    setFocused = vi.spyOn(focusManager, 'setFocused');
     const addListener = vi.fn(async (name: 'resume' | 'appStateChange', listener: () => void) => {
       if (name === 'appStateChange') {
         (listener as (event: { isActive: boolean }) => void)({ isActive: false });
@@ -21,7 +28,6 @@ describe('Capacitor lifecycle', () => {
     expect(addListener).toHaveBeenCalledWith('appStateChange', expect.any(Function));
     expect(setFocused).toHaveBeenNthCalledWith(1, false);
     expect(setFocused).toHaveBeenNthCalledWith(2, true);
-    setFocused.mockRestore();
   });
 
   it('shares one native listener registration across concurrent callers', async () => {

--- a/apps/vela-mobile/src/boot/capacitor-lifecycle.ts
+++ b/apps/vela-mobile/src/boot/capacitor-lifecycle.ts
@@ -1,10 +1,15 @@
 import { App } from '@capacitor/app';
 import type { PluginListenerHandle } from '@capacitor/core';
+import { focusManager } from '@tanstack/vue-query';
 import { defineBoot } from '#q-app/wrappers';
 import { recordAppResume } from 'src/services/mobile-lifecycle';
 
 export type ResumeAppAdapter = {
   addListener(eventName: 'resume', listener: () => void): Promise<PluginListenerHandle>;
+  addListener(
+    eventName: 'appStateChange',
+    listener: (event: { isActive: boolean }) => void,
+  ): Promise<PluginListenerHandle>;
 };
 
 let registered = false;
@@ -13,15 +18,24 @@ let registration: Promise<void> | null = null;
 export async function registerCapacitorLifecycle(adapter: ResumeAppAdapter = App): Promise<void> {
   if (registered) return;
   if (registration !== null) return registration;
-  registration = adapter
-    .addListener('resume', () => recordAppResume())
-    .then(() => {
+
+  registration = (async () => {
+    const handles: PluginListenerHandle[] = [];
+    try {
+      handles.push(await adapter.addListener('resume', () => recordAppResume()));
+      handles.push(
+        await adapter.addListener('appStateChange', (event) => {
+          focusManager.setFocused(event.isActive);
+        }),
+      );
       registered = true;
-    })
-    .catch((error: unknown) => {
+    } catch (error) {
+      await Promise.all(handles.map(async (handle) => handle.remove().catch(() => undefined)));
       registration = null;
       throw error;
-    });
+    }
+  })();
+
   return registration;
 }
 

--- a/apps/vela-mobile/src/boot/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/boot/mobile-auth.test.ts
@@ -51,6 +51,7 @@ const mocks = vi.hoisted(() => {
     },
     coordinator,
     createCoordinator: vi.fn((_dependencies: unknown) => coordinator),
+    provideMobileServices: vi.fn(),
     createTransactionStore: vi.fn(),
     createIosStore: vi.fn(),
     createUnsupportedStore: vi.fn(),
@@ -75,6 +76,9 @@ vi.mock('../services/mobile-auth', async (importOriginal) => {
     createMobileAuthCoordinator: mocks.createCoordinator,
   };
 });
+vi.mock('../services/mobile-services', () => ({
+  provideMobileServices: mocks.provideMobileServices,
+}));
 vi.mock('../auth/oauth-transaction-store', () => ({
   createOAuthTransactionStore: mocks.createTransactionStore,
 }));
@@ -156,14 +160,18 @@ describe('mobile auth boot', () => {
     expect(mocks.secureStorage.remove).not.toHaveBeenCalled();
   });
 
-  it('provides the coordinator and starts initialization without blocking app mount', () => {
+  it('provides services with the coordinator before starting initialization without blocking mount', () => {
     const app = { provide: vi.fn() };
 
     const result = runBoot({ app });
 
     expect(result).toBeUndefined();
     expect(app.provide).toHaveBeenCalledWith(MOBILE_AUTH_KEY, mocks.coordinator);
+    expect(mocks.provideMobileServices).toHaveBeenCalledWith(app, mocks.coordinator);
     expect(mocks.coordinator.initialize).toHaveBeenCalledOnce();
+    expect(mocks.provideMobileServices.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.coordinator.initialize.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
   });
 
   it('maps Capacitor, browser, preferences, Web Crypto, fetch, and config adapters', async () => {

--- a/apps/vela-mobile/src/boot/mobile-auth.ts
+++ b/apps/vela-mobile/src/boot/mobile-auth.ts
@@ -12,6 +12,7 @@ import {
 import { createOAuthTransactionStore } from '../auth/oauth-transaction-store';
 import { config } from '../config';
 import { createMobileAuthCoordinator, MOBILE_AUTH_KEY } from '../services/mobile-auth';
+import { provideMobileServices } from '../services/mobile-services';
 
 export default defineBoot(({ app }) => {
   const isNativeIos = Capacitor.isNativePlatform() && Capacitor.getPlatform() === 'ios';
@@ -61,5 +62,6 @@ export default defineBoot(({ app }) => {
   });
 
   app.provide(MOBILE_AUTH_KEY, coordinator);
+  provideMobileServices(app, coordinator);
   void coordinator.initialize();
 });

--- a/apps/vela-mobile/src/boot/query.test.ts
+++ b/apps/vela-mobile/src/boot/query.test.ts
@@ -1,0 +1,15 @@
+import { VueQueryPlugin } from '@tanstack/vue-query';
+import { describe, expect, it, vi } from 'vitest';
+import queryBoot, { mobileQueryClient } from './query';
+
+describe('mobile query boot', () => {
+  it('installs the exported singleton into Vue Query', () => {
+    const app = { use: vi.fn() };
+
+    queryBoot({ app } as never);
+
+    expect(app.use).toHaveBeenCalledWith(VueQueryPlugin, {
+      queryClient: mobileQueryClient,
+    });
+  });
+});

--- a/apps/vela-mobile/src/boot/query.ts
+++ b/apps/vela-mobile/src/boot/query.ts
@@ -1,0 +1,9 @@
+import { createQueryClient } from '@vela/common';
+import { VueQueryPlugin } from '@tanstack/vue-query';
+import { defineBoot } from '#q-app/wrappers';
+
+export const mobileQueryClient = createQueryClient();
+
+export default defineBoot(({ app }) => {
+  app.use(VueQueryPlugin, { queryClient: mobileQueryClient });
+});

--- a/apps/vela-mobile/src/components/home/due-review-view.test.ts
+++ b/apps/vela-mobile/src/components/home/due-review-view.test.ts
@@ -1,4 +1,3 @@
-import type { SRSStats } from '@vela/common';
 import { describe, expect, it } from 'vitest';
 import { MobileApiError } from '../../services/mobile-api-client';
 import {
@@ -8,15 +7,7 @@ import {
   selectDueReviewView,
   type DueReviewViewInput,
 } from './due-review-view';
-
-const stats = (dueToday: number): SRSStats => ({
-  total_items: dueToday,
-  due_today: dueToday,
-  mastery_breakdown: { new: 0, learning: 0, reviewing: dueToday, mastered: 0 },
-  average_ease_factor: 2.5,
-  total_reviews: 0,
-  accuracy_rate: 100,
-});
+import { dueReviewStats as stats } from './stats-fixture';
 
 const input = (overrides: Partial<DueReviewViewInput> = {}): DueReviewViewInput => ({
   stats: undefined,
@@ -95,6 +86,16 @@ describe('selectDueReviewView', () => {
       'repeated session control race has generic manual recovery',
       input({ error: new MobileApiError('session_changed') }),
       { kind: 'blocking_error', message: GENERIC_MESSAGE, retrying: false, canRetry: true },
+    ],
+    [
+      'unauthorized without cache routes to session recovery loading',
+      input({ error: new MobileApiError('unauthorized') }),
+      { kind: 'loading', recoveringSession: true },
+    ],
+    [
+      'unauthorized with cache keeps data during session recovery',
+      input({ stats: stats(3), error: new MobileApiError('unauthorized') }),
+      { kind: 'positive', count: 3, refreshing: false },
     ],
   ])('selects %s', (_name, viewInput, expected) => {
     expect(selectDueReviewView(viewInput)).toEqual(expected);

--- a/apps/vela-mobile/src/components/home/due-review-view.test.ts
+++ b/apps/vela-mobile/src/components/home/due-review-view.test.ts
@@ -1,0 +1,116 @@
+import type { SRSStats } from '@vela/common';
+import { describe, expect, it } from 'vitest';
+import { MobileApiError } from '../../services/mobile-api-client';
+import {
+  GENERIC_MESSAGE,
+  NETWORK_MESSAGE,
+  STALE_MESSAGE,
+  selectDueReviewView,
+  type DueReviewViewInput,
+} from './due-review-view';
+
+const stats = (dueToday: number): SRSStats => ({
+  total_items: dueToday,
+  due_today: dueToday,
+  mastery_breakdown: { new: 0, learning: 0, reviewing: dueToday, mastered: 0 },
+  average_ease_factor: 2.5,
+  total_reviews: 0,
+  accuracy_rate: 100,
+});
+
+const input = (overrides: Partial<DueReviewViewInput> = {}): DueReviewViewInput => ({
+  stats: undefined,
+  error: null,
+  isInitialPending: false,
+  isFetching: false,
+  sessionRecoveryPending: false,
+  manualRetryPending: false,
+  ...overrides,
+});
+
+describe('selectDueReviewView', () => {
+  it.each([
+    [
+      'initial loading',
+      input({ isInitialPending: true }),
+      { kind: 'loading', recoveringSession: false },
+    ],
+    [
+      'session recovery loading',
+      input({ sessionRecoveryPending: true }),
+      { kind: 'loading', recoveringSession: true },
+    ],
+    ['zero count', input({ stats: stats(0) }), { kind: 'zero', refreshing: false }],
+    [
+      'positive count',
+      input({ stats: stats(3) }),
+      { kind: 'positive', count: 3, refreshing: false },
+    ],
+    [
+      'zero background refresh',
+      input({ stats: stats(0), isFetching: true }),
+      { kind: 'zero', refreshing: true },
+    ],
+    [
+      'positive background refresh',
+      input({ stats: stats(3), isFetching: true }),
+      { kind: 'positive', count: 3, refreshing: true },
+    ],
+    [
+      'blocking network error',
+      input({ error: new MobileApiError('network') }),
+      { kind: 'blocking_error', message: NETWORK_MESSAGE, retrying: false, canRetry: true },
+    ],
+    [
+      'cached positive stale error',
+      input({ stats: stats(3), error: new MobileApiError('network') }),
+      { kind: 'cached_error', count: 3, message: STALE_MESSAGE, retrying: false, canRetry: true },
+    ],
+    [
+      'cached zero stale error',
+      input({ stats: stats(0), error: new MobileApiError('server') }),
+      { kind: 'cached_error', count: 0, message: STALE_MESSAGE, retrying: false, canRetry: true },
+    ],
+    [
+      'manual blocking retry',
+      input({ error: new MobileApiError('network'), manualRetryPending: true }),
+      { kind: 'blocking_error', message: NETWORK_MESSAGE, retrying: true, canRetry: true },
+    ],
+    [
+      'manual cached retry',
+      input({ stats: stats(3), error: new MobileApiError('server'), manualRetryPending: true }),
+      { kind: 'cached_error', count: 3, message: STALE_MESSAGE, retrying: true, canRetry: true },
+    ],
+    [
+      'invalid request cannot retry',
+      input({ error: new MobileApiError('invalid_request') }),
+      { kind: 'blocking_error', message: GENERIC_MESSAGE, retrying: false, canRetry: false },
+    ],
+    [
+      'invalid response can retry',
+      input({ error: new MobileApiError('invalid_response') }),
+      { kind: 'blocking_error', message: GENERIC_MESSAGE, retrying: false, canRetry: true },
+    ],
+    [
+      'repeated session control race has generic manual recovery',
+      input({ error: new MobileApiError('session_changed') }),
+      { kind: 'blocking_error', message: GENERIC_MESSAGE, retrying: false, canRetry: true },
+    ],
+  ])('selects %s', (_name, viewInput, expected) => {
+    expect(selectDueReviewView(viewInput)).toEqual(expected);
+  });
+
+  it('suppresses refreshing while a manual retry retains cached data', () => {
+    expect(
+      selectDueReviewView(input({ stats: stats(3), isFetching: true, manualRetryPending: true })),
+    ).toEqual({ kind: 'positive', count: 3, refreshing: false });
+  });
+
+  it('keeps cached data visible during session recovery', () => {
+    expect(selectDueReviewView(input({ stats: stats(3), sessionRecoveryPending: true }))).toEqual({
+      kind: 'positive',
+      count: 3,
+      refreshing: false,
+    });
+  });
+});

--- a/apps/vela-mobile/src/components/home/due-review-view.ts
+++ b/apps/vela-mobile/src/components/home/due-review-view.ts
@@ -22,10 +22,14 @@ export const NETWORK_MESSAGE =
 export const GENERIC_MESSAGE = 'Vela couldn’t load your review count. Please try again.';
 export const STALE_MESSAGE = 'This count may be out of date.';
 
+function canRetryError(error: MobileApiError): boolean {
+  return error.code !== 'invalid_request';
+}
+
 export function selectDueReviewView(input: DueReviewViewInput): DueReviewView {
   const refreshing = input.isFetching && input.stats !== undefined && !input.manualRetryPending;
 
-  if (input.sessionRecoveryPending) {
+  if (input.sessionRecoveryPending || input.error?.code === 'unauthorized') {
     if (input.stats === undefined) return { kind: 'loading', recoveringSession: true };
     if (input.stats.due_today === 0) return { kind: 'zero', refreshing: false };
     return { kind: 'positive', count: input.stats.due_today, refreshing: false };
@@ -37,7 +41,7 @@ export function selectDueReviewView(input: DueReviewViewInput): DueReviewView {
       count: input.stats.due_today,
       message: STALE_MESSAGE,
       retrying: input.manualRetryPending,
-      canRetry: input.error.code !== 'invalid_request',
+      canRetry: canRetryError(input.error),
     };
   }
 
@@ -46,7 +50,7 @@ export function selectDueReviewView(input: DueReviewViewInput): DueReviewView {
       kind: 'blocking_error',
       message: input.error.code === 'network' ? NETWORK_MESSAGE : GENERIC_MESSAGE,
       retrying: input.manualRetryPending,
-      canRetry: input.error.code !== 'invalid_request',
+      canRetry: canRetryError(input.error),
     };
   }
 

--- a/apps/vela-mobile/src/components/home/due-review-view.ts
+++ b/apps/vela-mobile/src/components/home/due-review-view.ts
@@ -1,0 +1,60 @@
+import type { SRSStats } from '@vela/common';
+import type { MobileApiError } from '../../services/mobile-api-client';
+
+export type DueReviewView =
+  | { kind: 'loading'; recoveringSession: boolean }
+  | { kind: 'zero'; refreshing: boolean }
+  | { kind: 'positive'; count: number; refreshing: boolean }
+  | { kind: 'blocking_error'; message: string; retrying: boolean; canRetry: boolean }
+  | { kind: 'cached_error'; count: number; message: string; retrying: boolean; canRetry: boolean };
+
+export type DueReviewViewInput = {
+  stats: SRSStats | undefined;
+  error: MobileApiError | null;
+  isInitialPending: boolean;
+  isFetching: boolean;
+  sessionRecoveryPending: boolean;
+  manualRetryPending: boolean;
+};
+
+export const NETWORK_MESSAGE =
+  'Vela couldn’t load your review count. Check your connection and try again.';
+export const GENERIC_MESSAGE = 'Vela couldn’t load your review count. Please try again.';
+export const STALE_MESSAGE = 'This count may be out of date.';
+
+export function selectDueReviewView(input: DueReviewViewInput): DueReviewView {
+  const refreshing = input.isFetching && input.stats !== undefined && !input.manualRetryPending;
+
+  if (input.sessionRecoveryPending) {
+    if (input.stats === undefined) return { kind: 'loading', recoveringSession: true };
+    if (input.stats.due_today === 0) return { kind: 'zero', refreshing: false };
+    return { kind: 'positive', count: input.stats.due_today, refreshing: false };
+  }
+
+  if (input.error && input.stats !== undefined) {
+    return {
+      kind: 'cached_error',
+      count: input.stats.due_today,
+      message: STALE_MESSAGE,
+      retrying: input.manualRetryPending,
+      canRetry: input.error.code !== 'invalid_request',
+    };
+  }
+
+  if (input.error) {
+    return {
+      kind: 'blocking_error',
+      message: input.error.code === 'network' ? NETWORK_MESSAGE : GENERIC_MESSAGE,
+      retrying: input.manualRetryPending,
+      canRetry: input.error.code !== 'invalid_request',
+    };
+  }
+
+  if (input.stats?.due_today === 0) return { kind: 'zero', refreshing };
+  if (input.stats && input.stats.due_today > 0) {
+    return { kind: 'positive', count: input.stats.due_today, refreshing };
+  }
+  if (input.isInitialPending) return { kind: 'loading', recoveringSession: false };
+
+  return { kind: 'blocking_error', message: GENERIC_MESSAGE, retrying: false, canRetry: true };
+}

--- a/apps/vela-mobile/src/components/home/stats-fixture.ts
+++ b/apps/vela-mobile/src/components/home/stats-fixture.ts
@@ -1,0 +1,12 @@
+import type { SRSStats } from '@vela/common';
+
+export function dueReviewStats(dueToday: number): SRSStats {
+  return {
+    total_items: dueToday,
+    due_today: dueToday,
+    mastery_breakdown: { new: 0, learning: 0, reviewing: dueToday, mastered: 0 },
+    average_ease_factor: 2.5,
+    total_reviews: 0,
+    accuracy_rate: 100,
+  };
+}

--- a/apps/vela-mobile/src/components/mobile/MobileAuthGate.navigation.test.ts
+++ b/apps/vela-mobile/src/components/mobile/MobileAuthGate.navigation.test.ts
@@ -2,7 +2,11 @@ import { defineComponent, nextTick, reactive } from 'vue';
 import { flushPromises, mount } from '@vue/test-utils';
 import { createMemoryHistory, createRouter, type RouteRecordRaw } from 'vue-router';
 import { describe, expect, it, vi } from 'vitest';
-import type { MobileAuthCoordinator, MobileAuthState } from '../../auth/mobile-auth-contract';
+import {
+  MobileAuthenticatedApiRequestError,
+  type MobileAuthCoordinator,
+  type MobileAuthState,
+} from '../../auth/mobile-auth-contract';
 import { MOBILE_AUTH_KEY } from '../../services/mobile-auth';
 import MobileAuthGate from './MobileAuthGate.vue';
 
@@ -50,6 +54,9 @@ async function mountGate(path = '/review') {
     initialize: vi.fn().mockResolvedValue(undefined),
     startSignIn: vi.fn().mockResolvedValue(undefined),
     completeCallback: vi.fn().mockResolvedValue(undefined),
+    requestAuthenticatedApi: vi
+      .fn()
+      .mockRejectedValue(new MobileAuthenticatedApiRequestError('session_unavailable')),
     retryCurrentOperation: vi.fn().mockResolvedValue(undefined),
     signOut: vi.fn().mockResolvedValue(undefined),
     dispose: vi.fn().mockResolvedValue(undefined),

--- a/apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts
+++ b/apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts
@@ -2,7 +2,8 @@ import { defineComponent, nextTick, reactive } from 'vue';
 import { flushPromises, mount } from '@vue/test-utils';
 import { createMemoryHistory, createRouter, type RouteRecordRaw } from 'vue-router';
 import { describe, expect, it, vi } from 'vitest';
-import type {
+import {
+  MobileAuthenticatedApiRequestError,
   MobileAuthCoordinator,
   MobileAuthErrorCode,
   MobileAuthPhase,
@@ -128,6 +129,9 @@ function createFakeCoordinator(
     initialize: vi.fn().mockResolvedValue(undefined),
     startSignIn: vi.fn().mockResolvedValue(undefined),
     completeCallback: vi.fn().mockResolvedValue(undefined),
+    requestAuthenticatedApi: vi
+      .fn()
+      .mockRejectedValue(new MobileAuthenticatedApiRequestError('session_unavailable')),
     retryCurrentOperation: vi.fn().mockResolvedValue(undefined),
     signOut: vi.fn().mockResolvedValue(undefined),
     dispose: vi.fn().mockResolvedValue(undefined),

--- a/apps/vela-mobile/src/composables/useDueReviewCount.test.ts
+++ b/apps/vela-mobile/src/composables/useDueReviewCount.test.ts
@@ -237,6 +237,26 @@ describe('useDueReviewCount', () => {
     expect(result.stats.value).toEqual(stats);
   });
 
+  it('refetches once when auth becomes usable before pending recovery commits', async () => {
+    const firstRequest = deferred<SRSStats>();
+    const { state, getStats, result } = harness({
+      initialState: recoveringState(),
+      getStats: vi
+        .fn<MobileSrsService['getStats']>()
+        .mockImplementationOnce(() => firstRequest.promise)
+        .mockResolvedValueOnce(stats),
+    });
+    await vi.waitFor(() => expect(getStats).toHaveBeenCalledOnce());
+
+    firstRequest.reject(new MobileApiError('session_recovery_pending'));
+    Object.assign(state, usableState());
+
+    await vi.waitFor(() => expect(getStats).toHaveBeenCalledTimes(2));
+    expect(result.stats.value).toEqual(stats);
+    await settle();
+    expect(getStats).toHaveBeenCalledTimes(2);
+  });
+
   it('disables the query while recovery has no usable session', async () => {
     const { getStats, result } = harness({ initialState: recoveringState('user-1', false) });
     await settle();

--- a/apps/vela-mobile/src/composables/useDueReviewCount.test.ts
+++ b/apps/vela-mobile/src/composables/useDueReviewCount.test.ts
@@ -309,6 +309,38 @@ describe('useDueReviewCount', () => {
     expect(result.error.value).toBeNull();
     expect(result.stats.value).toEqual(stats);
   });
+
+  it('bounds persistent network failure within three timed attempts', async () => {
+    vi.useFakeTimers();
+    try {
+      const networkError = new MobileApiError('network');
+      const { getStats, result } = harness({
+        initialState: usableState(),
+        getStats: vi.fn<MobileSrsService['getStats']>(
+          () =>
+            new Promise((_resolve, reject) => {
+              setTimeout(() => reject(networkError), 8_000);
+            }),
+        ),
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(getStats).toHaveBeenCalledOnce();
+
+      await vi.advanceTimersByTimeAsync(26_999);
+      expect(getStats).toHaveBeenCalledTimes(3);
+      expect(result.isFetching.value).toBe(true);
+      expect(result.error.value).toBeNull();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await nextTick();
+      expect(getStats).toHaveBeenCalledTimes(3);
+      expect(result.isFetching.value).toBe(false);
+      expect(result.error.value).toBe(networkError);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('retryDueCountQuery', () => {

--- a/apps/vela-mobile/src/composables/useDueReviewCount.test.ts
+++ b/apps/vela-mobile/src/composables/useDueReviewCount.test.ts
@@ -1,0 +1,304 @@
+import { QueryClient, VueQueryPlugin } from '@tanstack/vue-query';
+import { srsKeys, type SRSStats } from '@vela/common';
+import { flushPromises, mount } from '@vue/test-utils';
+import { defineComponent, nextTick, reactive } from 'vue';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { MobileAuthCoordinator, MobileAuthState } from '../auth/mobile-auth-contract';
+import { MOBILE_AUTH_KEY } from '../services/mobile-auth';
+import { MobileApiError } from '../services/mobile-api-client';
+import type { MobileSrsService } from '../services/mobile-srs';
+import { MOBILE_SRS_SERVICE_KEY } from '../services/mobile-services';
+import { retryDueCountQuery, useDueReviewCount } from './useDueReviewCount';
+
+const stats: SRSStats = {
+  total_items: 8,
+  due_today: 3,
+  mastery_breakdown: { new: 1, learning: 2, reviewing: 3, mastered: 2 },
+  average_ease_factor: 2.5,
+  total_reviews: 12,
+  accuracy_rate: 90,
+};
+
+function restoringState(): MobileAuthState {
+  return {
+    phase: 'initializing',
+    operation: 'restoring',
+    sessionUsable: false,
+    errorCode: null,
+    retryAction: null,
+    notice: null,
+    user: null,
+  };
+}
+
+function usableState(userId = 'user-1'): MobileAuthState {
+  return {
+    phase: 'authenticated',
+    operation: 'idle',
+    sessionUsable: true,
+    errorCode: null,
+    retryAction: null,
+    notice: null,
+    user: { userId, email: null },
+  };
+}
+
+function recoveringState(userId = 'user-1', sessionUsable = true): MobileAuthState {
+  return {
+    ...usableState(userId),
+    operation: 'refreshing',
+    sessionUsable,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function mountHarness(
+  options: {
+    initialState?: MobileAuthState;
+    getStats?: MobileSrsService['getStats'];
+    retry?: boolean;
+  } = {},
+) {
+  const state = reactive(options.initialState ?? restoringState());
+  const coordinator: MobileAuthCoordinator = {
+    state,
+    initialize: vi.fn(),
+    startSignIn: vi.fn(),
+    completeCallback: vi.fn(),
+    requestAuthenticatedApi: vi.fn(),
+    retryCurrentOperation: vi.fn(),
+    signOut: vi.fn(),
+    dispose: vi.fn(),
+  };
+  const getStats = vi.fn(options.getStats ?? (async () => stats));
+  const service: MobileSrsService = { getStats };
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: options.retry ?? false, gcTime: 0 } },
+  });
+  let result!: ReturnType<typeof useDueReviewCount>;
+  const Harness = defineComponent({
+    setup() {
+      result = useDueReviewCount();
+      return () => null;
+    },
+  });
+  const wrapper = mount(Harness, {
+    global: {
+      plugins: [[VueQueryPlugin, { queryClient }]],
+      provide: {
+        [MOBILE_AUTH_KEY as symbol]: coordinator,
+        [MOBILE_SRS_SERVICE_KEY as symbol]: service,
+      },
+    },
+  });
+
+  return { state, getStats, queryClient, result, wrapper };
+}
+
+async function settle(): Promise<void> {
+  await nextTick();
+  await flushPromises();
+  await nextTick();
+  await flushPromises();
+}
+
+describe('useDueReviewCount', () => {
+  const cleanups: (() => void)[] = [];
+
+  afterEach(() => {
+    cleanups.splice(0).forEach((cleanup) => cleanup());
+  });
+
+  function harness(options?: Parameters<typeof mountHarness>[0]) {
+    const mounted = mountHarness(options);
+    cleanups.push(() => {
+      mounted.wrapper.unmount();
+      mounted.queryClient.clear();
+    });
+    return mounted;
+  }
+
+  it('does not request while auth restoration is in progress', async () => {
+    const { getStats, result } = harness();
+    await settle();
+
+    expect(getStats).not.toHaveBeenCalled();
+    expect(result.sessionStatus.value).toEqual({ kind: 'unavailable' });
+  });
+
+  it('requests exactly once when restored auth becomes usable', async () => {
+    const { state, getStats, result } = harness();
+
+    Object.assign(state, usableState());
+    await vi.waitFor(() => expect(getStats).toHaveBeenCalledOnce());
+
+    expect(result.stats.value).toEqual(stats);
+  });
+
+  it('uses the authenticated user in its query key', async () => {
+    const { queryClient, getStats } = harness({ initialState: usableState('user-7') });
+    await vi.waitFor(() => expect(getStats).toHaveBeenCalledOnce());
+    await vi.waitFor(() =>
+      expect(queryClient.getQueryData(srsKeys.stats('user-7'))).toEqual(stats),
+    );
+
+    expect(queryClient.getQueryData(srsKeys.stats('user-7'))).toEqual(stats);
+    expect(queryClient.getQueryData(srsKeys.stats(null))).toBeUndefined();
+  });
+
+  it('silently retries one same-user session_changed control race', async () => {
+    const { getStats, result } = harness({
+      initialState: usableState(),
+      getStats: vi
+        .fn<MobileSrsService['getStats']>()
+        .mockRejectedValueOnce(new MobileApiError('session_changed'))
+        .mockResolvedValueOnce(stats),
+    });
+
+    await vi.waitFor(() => expect(getStats).toHaveBeenCalledTimes(2));
+    expect(result.stats.value).toEqual(stats);
+    expect(result.error.value).toBeNull();
+  });
+
+  it('silently retries one same-user dispatch-time session_unavailable control race', async () => {
+    const { getStats, result } = harness({
+      initialState: usableState(),
+      getStats: vi
+        .fn<MobileSrsService['getStats']>()
+        .mockRejectedValueOnce(new MobileApiError('session_unavailable'))
+        .mockResolvedValueOnce(stats),
+    });
+
+    await vi.waitFor(() => expect(getStats).toHaveBeenCalledTimes(2));
+    expect(result.stats.value).toEqual(stats);
+    expect(result.error.value).toBeNull();
+  });
+
+  it('makes a repeated session control race manually retryable', async () => {
+    const error = new MobileApiError('session_changed');
+    const { getStats, result } = harness({
+      initialState: usableState(),
+      getStats: vi.fn<MobileSrsService['getStats']>().mockRejectedValue(error),
+    });
+
+    await vi.waitFor(() => expect(getStats).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(result.error.value).toBe(error));
+  });
+
+  it('keeps cached data while session recovery is pending', async () => {
+    const { queryClient, result } = harness({
+      initialState: recoveringState(),
+      getStats: vi
+        .fn<MobileSrsService['getStats']>()
+        .mockRejectedValue(new MobileApiError('session_recovery_pending')),
+    });
+    queryClient.setQueryData(srsKeys.stats('user-1'), stats);
+    await settle();
+
+    await vi.waitFor(() => expect(result.sessionRecoveryPending.value).toBe(true));
+    expect(result.stats.value).toEqual(stats);
+    expect(result.error.value).toBeNull();
+  });
+
+  it('exposes recovery loading when session recovery is pending without cached data', async () => {
+    const { result } = harness({
+      initialState: recoveringState(),
+      getStats: vi
+        .fn<MobileSrsService['getStats']>()
+        .mockRejectedValue(new MobileApiError('session_recovery_pending')),
+    });
+
+    await vi.waitFor(() => expect(result.sessionRecoveryPending.value).toBe(true));
+    expect(result.stats.value).toBeUndefined();
+    expect(result.error.value).toBeNull();
+  });
+
+  it('refetches once when a same-user recovery becomes usable after pending recovery', async () => {
+    const { state, getStats, result } = harness({
+      initialState: recoveringState(),
+      getStats: vi
+        .fn<MobileSrsService['getStats']>()
+        .mockRejectedValueOnce(new MobileApiError('session_recovery_pending'))
+        .mockResolvedValueOnce(stats),
+    });
+    await vi.waitFor(() => expect(result.sessionRecoveryPending.value).toBe(true));
+
+    Object.assign(state, usableState());
+    await vi.waitFor(() => expect(getStats).toHaveBeenCalledTimes(2));
+    expect(result.stats.value).toEqual(stats);
+  });
+
+  it('disables the query while recovery has no usable session', async () => {
+    const { getStats, result } = harness({ initialState: recoveringState('user-1', false) });
+    await settle();
+
+    expect(getStats).not.toHaveBeenCalled();
+    expect(result.sessionStatus.value).toEqual({
+      kind: 'recovering',
+      userId: 'user-1',
+      sessionUsable: false,
+    });
+  });
+
+  it('selects a new user-scoped key when the authenticated user changes', async () => {
+    const { state, getStats, queryClient } = harness({ initialState: usableState('user-1') });
+    await vi.waitFor(() => expect(getStats).toHaveBeenCalledOnce());
+    await vi.waitFor(() =>
+      expect(queryClient.getQueryData(srsKeys.stats('user-1'))).toEqual(stats),
+    );
+
+    state.user = { userId: 'user-2', email: null };
+    await vi.waitFor(() => expect(getStats).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() =>
+      expect(queryClient.getQueryData(srsKeys.stats('user-2'))).toEqual(stats),
+    );
+
+    expect(queryClient.getQueryData(srsKeys.stats('user-2'))).toEqual(stats);
+  });
+
+  it('retains the manual error surface while a manual retry is pending', async () => {
+    const secondRequest = deferred<SRSStats>();
+    const error = new MobileApiError('forbidden');
+    const { getStats, result } = harness({
+      initialState: usableState(),
+      getStats: vi
+        .fn<MobileSrsService['getStats']>()
+        .mockRejectedValueOnce(error)
+        .mockImplementationOnce(() => secondRequest.promise),
+    });
+    await vi.waitFor(() => expect(result.error.value).toBe(error));
+
+    const retry = result.retry();
+    await vi.waitFor(() => expect(result.manualRetryPending.value).toBe(true));
+    await vi.waitFor(() => expect(result.isFetching.value).toBe(true));
+    expect(result.error.value).toBe(error);
+    expect(getStats).toHaveBeenCalledTimes(2);
+
+    secondRequest.resolve(stats);
+    await retry;
+    expect(result.manualRetryPending.value).toBe(false);
+    expect(result.error.value).toBeNull();
+    expect(result.stats.value).toEqual(stats);
+  });
+});
+
+describe('retryDueCountQuery', () => {
+  it.each([
+    [0, new MobileApiError('network'), true],
+    [1, new MobileApiError('server'), true],
+    [2, new MobileApiError('network'), false],
+    [0, new MobileApiError('unauthorized'), false],
+    [0, new Error('network'), false],
+  ])('returns %s only for bounded network/server retries', (failureCount, error, expected) => {
+    expect(retryDueCountQuery(failureCount, error)).toBe(expected);
+  });
+});

--- a/apps/vela-mobile/src/composables/useDueReviewCount.test.ts
+++ b/apps/vela-mobile/src/composables/useDueReviewCount.test.ts
@@ -325,15 +325,11 @@ describe('useDueReviewCount', () => {
       });
 
       await vi.advanceTimersByTimeAsync(0);
-      expect(getStats).toHaveBeenCalledOnce();
 
-      await vi.advanceTimersByTimeAsync(26_999);
-      expect(getStats).toHaveBeenCalledTimes(3);
-      expect(result.isFetching.value).toBe(true);
-      expect(result.error.value).toBeNull();
+      for (let i = 0; result.isFetching.value && i < 50; i++) {
+        await vi.advanceTimersByTimeAsync(1_000);
+      }
 
-      await vi.advanceTimersByTimeAsync(1);
-      await nextTick();
       expect(getStats).toHaveBeenCalledTimes(3);
       expect(result.isFetching.value).toBe(false);
       expect(result.error.value).toBe(networkError);

--- a/apps/vela-mobile/src/composables/useDueReviewCount.ts
+++ b/apps/vela-mobile/src/composables/useDueReviewCount.ts
@@ -45,6 +45,10 @@ function canRetryControlRace(
   );
 }
 
+function sessionStatusUserId(status: MobileFeatureSessionStatus): string | null {
+  return status.kind === 'unavailable' ? null : status.userId;
+}
+
 export function useDueReviewCount(): UseDueReviewCountResult {
   const coordinator = inject(MOBILE_AUTH_KEY);
   const srsService = inject(MOBILE_SRS_SERVICE_KEY);
@@ -59,6 +63,8 @@ export function useDueReviewCount(): UseDueReviewCountResult {
       sessionStatus.value.kind === 'usable' ||
       (sessionStatus.value.kind === 'recovering' && sessionStatus.value.sessionUsable),
   );
+  const pendingRecoveryUserId = ref<string | null>(null);
+  const recoveryRefetchConsumed = ref(false);
 
   async function fetchStatsWithSessionRaceRecovery(signal: AbortSignal): Promise<SRSStats> {
     const startingStatus = sessionStatus.value;
@@ -67,6 +73,12 @@ export function useDueReviewCount(): UseDueReviewCountResult {
     try {
       return await dueCountSrsService.getStats({ signal });
     } catch (error) {
+      if (error instanceof MobileApiError && error.code === 'session_recovery_pending') {
+        const currentUserId = sessionStatusUserId(sessionStatus.value);
+        if (startingUserId !== null && startingUserId === currentUserId) {
+          pendingRecoveryUserId.value = startingUserId;
+        }
+      }
       const isControlRace =
         error instanceof MobileApiError &&
         (error.code === 'session_changed' || error.code === 'session_unavailable');
@@ -109,16 +121,35 @@ export function useDueReviewCount(): UseDueReviewCountResult {
     return error;
   });
 
-  watch(sessionStatus, (next, previous) => {
+  function refetchAfterPendingRecovery(): void {
+    const status = sessionStatus.value;
     if (
       !sessionRecoveryPending.value ||
-      previous?.kind !== 'recovering' ||
-      next.kind !== 'usable' ||
-      previous.userId !== next.userId
+      recoveryRefetchConsumed.value ||
+      pendingRecoveryUserId.value === null ||
+      status.kind !== 'usable' ||
+      status.userId !== pendingRecoveryUserId.value
     ) {
       return;
     }
+    recoveryRefetchConsumed.value = true;
     void query.refetch();
+  }
+
+  watch(sessionStatus, (next, previous) => {
+    if (previous && sessionStatusUserId(previous) !== sessionStatusUserId(next)) {
+      pendingRecoveryUserId.value = null;
+      recoveryRefetchConsumed.value = false;
+      return;
+    }
+    if (next.kind === 'recovering') {
+      recoveryRefetchConsumed.value = false;
+    }
+    refetchAfterPendingRecovery();
+  });
+
+  watch([sessionRecoveryPending, pendingRecoveryUserId], () => {
+    refetchAfterPendingRecovery();
   });
 
   async function retry(): Promise<void> {

--- a/apps/vela-mobile/src/composables/useDueReviewCount.ts
+++ b/apps/vela-mobile/src/composables/useDueReviewCount.ts
@@ -1,0 +1,147 @@
+import { useQuery } from '@tanstack/vue-query';
+import { srsKeys, type SRSStats } from '@vela/common';
+import { computed, inject, ref, watch, type ComputedRef, type Ref } from 'vue';
+import {
+  selectMobileFeatureSessionStatus,
+  type MobileFeatureSessionStatus,
+} from '../auth/mobile-feature-session-status';
+import { MOBILE_AUTH_KEY } from '../services/mobile-auth';
+import { MobileApiError } from '../services/mobile-api-client';
+import type { MobileSrsService } from '../services/mobile-srs';
+import { MOBILE_SRS_SERVICE_KEY } from '../services/mobile-services';
+
+export const DUE_COUNT_RETRY_LIMIT = 2;
+
+export type UseDueReviewCountResult = {
+  stats: ComputedRef<SRSStats | undefined>;
+  error: ComputedRef<MobileApiError | null>;
+  sessionStatus: ComputedRef<MobileFeatureSessionStatus>;
+  isInitialPending: ComputedRef<boolean>;
+  isFetching: ComputedRef<boolean>;
+  sessionRecoveryPending: ComputedRef<boolean>;
+  manualRetryPending: Readonly<Ref<boolean>>;
+  retry(): Promise<void>;
+};
+
+export function retryDueCountQuery(failureCount: number, error: unknown): boolean {
+  return (
+    error instanceof MobileApiError &&
+    (error.code === 'network' || error.code === 'server') &&
+    failureCount < DUE_COUNT_RETRY_LIMIT
+  );
+}
+
+function canRetryControlRace(
+  status: MobileFeatureSessionStatus,
+  startingUserId: string | null,
+  signal: AbortSignal,
+): boolean {
+  return (
+    !signal.aborted &&
+    startingUserId !== null &&
+    status.kind !== 'unavailable' &&
+    status.userId === startingUserId &&
+    (status.kind === 'usable' || status.sessionUsable)
+  );
+}
+
+export function useDueReviewCount(): UseDueReviewCountResult {
+  const coordinator = inject(MOBILE_AUTH_KEY);
+  const srsService = inject(MOBILE_SRS_SERVICE_KEY);
+  if (!coordinator || !srsService) {
+    throw new Error('mobile_due_review_count_dependencies_unavailable');
+  }
+  const dueCountSrsService: MobileSrsService = srsService;
+
+  const sessionStatus = computed(() => selectMobileFeatureSessionStatus(coordinator.state));
+  const queryEnabled = computed(
+    () =>
+      sessionStatus.value.kind === 'usable' ||
+      (sessionStatus.value.kind === 'recovering' && sessionStatus.value.sessionUsable),
+  );
+
+  async function fetchStatsWithSessionRaceRecovery(signal: AbortSignal): Promise<SRSStats> {
+    const startingStatus = sessionStatus.value;
+    const startingUserId = startingStatus.kind === 'unavailable' ? null : startingStatus.userId;
+
+    try {
+      return await dueCountSrsService.getStats({ signal });
+    } catch (error) {
+      const isControlRace =
+        error instanceof MobileApiError &&
+        (error.code === 'session_changed' || error.code === 'session_unavailable');
+      if (!isControlRace || !canRetryControlRace(sessionStatus.value, startingUserId, signal)) {
+        throw error;
+      }
+
+      // The coordinator can reject a request dispatched during the narrow
+      // session handoff window. Retry exactly once for the same live user;
+      // a second control failure remains visible for an explicit user retry.
+      return dueCountSrsService.getStats({ signal });
+    }
+  }
+
+  const query = useQuery<SRSStats, MobileApiError>({
+    queryKey: computed(() =>
+      srsKeys.stats(sessionStatus.value.kind === 'unavailable' ? null : sessionStatus.value.userId),
+    ),
+    enabled: queryEnabled,
+    queryFn: ({ signal }) => fetchStatsWithSessionRaceRecovery(signal),
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: 'always',
+    retry: retryDueCountQuery,
+  });
+
+  const sessionRecoveryPending = computed(
+    () =>
+      query.error.value instanceof MobileApiError &&
+      query.error.value.code === 'session_recovery_pending',
+  );
+  const manualRetryPending = ref(false);
+  const retainedManualError = ref<MobileApiError | null>(null);
+
+  const visibleError = computed<MobileApiError | null>(() => {
+    const error = retainedManualError.value ?? query.error.value;
+    if (!(error instanceof MobileApiError)) return null;
+    if (error.code === 'session_recovery_pending' || error.code === 'unauthorized') {
+      return null;
+    }
+    return error;
+  });
+
+  watch(sessionStatus, (next, previous) => {
+    if (
+      !sessionRecoveryPending.value ||
+      previous?.kind !== 'recovering' ||
+      next.kind !== 'usable' ||
+      previous.userId !== next.userId
+    ) {
+      return;
+    }
+    void query.refetch();
+  });
+
+  async function retry(): Promise<void> {
+    if (manualRetryPending.value) return;
+    retainedManualError.value =
+      query.error.value instanceof MobileApiError ? query.error.value : null;
+    manualRetryPending.value = true;
+    try {
+      await query.refetch();
+    } finally {
+      manualRetryPending.value = false;
+      retainedManualError.value = null;
+    }
+  }
+
+  return {
+    stats: computed(() => query.data.value),
+    error: visibleError,
+    sessionStatus,
+    isInitialPending: computed(() => query.isPending.value),
+    isFetching: computed(() => query.isFetching.value),
+    sessionRecoveryPending,
+    manualRetryPending: manualRetryPending as Readonly<Ref<boolean>>,
+    retry,
+  };
+}

--- a/apps/vela-mobile/src/composables/useDueReviewCount.ts
+++ b/apps/vela-mobile/src/composables/useDueReviewCount.ts
@@ -115,9 +115,7 @@ export function useDueReviewCount(): UseDueReviewCountResult {
   const visibleError = computed<MobileApiError | null>(() => {
     const error = retainedManualError.value ?? query.error.value;
     if (!(error instanceof MobileApiError)) return null;
-    if (error.code === 'session_recovery_pending' || error.code === 'unauthorized') {
-      return null;
-    }
+    if (error.code === 'session_recovery_pending') return null;
     return error;
   });
 

--- a/apps/vela-mobile/src/pages/HomePage.test.ts
+++ b/apps/vela-mobile/src/pages/HomePage.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Quasar, QLayout, QPageContainer } from 'quasar';
 import { MobileApiError } from 'src/services/mobile-api-client';
 import { NETWORK_MESSAGE, STALE_MESSAGE } from 'src/components/home/due-review-view';
+import { dueReviewStats as stats } from 'src/components/home/stats-fixture';
 import HomePage from './HomePage.vue';
 
 const dueReview = {
@@ -20,15 +21,6 @@ const dueReview = {
 vi.mock('src/composables/useDueReviewCount', () => ({
   useDueReviewCount: () => dueReview,
 }));
-
-const stats = (dueToday: number): SRSStats => ({
-  total_items: dueToday,
-  due_today: dueToday,
-  mastery_breakdown: { new: 0, learning: 0, reviewing: dueToday, mastered: 0 },
-  average_ease_factor: 2.5,
-  total_reviews: 0,
-  accuracy_rate: 100,
-});
 
 const Host = defineComponent({
   components: { QLayout, QPageContainer, HomePage },

--- a/apps/vela-mobile/src/pages/HomePage.test.ts
+++ b/apps/vela-mobile/src/pages/HomePage.test.ts
@@ -1,12 +1,35 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { SRSStats } from '@vela/common';
 import { mount } from '@vue/test-utils';
+import { defineComponent, ref } from 'vue';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Quasar, QLayout, QPageContainer } from 'quasar';
-import { defineComponent } from 'vue';
+import { MobileApiError } from 'src/services/mobile-api-client';
+import { NETWORK_MESSAGE, STALE_MESSAGE } from 'src/components/home/due-review-view';
 import HomePage from './HomePage.vue';
-import { config } from 'src/config';
 
-// q-page must be a deep child of q-layout; wrap HomePage so Quasar renders its
-// content under jsdom instead of silently emitting nothing.
+const dueReview = {
+  stats: ref<SRSStats | undefined>(),
+  error: ref<MobileApiError | null>(null),
+  isInitialPending: ref(false),
+  isFetching: ref(false),
+  sessionRecoveryPending: ref(false),
+  manualRetryPending: ref(false),
+  retry: vi.fn<() => Promise<void>>().mockResolvedValue(),
+};
+
+vi.mock('src/composables/useDueReviewCount', () => ({
+  useDueReviewCount: () => dueReview,
+}));
+
+const stats = (dueToday: number): SRSStats => ({
+  total_items: dueToday,
+  due_today: dueToday,
+  mastery_breakdown: { new: 0, learning: 0, reviewing: dueToday, mastered: 0 },
+  average_ease_factor: 2.5,
+  total_reviews: 0,
+  accuracy_rate: 100,
+});
+
 const Host = defineComponent({
   components: { QLayout, QPageContainer, HomePage },
   template:
@@ -15,48 +38,110 @@ const Host = defineComponent({
 
 const mountPage = () => mount(Host, { global: { plugins: [Quasar] } });
 
+function setDueReview(overrides: Partial<typeof dueReview> = {}) {
+  dueReview.stats.value = undefined;
+  dueReview.error.value = null;
+  dueReview.isInitialPending.value = false;
+  dueReview.isFetching.value = false;
+  dueReview.sessionRecoveryPending.value = false;
+  dueReview.manualRetryPending.value = false;
+  Object.assign(dueReview, overrides);
+}
+
 describe('HomePage', () => {
   afterEach(() => {
-    vi.doUnmock('src/config');
-    vi.resetModules();
+    setDueReview();
+    dueReview.retry.mockClear();
   });
 
-  it('renders the app name', () => {
+  it('announces loading accessibly', () => {
+    dueReview.isInitialPending.value = true;
     const wrapper = mountPage();
-    expect(wrapper.text()).toContain(config.app.name);
+
+    expect(wrapper.get('h1').text()).toBe('Today’s review');
+    expect(wrapper.get('[role="status"]').text()).toContain('Loading your review count…');
+    expect(wrapper.get('[role="status"]').attributes('aria-live')).toBe('polite');
   });
 
-  it('renders the app version', () => {
+  it('announces session recovery loading accessibly', () => {
+    dueReview.sessionRecoveryPending.value = true;
     const wrapper = mountPage();
-    expect(wrapper.text()).toContain(config.app.version);
+
+    expect(wrapper.get('[role="status"]').text()).toContain('Refreshing your session…');
   });
 
-  it('renders the M1 scaffold label', () => {
+  it('shows a caught-up zero count', () => {
+    dueReview.stats.value = stats(0);
     const wrapper = mountPage();
-    expect(wrapper.text()).toContain('M1');
+
+    expect(wrapper.get('.due-review__count').text()).toBe('0');
+    expect(wrapper.text()).toContain('You’re caught up for now.');
   });
 
-  it('shows the Development chip in dev mode', () => {
+  it.each([
+    [1, '1 word is due for review.'],
+    [3, '3 words are due for review.'],
+  ])('uses the correct due-count copy for %i word(s)', (count, copy) => {
+    dueReview.stats.value = stats(count);
     const wrapper = mountPage();
-    expect(wrapper.text()).toContain('Development');
-    expect(wrapper.find('.q-chip').text()).toContain('Development');
+
+    expect(wrapper.get('.due-review__count').text()).toBe(String(count));
+    expect(wrapper.text()).toContain(copy);
   });
 
-  it('shows the Production chip when config.app.isDev is false', async () => {
-    vi.doMock('src/config', () => ({
-      config: {
-        app: { name: 'Vela', version: '0.0.1', isDev: false, isProd: true },
-      },
-    }));
-    vi.resetModules();
-    const { default: HomePageProd } = await import('./HomePage.vue');
-    const ProdHost = defineComponent({
-      components: { QLayout, QPageContainer, HomePageProd },
-      template:
-        '<q-layout view="hHh Lpr fFf"><q-page-container><home-page-prod/></q-page-container></q-layout>',
-    });
-    const wrapper = mount(ProdHost, { global: { plugins: [Quasar] } });
-    expect(wrapper.text()).toContain('Production');
-    expect(wrapper.text()).not.toContain('Development');
+  it('retains the count while it refreshes in the background', () => {
+    dueReview.stats.value = stats(3);
+    dueReview.isFetching.value = true;
+    const wrapper = mountPage();
+
+    expect(wrapper.get('.due-review__count').text()).toBe('3');
+    expect(wrapper.get('[role="status"]').text()).toContain('Refreshing review count…');
+  });
+
+  it('shows a blocking network error and retries', async () => {
+    dueReview.error.value = new MobileApiError('network');
+    const wrapper = mountPage();
+
+    expect(wrapper.get('[role="alert"]').text()).toContain(NETWORK_MESSAGE);
+    await wrapper.get('button').trigger('click');
+    expect(dueReview.retry).toHaveBeenCalledOnce();
+  });
+
+  it.each([0, 3])('keeps the cached %i count with a stale-error warning', (count) => {
+    dueReview.stats.value = stats(count);
+    dueReview.error.value = new MobileApiError('server');
+    const wrapper = mountPage();
+
+    expect(wrapper.get('[role="alert"] .due-review__count').text()).toBe(String(count));
+    expect(wrapper.get('[role="alert"]').text()).toContain(STALE_MESSAGE);
+  });
+
+  it('disables and relabels retry while a manual retry is pending', () => {
+    dueReview.error.value = new MobileApiError('network');
+    dueReview.manualRetryPending.value = true;
+    const wrapper = mountPage();
+    const retry = wrapper.get('button');
+
+    expect(retry.attributes('aria-label')).toBe('Retrying review count');
+    expect(retry.attributes('disabled')).toBeDefined();
+  });
+
+  it('does not offer retry for an invalid request', () => {
+    dueReview.error.value = new MobileApiError('invalid_request');
+    const wrapper = mountPage();
+
+    expect(wrapper.get('[role="alert"]').text()).toContain('Please try again.');
+    expect(wrapper.find('button').exists()).toBe(false);
+  });
+
+  it('does not render the scaffold, environment, version, or Start Review copy', () => {
+    dueReview.stats.value = stats(3);
+    const text = mountPage().text();
+
+    expect(text).not.toContain('M1 Scaffold');
+    expect(text).not.toContain('Development');
+    expect(text).not.toContain('Production');
+    expect(text).not.toContain('Version');
+    expect(text).not.toContain('Start Review');
   });
 });

--- a/apps/vela-mobile/src/pages/HomePage.vue
+++ b/apps/vela-mobile/src/pages/HomePage.vue
@@ -19,7 +19,7 @@
         <p class="due-review__count" aria-live="polite">
           {{ view.kind === 'zero' ? 0 : view.count }}
         </p>
-        <p>
+        <p aria-live="polite">
           {{
             view.kind === 'zero'
               ? 'You’re caught up for now.'

--- a/apps/vela-mobile/src/pages/HomePage.vue
+++ b/apps/vela-mobile/src/pages/HomePage.vue
@@ -1,18 +1,70 @@
 <template>
-  <q-page class="flex flex-center">
-    <div class="text-center q-pa-xl">
-      <h1 class="text-h3 text-weight-bold text-primary q-mb-sm">
-        {{ config.app.name }}
-      </h1>
-      <p class="text-subtitle1 text-grey-7 q-mb-md">Version {{ config.app.version }}</p>
-      <q-chip :color="config.app.isDev ? 'orange' : 'green'" text-color="white" size="sm">
-        {{ config.app.isDev ? 'Development' : 'Production' }}
-      </q-chip>
-      <p class="text-caption text-grey-6 q-mt-lg">M1 Scaffold</p>
-    </div>
+  <q-page class="q-pa-lg">
+    <section class="due-review" aria-labelledby="due-review-heading">
+      <h1 id="due-review-heading" class="text-h5 text-weight-bold">Today’s review</h1>
+
+      <div
+        v-if="view.kind === 'loading'"
+        role="status"
+        aria-live="polite"
+        class="text-center q-py-xl"
+      >
+        <q-spinner size="40px" color="primary" />
+        <p class="q-mt-md">
+          {{ view.recoveringSession ? 'Refreshing your session…' : 'Loading your review count…' }}
+        </p>
+      </div>
+
+      <template v-else-if="view.kind === 'zero' || view.kind === 'positive'">
+        <p class="due-review__count" aria-live="polite">
+          {{ view.kind === 'zero' ? 0 : view.count }}
+        </p>
+        <p>
+          {{
+            view.kind === 'zero'
+              ? 'You’re caught up for now.'
+              : view.count === 1
+                ? '1 word is due for review.'
+                : `${view.count} words are due for review.`
+          }}
+        </p>
+        <p v-if="view.refreshing" role="status" aria-live="polite">Refreshing review count…</p>
+      </template>
+
+      <div v-else role="alert">
+        <template v-if="view.kind === 'cached_error'">
+          <p class="due-review__count">{{ view.count }}</p>
+        </template>
+        <p>{{ view.message }}</p>
+        <q-btn
+          v-if="view.canRetry"
+          color="primary"
+          label="Retry"
+          :loading="view.retrying"
+          :disable="view.retrying"
+          :aria-label="view.retrying ? 'Retrying review count' : 'Retry review count'"
+          @click="retry"
+        />
+      </div>
+    </section>
   </q-page>
 </template>
 
 <script setup lang="ts">
-import { config } from 'src/config';
+import { computed } from 'vue';
+import { selectDueReviewView } from 'src/components/home/due-review-view';
+import { useDueReviewCount } from 'src/composables/useDueReviewCount';
+
+const dueReview = useDueReviewCount();
+const view = computed(() =>
+  selectDueReviewView({
+    stats: dueReview.stats.value,
+    error: dueReview.error.value,
+    isInitialPending: dueReview.isInitialPending.value,
+    isFetching: dueReview.isFetching.value,
+    sessionRecoveryPending: dueReview.sessionRecoveryPending.value,
+    manualRetryPending: dueReview.manualRetryPending.value,
+  }),
+);
+const retry = () => dueReview.retry();
 </script>

--- a/apps/vela-mobile/src/pages/MorePage.test.ts
+++ b/apps/vela-mobile/src/pages/MorePage.test.ts
@@ -2,7 +2,11 @@ import { flushPromises, mount } from '@vue/test-utils';
 import { Quasar, QLayout, QPageContainer } from 'quasar';
 import { defineComponent } from 'vue';
 import { describe, expect, it, vi } from 'vitest';
-import type { MobileAuthCoordinator, MobileAuthState } from '../auth/mobile-auth-contract';
+import {
+  MobileAuthenticatedApiRequestError,
+  type MobileAuthCoordinator,
+  type MobileAuthState,
+} from '../auth/mobile-auth-contract';
 import { MOBILE_AUTH_KEY } from '../services/mobile-auth';
 import MorePage from './MorePage.vue';
 
@@ -37,6 +41,9 @@ function createCoordinatorStub(
     initialize: vi.fn().mockResolvedValue(undefined),
     startSignIn: vi.fn().mockResolvedValue(undefined),
     completeCallback: vi.fn().mockResolvedValue(undefined),
+    requestAuthenticatedApi: vi
+      .fn()
+      .mockRejectedValue(new MobileAuthenticatedApiRequestError('session_unavailable')),
     retryCurrentOperation: vi.fn().mockResolvedValue(undefined),
     signOut: vi.fn().mockResolvedValue(undefined),
     dispose: vi.fn().mockResolvedValue(undefined),

--- a/apps/vela-mobile/src/pages/StubPages.test.ts
+++ b/apps/vela-mobile/src/pages/StubPages.test.ts
@@ -7,7 +7,10 @@ import LearnPage from './LearnPage.vue';
 import ReviewPage from './ReviewPage.vue';
 import WordsPage from './WordsPage.vue';
 import MorePage from './MorePage.vue';
-import type { MobileAuthCoordinator } from '../auth/mobile-auth-contract';
+import {
+  MobileAuthenticatedApiRequestError,
+  type MobileAuthCoordinator,
+} from '../auth/mobile-auth-contract';
 import { MOBILE_AUTH_KEY } from '../services/mobile-auth';
 
 const coordinator: MobileAuthCoordinator = {
@@ -23,6 +26,9 @@ const coordinator: MobileAuthCoordinator = {
   initialize: vi.fn().mockResolvedValue(undefined),
   startSignIn: vi.fn().mockResolvedValue(undefined),
   completeCallback: vi.fn().mockResolvedValue(undefined),
+  requestAuthenticatedApi: vi
+    .fn()
+    .mockRejectedValue(new MobileAuthenticatedApiRequestError('session_unavailable')),
   retryCurrentOperation: vi.fn().mockResolvedValue(undefined),
   signOut: vi.fn().mockResolvedValue(undefined),
   dispose: vi.fn().mockResolvedValue(undefined),

--- a/apps/vela-mobile/src/services/mobile-api-client.test.ts
+++ b/apps/vela-mobile/src/services/mobile-api-client.test.ts
@@ -4,7 +4,7 @@ import {
   type MobileAuthCoordinator,
   type MobileAuthState,
 } from '../auth/mobile-auth-contract';
-import { createMobileApiClient, MOBILE_DUE_COUNT_EXECUTION_TIMEOUT_MS } from './mobile-api-client';
+import { createMobileApiClient, MOBILE_API_DEFAULT_TIMEOUT_MS } from './mobile-api-client';
 
 const usableState: MobileAuthState = {
   phase: 'authenticated',
@@ -37,13 +37,12 @@ function coordinator(overrides: Partial<MobileAuthCoordinator> = {}): MobileAuth
     signOut: vi.fn(),
     dispose: vi.fn(),
     ...overrides,
-  } as unknown as MobileAuthCoordinator;
+  };
 }
 
 function expectCallerCleanup(caller: AbortController, remove: ReturnType<typeof vi.spyOn>): void {
   expect(vi.getTimerCount()).toBe(0);
   expect(remove).toHaveBeenCalledWith('abort', expect.any(Function));
-  caller.abort();
 }
 
 describe('mobile API client', () => {
@@ -187,7 +186,7 @@ describe('mobile API client', () => {
       const promise = createMobileApiClient(auth).getJson('srs/stats', { signal: caller.signal });
       const expected = expect(promise).rejects.toMatchObject({ code: 'network' });
 
-      await vi.advanceTimersByTimeAsync(MOBILE_DUE_COUNT_EXECUTION_TIMEOUT_MS);
+      await vi.advanceTimersByTimeAsync(MOBILE_API_DEFAULT_TIMEOUT_MS);
 
       await expected;
       expectCallerCleanup(caller, remove);
@@ -213,7 +212,7 @@ describe('mobile API client', () => {
       const promise = createMobileApiClient(auth).getJson('srs/stats');
       const expected = expect(promise).rejects.toMatchObject({ code: 'session_recovery_pending' });
 
-      await vi.advanceTimersByTimeAsync(MOBILE_DUE_COUNT_EXECUTION_TIMEOUT_MS);
+      await vi.advanceTimersByTimeAsync(MOBILE_API_DEFAULT_TIMEOUT_MS);
 
       await expected;
     } finally {
@@ -268,7 +267,7 @@ describe('mobile API client', () => {
       });
       const promise = createMobileApiClient(auth).getJson('srs/stats');
       const expected = expect(promise).rejects.toMatchObject({ code: 'network' });
-      await vi.advanceTimersByTimeAsync(MOBILE_DUE_COUNT_EXECUTION_TIMEOUT_MS);
+      await vi.advanceTimersByTimeAsync(MOBILE_API_DEFAULT_TIMEOUT_MS);
 
       await expected;
     } finally {

--- a/apps/vela-mobile/src/services/mobile-api-client.test.ts
+++ b/apps/vela-mobile/src/services/mobile-api-client.test.ts
@@ -139,7 +139,7 @@ describe('mobile API client', () => {
     }
   });
 
-  it('cleans the deadline and caller listener after a body rejection', async () => {
+  it('maps malformed JSON to invalid_response and cleans request resources', async () => {
     vi.useFakeTimers();
     try {
       const caller = new AbortController();
@@ -151,12 +151,22 @@ describe('mobile API client', () => {
       );
 
       await expect(client.getJson('srs/stats', { signal: caller.signal })).rejects.toMatchObject({
-        code: 'network',
+        code: 'invalid_response',
       });
       expectCallerCleanup(caller, remove);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('maps a body transport rejection to network', async () => {
+    const unreadable = response(200, {});
+    vi.mocked(unreadable.json).mockRejectedValue(new TypeError('body stream failed'));
+    const client = createMobileApiClient(
+      coordinator({ requestAuthenticatedApi: vi.fn().mockResolvedValue(unreadable) }),
+    );
+
+    await expect(client.getJson('srs/stats')).rejects.toMatchObject({ code: 'network' });
   });
 
   it('maps an execution deadline outside recovery to network', async () => {

--- a/apps/vela-mobile/src/services/mobile-api-client.test.ts
+++ b/apps/vela-mobile/src/services/mobile-api-client.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  MobileAuthenticatedApiRequestError,
+  type MobileAuthCoordinator,
+  type MobileAuthState,
+} from '../auth/mobile-auth-contract';
+import { createMobileApiClient, MOBILE_DUE_COUNT_EXECUTION_TIMEOUT_MS } from './mobile-api-client';
+
+const usableState: MobileAuthState = {
+  phase: 'authenticated',
+  operation: 'idle',
+  sessionUsable: true,
+  errorCode: null,
+  retryAction: null,
+  notice: null,
+  user: { userId: 'user-1', email: null },
+};
+
+type AuthenticatedRequest = { init?: { signal?: AbortSignal | null } };
+
+function response(status: number, value: unknown): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: vi.fn().mockResolvedValue(value),
+  } as unknown as Response;
+}
+
+function coordinator(overrides: Partial<MobileAuthCoordinator> = {}): MobileAuthCoordinator {
+  return {
+    state: usableState,
+    initialize: vi.fn(),
+    startSignIn: vi.fn(),
+    completeCallback: vi.fn(),
+    requestAuthenticatedApi: vi.fn().mockResolvedValue(response(200, { due_today: 4 })),
+    retryCurrentOperation: vi.fn(),
+    signOut: vi.fn(),
+    dispose: vi.fn(),
+    ...overrides,
+  } as unknown as MobileAuthCoordinator;
+}
+
+describe('mobile API client', () => {
+  it('returns a successful JSON response', async () => {
+    const auth = coordinator();
+    const client = createMobileApiClient(auth);
+
+    await expect(client.getJson('srs/stats')).resolves.toEqual({ due_today: 4 });
+    expect(auth.requestAuthenticatedApi).toHaveBeenCalledWith({
+      path: 'srs/stats',
+      init: { signal: expect.any(AbortSignal) },
+    });
+  });
+
+  it.each([
+    [401, 'unauthorized'],
+    [403, 'forbidden'],
+    [404, 'server'],
+    [409, 'server'],
+    [500, 'server'],
+  ] as const)('maps HTTP %i to %s', async (status, code) => {
+    const client = createMobileApiClient(
+      coordinator({ requestAuthenticatedApi: vi.fn().mockResolvedValue(response(status, {})) }),
+    );
+
+    await expect(client.getJson('srs/stats')).rejects.toMatchObject({ code });
+  });
+
+  it.each([
+    ['invalid_request_path', 'invalid_request'],
+    ['invalid_request_headers', 'invalid_request'],
+    ['session_unavailable', 'session_unavailable'],
+    ['session_changed', 'session_changed'],
+    ['session_recovery_pending', 'session_recovery_pending'],
+    ['request_timeout', 'network'],
+  ] as const)('maps coordinator %s to %s', async (source, code) => {
+    const client = createMobileApiClient(
+      coordinator({
+        requestAuthenticatedApi: vi
+          .fn()
+          .mockRejectedValue(new MobileAuthenticatedApiRequestError(source)),
+      }),
+    );
+
+    await expect(client.getJson('srs/stats')).rejects.toMatchObject({ code });
+  });
+
+  it('maps a raw transport TypeError to network', async () => {
+    const client = createMobileApiClient(
+      coordinator({ requestAuthenticatedApi: vi.fn().mockRejectedValue(new TypeError('offline')) }),
+    );
+
+    await expect(client.getJson('srs/stats')).rejects.toMatchObject({ code: 'network' });
+  });
+
+  it('maps an execution deadline outside recovery to network', async () => {
+    vi.useFakeTimers();
+    try {
+      const auth = coordinator({
+        requestAuthenticatedApi: vi.fn(
+          ({ init }: AuthenticatedRequest) =>
+            new Promise<Response>((_resolve, reject) => {
+              init?.signal?.addEventListener('abort', () =>
+                reject(new DOMException('aborted', 'AbortError')),
+              );
+            }),
+        ),
+      });
+      const promise = createMobileApiClient(auth).getJson('srs/stats');
+      const expected = expect(promise).rejects.toMatchObject({ code: 'network' });
+
+      await vi.advanceTimersByTimeAsync(MOBILE_DUE_COUNT_EXECUTION_TIMEOUT_MS);
+
+      await expected;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('maps an execution deadline during recovery to session_recovery_pending', async () => {
+    vi.useFakeTimers();
+    try {
+      const auth = coordinator({
+        state: { ...usableState, operation: 'refreshing', sessionUsable: false },
+        requestAuthenticatedApi: vi.fn(
+          ({ init }: AuthenticatedRequest) =>
+            new Promise<Response>((_resolve, reject) => {
+              init?.signal?.addEventListener('abort', () =>
+                reject(new DOMException('aborted', 'AbortError')),
+              );
+            }),
+        ),
+      });
+      const promise = createMobileApiClient(auth).getJson('srs/stats');
+      const expected = expect(promise).rejects.toMatchObject({ code: 'session_recovery_pending' });
+
+      await vi.advanceTimersByTimeAsync(MOBILE_DUE_COUNT_EXECUTION_TIMEOUT_MS);
+
+      await expected;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('preserves a caller abort as AbortError', async () => {
+    const caller = new AbortController();
+    const auth = coordinator({
+      requestAuthenticatedApi: vi.fn(
+        ({ init }: AuthenticatedRequest) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () =>
+              reject(new DOMException('aborted', 'AbortError')),
+            );
+          }),
+      ),
+    });
+    const promise = createMobileApiClient(auth).getJson('srs/stats', { signal: caller.signal });
+    caller.abort();
+
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('maps a stalled response body at the execution deadline to network', async () => {
+    vi.useFakeTimers();
+    try {
+      let signal: AbortSignal | undefined;
+      const stalled = response(200, {});
+      vi.mocked(stalled.json).mockImplementation(
+        () =>
+          new Promise((_resolve, reject) => {
+            signal?.addEventListener('abort', () =>
+              reject(new DOMException('aborted', 'AbortError')),
+            );
+          }),
+      );
+      const auth = coordinator({
+        requestAuthenticatedApi: vi.fn(({ init }: AuthenticatedRequest) => {
+          signal = init?.signal ?? undefined;
+          return Promise.resolve(stalled);
+        }),
+      });
+      const promise = createMobileApiClient(auth).getJson('srs/stats');
+      const expected = expect(promise).rejects.toMatchObject({ code: 'network' });
+      await vi.advanceTimersByTimeAsync(MOBILE_DUE_COUNT_EXECUTION_TIMEOUT_MS);
+
+      await expected;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('cleans its deadline timer and caller listener after success', async () => {
+    vi.useFakeTimers();
+    try {
+      const caller = new AbortController();
+      const remove = vi.spyOn(caller.signal, 'removeEventListener');
+      await expect(
+        createMobileApiClient(coordinator()).getJson('srs/stats', { signal: caller.signal }),
+      ).resolves.toEqual({ due_today: 4 });
+
+      expect(vi.getTimerCount()).toBe(0);
+      expect(remove).toHaveBeenCalledWith('abort', expect.any(Function));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/vela-mobile/src/services/mobile-api-client.test.ts
+++ b/apps/vela-mobile/src/services/mobile-api-client.test.ts
@@ -40,6 +40,12 @@ function coordinator(overrides: Partial<MobileAuthCoordinator> = {}): MobileAuth
   } as unknown as MobileAuthCoordinator;
 }
 
+function expectCallerCleanup(caller: AbortController, remove: ReturnType<typeof vi.spyOn>): void {
+  expect(vi.getTimerCount()).toBe(0);
+  expect(remove).toHaveBeenCalledWith('abort', expect.any(Function));
+  caller.abort();
+}
+
 describe('mobile API client', () => {
   it('returns a successful JSON response', async () => {
     const auth = coordinator();
@@ -93,6 +99,66 @@ describe('mobile API client', () => {
     await expect(client.getJson('srs/stats')).rejects.toMatchObject({ code: 'network' });
   });
 
+  it('cleans the deadline and caller listener after a coordinator rejection', async () => {
+    vi.useFakeTimers();
+    try {
+      const caller = new AbortController();
+      const remove = vi.spyOn(caller.signal, 'removeEventListener');
+      const client = createMobileApiClient(
+        coordinator({
+          requestAuthenticatedApi: vi
+            .fn()
+            .mockRejectedValue(new MobileAuthenticatedApiRequestError('session_unavailable')),
+        }),
+      );
+
+      await expect(client.getJson('srs/stats', { signal: caller.signal })).rejects.toMatchObject({
+        code: 'session_unavailable',
+      });
+      expectCallerCleanup(caller, remove);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('cleans the deadline and caller listener after an HTTP error', async () => {
+    vi.useFakeTimers();
+    try {
+      const caller = new AbortController();
+      const remove = vi.spyOn(caller.signal, 'removeEventListener');
+      const client = createMobileApiClient(
+        coordinator({ requestAuthenticatedApi: vi.fn().mockResolvedValue(response(500, {})) }),
+      );
+
+      await expect(client.getJson('srs/stats', { signal: caller.signal })).rejects.toMatchObject({
+        code: 'server',
+      });
+      expectCallerCleanup(caller, remove);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('cleans the deadline and caller listener after a body rejection', async () => {
+    vi.useFakeTimers();
+    try {
+      const caller = new AbortController();
+      const remove = vi.spyOn(caller.signal, 'removeEventListener');
+      const malformed = response(200, {});
+      vi.mocked(malformed.json).mockRejectedValue(new SyntaxError('bad JSON'));
+      const client = createMobileApiClient(
+        coordinator({ requestAuthenticatedApi: vi.fn().mockResolvedValue(malformed) }),
+      );
+
+      await expect(client.getJson('srs/stats', { signal: caller.signal })).rejects.toMatchObject({
+        code: 'network',
+      });
+      expectCallerCleanup(caller, remove);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('maps an execution deadline outside recovery to network', async () => {
     vi.useFakeTimers();
     try {
@@ -106,12 +172,15 @@ describe('mobile API client', () => {
             }),
         ),
       });
-      const promise = createMobileApiClient(auth).getJson('srs/stats');
+      const caller = new AbortController();
+      const remove = vi.spyOn(caller.signal, 'removeEventListener');
+      const promise = createMobileApiClient(auth).getJson('srs/stats', { signal: caller.signal });
       const expected = expect(promise).rejects.toMatchObject({ code: 'network' });
 
       await vi.advanceTimersByTimeAsync(MOBILE_DUE_COUNT_EXECUTION_TIMEOUT_MS);
 
       await expected;
+      expectCallerCleanup(caller, remove);
     } finally {
       vi.useRealTimers();
     }
@@ -143,21 +212,29 @@ describe('mobile API client', () => {
   });
 
   it('preserves a caller abort as AbortError', async () => {
-    const caller = new AbortController();
-    const auth = coordinator({
-      requestAuthenticatedApi: vi.fn(
-        ({ init }: AuthenticatedRequest) =>
-          new Promise<Response>((_resolve, reject) => {
-            init?.signal?.addEventListener('abort', () =>
-              reject(new DOMException('aborted', 'AbortError')),
-            );
-          }),
-      ),
-    });
-    const promise = createMobileApiClient(auth).getJson('srs/stats', { signal: caller.signal });
-    caller.abort();
+    vi.useFakeTimers();
+    try {
+      const caller = new AbortController();
+      const remove = vi.spyOn(caller.signal, 'removeEventListener');
+      const auth = coordinator({
+        requestAuthenticatedApi: vi.fn(
+          ({ init }: AuthenticatedRequest) =>
+            new Promise<Response>((_resolve, reject) => {
+              init?.signal?.addEventListener('abort', () =>
+                reject(new DOMException('aborted', 'AbortError')),
+              );
+            }),
+        ),
+      });
+      const promise = createMobileApiClient(auth).getJson('srs/stats', { signal: caller.signal });
+      const expected = expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+      caller.abort();
 
-    await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+      await expected;
+      expectCallerCleanup(caller, remove);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('maps a stalled response body at the execution deadline to network', async () => {

--- a/apps/vela-mobile/src/services/mobile-api-client.ts
+++ b/apps/vela-mobile/src/services/mobile-api-client.ts
@@ -65,6 +65,21 @@ function mapCoordinatorError(
   throw new MobileApiError('network', { cause: error });
 }
 
+function mapResponseBodyError(
+  error: unknown,
+  context: {
+    callerAborted: boolean;
+    deadlineExpired: boolean;
+    coordinator: MobileAuthCoordinator;
+  },
+): never {
+  if (error instanceof SyntaxError && !context.callerAborted && !context.deadlineExpired) {
+    throw new MobileApiError('invalid_response', { cause: error });
+  }
+
+  return mapCoordinatorError(error, context);
+}
+
 export function createMobileApiClient(
   coordinator: MobileAuthCoordinator,
   timeoutMs = MOBILE_DUE_COUNT_EXECUTION_TIMEOUT_MS,
@@ -107,7 +122,7 @@ export function createMobileApiClient(
         try {
           return await response.json();
         } catch (error) {
-          return mapCoordinatorError(error, { callerAborted, deadlineExpired, coordinator });
+          return mapResponseBodyError(error, { callerAborted, deadlineExpired, coordinator });
         }
       } finally {
         clearTimeout(deadline);

--- a/apps/vela-mobile/src/services/mobile-api-client.ts
+++ b/apps/vela-mobile/src/services/mobile-api-client.ts
@@ -25,7 +25,7 @@ export class MobileApiError extends Error {
   }
 }
 
-export const MOBILE_DUE_COUNT_EXECUTION_TIMEOUT_MS = 8_000;
+export const MOBILE_API_DEFAULT_TIMEOUT_MS = 8_000;
 
 export type MobileApiClient = {
   getJson(path: string, options?: { signal?: AbortSignal }): Promise<unknown>;
@@ -53,6 +53,10 @@ function mapCoordinatorError(
 
   if (error instanceof DOMException && error.name === 'AbortError') {
     if (callerAborted) throw error;
+    // A deadline abort during coordinator session recovery is expected: the
+    // token refresh in flight has not finished within the request budget, so
+    // surface it as session-recovery-pending (the UI waits for recovery)
+    // instead of a hard network failure that would prompt a pointless retry.
     if (
       deadlineExpired &&
       selectMobileFeatureSessionStatus(coordinator.state).kind === 'recovering'
@@ -82,7 +86,7 @@ function mapResponseBodyError(
 
 export function createMobileApiClient(
   coordinator: MobileAuthCoordinator,
-  timeoutMs = MOBILE_DUE_COUNT_EXECUTION_TIMEOUT_MS,
+  timeoutMs = MOBILE_API_DEFAULT_TIMEOUT_MS,
 ): MobileApiClient {
   return {
     async getJson(path, options = {}) {

--- a/apps/vela-mobile/src/services/mobile-api-client.ts
+++ b/apps/vela-mobile/src/services/mobile-api-client.ts
@@ -1,0 +1,118 @@
+import {
+  MobileAuthenticatedApiRequestError,
+  type MobileAuthCoordinator,
+} from '../auth/mobile-auth-contract';
+import { selectMobileFeatureSessionStatus } from '../auth/mobile-feature-session-status';
+
+export type MobileApiErrorCode =
+  | 'invalid_request'
+  | 'session_unavailable'
+  | 'session_changed'
+  | 'session_recovery_pending'
+  | 'unauthorized'
+  | 'forbidden'
+  | 'network'
+  | 'server'
+  | 'invalid_response';
+
+export class MobileApiError extends Error {
+  constructor(
+    readonly code: MobileApiErrorCode,
+    options?: { cause?: unknown },
+  ) {
+    super(code, options);
+    this.name = 'MobileApiError';
+  }
+}
+
+export const MOBILE_DUE_COUNT_EXECUTION_TIMEOUT_MS = 8_000;
+
+export type MobileApiClient = {
+  getJson(path: string, options?: { signal?: AbortSignal }): Promise<unknown>;
+};
+
+function mapCoordinatorError(
+  error: unknown,
+  context: {
+    callerAborted: boolean;
+    deadlineExpired: boolean;
+    coordinator: MobileAuthCoordinator;
+  },
+): never {
+  const { callerAborted, deadlineExpired, coordinator } = context;
+
+  if (error instanceof MobileAuthenticatedApiRequestError) {
+    if (error.code === 'invalid_request_path' || error.code === 'invalid_request_headers') {
+      throw new MobileApiError('invalid_request', { cause: error });
+    }
+    if (error.code === 'request_timeout') {
+      throw new MobileApiError('network', { cause: error });
+    }
+    throw new MobileApiError(error.code, { cause: error });
+  }
+
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    if (callerAborted) throw error;
+    if (
+      deadlineExpired &&
+      selectMobileFeatureSessionStatus(coordinator.state).kind === 'recovering'
+    ) {
+      throw new MobileApiError('session_recovery_pending', { cause: error });
+    }
+    throw new MobileApiError('network', { cause: error });
+  }
+
+  throw new MobileApiError('network', { cause: error });
+}
+
+export function createMobileApiClient(
+  coordinator: MobileAuthCoordinator,
+  timeoutMs = MOBILE_DUE_COUNT_EXECUTION_TIMEOUT_MS,
+): MobileApiClient {
+  return {
+    async getJson(path, options = {}) {
+      const controller = new AbortController();
+      let callerAborted = false;
+      let deadlineExpired = false;
+      const onCallerAbort = () => {
+        callerAborted = true;
+        controller.abort();
+      };
+
+      options.signal?.addEventListener('abort', onCallerAbort, { once: true });
+      if (options.signal?.aborted) {
+        onCallerAbort();
+      }
+
+      const deadline = setTimeout(() => {
+        deadlineExpired = true;
+        controller.abort();
+      }, timeoutMs);
+
+      try {
+        let response: Response;
+        try {
+          response = await coordinator.requestAuthenticatedApi({
+            path,
+            init: { signal: controller.signal },
+          });
+        } catch (error) {
+          return mapCoordinatorError(error, { callerAborted, deadlineExpired, coordinator });
+        }
+
+        if (response.status === 401) throw new MobileApiError('unauthorized');
+        if (response.status === 403) throw new MobileApiError('forbidden');
+        if (!response.ok) throw new MobileApiError('server');
+
+        try {
+          return await response.json();
+        } catch (error) {
+          return mapCoordinatorError(error, { callerAborted, deadlineExpired, coordinator });
+        }
+      } finally {
+        clearTimeout(deadline);
+        options.signal?.removeEventListener('abort', onCallerAbort);
+      }
+    },
+  };
+}

--- a/apps/vela-mobile/src/services/mobile-auth-disposal.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth-disposal.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { MOBILE_OAUTH_CALLBACK_URI } from '../auth/mobile-auth-contract';
-import {
-  createMobileAuthCoordinator,
-  type MobileAuthCoordinatorDependencies,
-} from './mobile-auth';
+import { createMobileAuthCoordinator, type MobileAuthCoordinatorDependencies } from './mobile-auth';
 
 function createDependencies(): MobileAuthCoordinatorDependencies {
   return {

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -3742,6 +3742,44 @@ describe('authenticated feature transport', () => {
     await expect(request).rejects.toMatchObject({ name: 'AbortError' });
   });
 
+  it('propagates a caller abort to the response body after headers arrive', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    const caller = new AbortController();
+    // fetch() resolves as soon as headers arrive, but response.json() is
+    // consumed by the API client only after the coordinator returns. The
+    // caller abort bridge must stay active through body consumption so a
+    // stalled body can be cancelled by the caller's deadline.
+    harness.sessionFetch.mockImplementationOnce((_url, init) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => {
+              reject(new DOMException('The operation was aborted.', 'AbortError'));
+            });
+          }),
+      } as unknown as Response),
+    );
+
+    const request = harness.coordinator.requestAuthenticatedApi({
+      path: 'srs/stats',
+      init: { signal: caller.signal },
+    });
+
+    // The coordinator has returned the Response; headers arrived but the
+    // body has not been consumed yet. Start consuming the body (which
+    // registers an abort listener on the fetch signal), then abort the
+    // caller signal. The bridge must still propagate the abort to the
+    // fetch signal that governs response.json().
+    const body = await request;
+    const jsonPromise = body.json();
+    caller.abort();
+
+    await expect(jsonPromise).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
   it('preserves the original caller abort when its init signal is replaced in flight', async () => {
     const harness = makeHarness();
     await authenticate(harness);
@@ -4017,6 +4055,82 @@ describe('authenticated feature transport', () => {
 
     await expect(request).resolves.toMatchObject({ status: 200 });
     expect(refreshRequests(harness)).toHaveLength(1);
+  });
+
+  it('joins an already-running proactive refresh after a still-valid-token 401', async () => {
+    let currentNow = NOW;
+    const harness = makeHarness({ now: () => currentNow });
+    await authenticateWithExpiry(harness, currentNow + 120_000, currentNow);
+    harness.sessionFetch.mockClear();
+    prepareSuccessfulRefresh(harness, {
+      claimExpirySeconds: Math.ceil((currentNow + 3_600_000) / 1_000),
+    });
+    const refreshGate = deferred<{ status: number; data: unknown }>();
+    harness.tokenTransport.gate = refreshGate.promise;
+    const featureResponse = deferred<Response>();
+    let featureCalls = 0;
+    harness.sessionFetch.mockImplementation(async (target) => {
+      if (String(target).endsWith('/srs/stats')) {
+        featureCalls += 1;
+        return featureCalls === 1 ? featureResponse.promise : response(200, {});
+      }
+      return response(200, {
+        authenticated: true,
+        user: { userId: 'user-123', email: 'person@example.com' },
+      });
+    });
+
+    const request = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
+    await vi.waitFor(() => expect(featureCalls).toBe(1));
+    // Advance into the proactive-refresh lead window but NOT past expiry —
+    // the captured token is still technically valid when the 401 arrives.
+    currentNow += 61_000;
+    harness.app.emitState(true);
+    await vi.waitFor(() => expect(refreshRequests(harness)).toHaveLength(1));
+    featureResponse.resolve(response(401, {}));
+    refreshGate.resolve(harness.tokenTransport.result);
+
+    // The in-flight refresh is joined (not treated as terminal). A successful
+    // promotion retries the feature request with the new bundle instead of
+    // reporting session_changed.
+    await expect(request).resolves.toMatchObject({ status: 200 });
+    expect(refreshRequests(harness)).toHaveLength(1);
+    expect(harness.sessionStore.clearCalls).toBe(0);
+  });
+
+  it('reports retryable failure when a still-valid-token 401 joins a transiently failing refresh', async () => {
+    let currentNow = NOW;
+    const harness = makeHarness({ now: () => currentNow });
+    await authenticateWithExpiry(harness, currentNow + 120_000, currentNow);
+    harness.sessionFetch.mockClear();
+    // 503 is a transient (non-invalid_grant) refresh failure: the session
+    // stays authenticated with retryAction 'refresh' — the durable
+    // credential must not be deleted.
+    harness.tokenTransport.result = { status: 503, data: {} };
+    const refreshGate = deferred<{ status: number; data: unknown }>();
+    harness.tokenTransport.gate = refreshGate.promise;
+    const featureResponse = deferred<Response>();
+    harness.sessionFetch.mockImplementation(async (target) =>
+      String(target).endsWith('/srs/stats')
+        ? featureResponse.promise
+        : response(200, {
+            authenticated: true,
+            user: { userId: 'user-123', email: 'person@example.com' },
+          }),
+    );
+
+    const request = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
+    await vi.waitFor(() => expect(harness.sessionFetch).toHaveBeenCalledOnce());
+    currentNow += 61_000;
+    harness.app.emitState(true);
+    await vi.waitFor(() => expect(refreshRequests(harness)).toHaveLength(1));
+    featureResponse.resolve(response(401, {}));
+    refreshGate.resolve(harness.tokenTransport.result);
+
+    // The in-flight refresh is joined. Its transient failure classifies as
+    // retryable_recovery — the durable credential is preserved for retry.
+    await expect(request).rejects.toMatchObject({ code: 'session_recovery_pending' });
+    expect(harness.sessionStore.clearCalls).toBe(0);
   });
 
   it('returns session_changed when sign-out supersedes a waiting expired-token recovery', async () => {

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -3853,6 +3853,163 @@ describe('authenticated feature transport', () => {
     await expect(request).resolves.toMatchObject({ status });
   });
 
+  it('retries concurrent 401s once after one expired-token refresh promotion', async () => {
+    let currentNow = NOW;
+    const harness = makeHarness({ now: () => currentNow });
+    await authenticateWithExpiry(harness, currentNow + 1_000, currentNow);
+    prepareSuccessfulRefresh(harness, {
+      claimExpirySeconds: Math.ceil((currentNow + 3_600_000) / 1_000),
+    });
+    const initialResponses = [deferred<Response>(), deferred<Response>()];
+    let featureCalls = 0;
+    harness.sessionFetch.mockImplementation(async (target) => {
+      if (String(target).endsWith('/srs/stats')) {
+        const responseForCall = initialResponses[featureCalls++];
+        return responseForCall?.promise ?? response(200, {});
+      }
+      return response(200, {
+        authenticated: true,
+        user: { userId: 'user-123', email: 'person@example.com' },
+      });
+    });
+
+    const first = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
+    const second = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
+    await vi.waitFor(() => expect(featureCalls).toBe(2));
+    currentNow += 2_000;
+    initialResponses[0]?.resolve(response(401, {}));
+    initialResponses[1]?.resolve(response(401, {}));
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      expect.objectContaining({ status: 200 }),
+      expect.objectContaining({ status: 200 }),
+    ]);
+    expect(refreshRequests(harness)).toHaveLength(1);
+    expect(featureCalls).toBe(4);
+  });
+
+  it('queues one terminal cleanup for concurrent still-valid-token 401s', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    harness.sessionFetch.mockImplementation(async (target) =>
+      String(target).endsWith('/srs/stats')
+        ? response(401, {})
+        : response(200, {
+            authenticated: true,
+            user: { userId: 'user-123', email: 'person@example.com' },
+          }),
+    );
+
+    await expect(
+      Promise.all([
+        harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' }),
+        harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' }),
+      ]),
+    ).resolves.toEqual([
+      expect.objectContaining({ status: 401 }),
+      expect.objectContaining({ status: 401 }),
+    ]);
+    expect(harness.sessionStore.clearCalls).toBe(1);
+    expect(refreshRequests(harness)).toHaveLength(0);
+  });
+
+  it('reports retryable recovery when an expired-token 401 cannot refresh while inactive', async () => {
+    let currentNow = NOW;
+    const harness = makeHarness({ now: () => currentNow });
+    await authenticateWithExpiry(harness, currentNow + 120_000, currentNow);
+    harness.sessionFetch.mockClear();
+    const featureResponse = deferred<Response>();
+    harness.sessionFetch.mockImplementation(async (target) =>
+      String(target).endsWith('/srs/stats')
+        ? featureResponse.promise
+        : response(200, {
+            authenticated: true,
+            user: { userId: 'user-123', email: 'person@example.com' },
+          }),
+    );
+
+    const request = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
+    await vi.waitFor(() => expect(harness.sessionFetch).toHaveBeenCalledOnce());
+    harness.app.emitState(false);
+    currentNow += 121_000;
+    featureResponse.resolve(response(401, {}));
+
+    await expect(request).rejects.toMatchObject({ code: 'session_recovery_pending' });
+    expect(refreshRequests(harness)).toHaveLength(0);
+    expect(harness.sessionStore.clearCalls).toBe(0);
+  });
+
+  it('detaches an aborted caller while its peer completes the shared recovery', async () => {
+    let currentNow = NOW;
+    const harness = makeHarness({ now: () => currentNow });
+    await authenticateWithExpiry(harness, currentNow + 1_000, currentNow);
+    prepareSuccessfulRefresh(harness, {
+      claimExpirySeconds: Math.ceil((currentNow + 3_600_000) / 1_000),
+    });
+    const refreshGate = deferred<{ status: number; data: unknown }>();
+    harness.tokenTransport.gate = refreshGate.promise;
+    const firstFeatureResponse = deferred<Response>();
+    const secondFeatureResponse = deferred<Response>();
+    let featureCalls = 0;
+    harness.sessionFetch.mockImplementation(async (target) => {
+      if (String(target).endsWith('/srs/stats')) {
+        const responseForCall = [firstFeatureResponse, secondFeatureResponse][featureCalls++];
+        return responseForCall?.promise ?? response(200, {});
+      }
+      return response(200, {
+        authenticated: true,
+        user: { userId: 'user-123', email: 'person@example.com' },
+      });
+    });
+    const caller = new AbortController();
+    const first = harness.coordinator.requestAuthenticatedApi({
+      path: 'srs/stats',
+      init: { signal: caller.signal },
+    });
+    const second = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
+    await vi.waitFor(() => expect(featureCalls).toBe(2));
+    currentNow += 2_000;
+    firstFeatureResponse.resolve(response(401, {}));
+    secondFeatureResponse.resolve(response(401, {}));
+    await vi.waitFor(() => expect(refreshRequests(harness)).toHaveLength(1));
+
+    caller.abort();
+    await expect(first).rejects.toMatchObject({ name: 'AbortError' });
+    refreshGate.resolve(harness.tokenTransport.result);
+    await expect(second).resolves.toMatchObject({ status: 200 });
+    expect(refreshRequests(harness)).toHaveLength(1);
+  });
+
+  it('performs terminal cleanup for a retry 401 without issuing another refresh', async () => {
+    let currentNow = NOW;
+    const harness = makeHarness({ now: () => currentNow });
+    await authenticateWithExpiry(harness, currentNow + 1_000, currentNow);
+    prepareSuccessfulRefresh(harness, {
+      claimExpirySeconds: Math.ceil((currentNow + 3_600_000) / 1_000),
+    });
+    const initialResponse = deferred<Response>();
+    let featureCalls = 0;
+    harness.sessionFetch.mockImplementation(async (target) => {
+      if (String(target).endsWith('/srs/stats')) {
+        featureCalls += 1;
+        return featureCalls === 1 ? initialResponse.promise : response(401, {});
+      }
+      return response(200, {
+        authenticated: true,
+        user: { userId: 'user-123', email: 'person@example.com' },
+      });
+    });
+
+    const request = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
+    await vi.waitFor(() => expect(featureCalls).toBe(1));
+    currentNow += 2_000;
+    initialResponse.resolve(response(401, {}));
+
+    await expect(request).resolves.toMatchObject({ status: 401 });
+    expect(refreshRequests(harness)).toHaveLength(1);
+    expect(harness.sessionStore.clearCalls).toBe(1);
+  });
+
   it('rejects a stale-generation 401 without cleanup', async () => {
     const harness = makeHarness();
     await authenticate(harness);

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -3631,6 +3631,8 @@ describe('authenticated feature transport', () => {
       '/api/srs/stats',
       '../secret',
       '%2e%2e/secret',
+      '%2e%2e%2fsecret',
+      'srs%2f..%2fsecret',
       String.raw`..\secret`,
       'srs/stats#fragment',
     ]) {
@@ -3722,6 +3724,26 @@ describe('authenticated feature transport', () => {
     await expect(request).rejects.toMatchObject({ name: 'AbortError' });
   });
 
+  it('preserves the original caller abort when its init signal is replaced in flight', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    const original = new AbortController();
+    const replacement = new AbortController();
+    const init = { signal: original.signal };
+    harness.sessionFetch.mockImplementationOnce(
+      (_url, fetchInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          fetchInit?.signal?.addEventListener('abort', () => reject(new Error('original aborted')));
+        }),
+    );
+
+    const request = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats', init });
+    init.signal = replacement.signal;
+    original.abort();
+
+    await expect(request).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
   it('maps the bounded feature timeout to request_timeout', async () => {
     const harness = makeHarness();
     await authenticate(harness);
@@ -3742,6 +3764,47 @@ describe('authenticated feature transport', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('keeps a timeout classified as request_timeout when the caller replaces its signal', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    const original = new AbortController();
+    const replacement = new AbortController();
+    replacement.abort();
+    const init = { signal: original.signal };
+    vi.useFakeTimers();
+    try {
+      harness.sessionFetch.mockImplementationOnce(
+        (_url, fetchInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            fetchInit?.signal?.addEventListener('abort', () => reject(new Error('timeout')));
+          }),
+      );
+
+      const request = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats', init });
+      const expected = expect(request).rejects.toMatchObject({ code: 'request_timeout' });
+      init.signal = replacement.signal;
+      await vi.advanceTimersByTimeAsync(MOBILE_AUTH_NETWORK_TIMEOUT_MS);
+
+      await expected;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects feature transport once disposal has been requested', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    const disposing = harness.coordinator.dispose();
+
+    await expect(
+      harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' }),
+    ).rejects.toMatchObject({
+      code: 'session_unavailable',
+    });
+    await disposing;
+    expect(harness.sessionFetch).toHaveBeenCalledOnce();
   });
 
   it('propagates raw fetch rejection without mutating auth state', async () => {

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -3659,6 +3659,24 @@ describe('authenticated feature transport', () => {
     },
   );
 
+  it.each([
+    ['name', { 'Invalid Header Name': 'value' }],
+    ['value', { 'X-Feature': 'value\nInjected: secret' }],
+  ])('normalizes an invalid header %s before network activity', async (_kind, headers) => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    const before = harness.sessionFetch.mock.calls.length;
+
+    await expect(
+      harness.coordinator.requestAuthenticatedApi({
+        path: 'srs/stats',
+        init: { headers },
+      }),
+    ).rejects.toMatchObject({ code: 'invalid_request_headers' });
+
+    expect(harness.sessionFetch).toHaveBeenCalledTimes(before);
+  });
+
   it.each(['https://vela.example/api', 'https://vela.example/api///'])(
     'normalizes %s before resolving a feature path',
     async (apiUrl) => {

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -4030,6 +4030,140 @@ describe('authenticated feature transport', () => {
     await signingOut;
   });
 
+  it('reports retryable recovery when a pending candidate makes queueRefresh a no-op', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    try {
+      const harness = makeHarness({ now: () => Date.now() });
+      await authenticateWithExpiry(harness, NOW + 120_000);
+      harness.sessionFetch.mockClear();
+      prepareSuccessfulRefresh(harness, {
+        claimExpirySeconds: 10_000,
+        rotatedRefreshToken: 'SECRET-pending-refresh-token',
+      });
+      harness.sessionStore.saveFailure = new Error('pending candidate');
+      const featureResponse = deferred<Response>();
+      harness.sessionFetch.mockImplementation(async (target) =>
+        String(target).endsWith('/srs/stats')
+          ? featureResponse.promise
+          : response(200, {
+              authenticated: true,
+              user: { userId: 'user-123', email: 'person@example.com' },
+            }),
+      );
+
+      const request = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
+      await vi.waitFor(() => expect(harness.sessionFetch).toHaveBeenCalledOnce());
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(harness.coordinator.state.retryAction).toBe('persist');
+      await vi.advanceTimersByTimeAsync(60_000);
+      featureResponse.resolve(response(401, {}));
+
+      await expect(request).rejects.toMatchObject({ code: 'session_recovery_pending' });
+      expect(refreshRequests(harness)).toHaveLength(1);
+      expect(harness.sessionStore.clearCalls).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retries after verified same-user generation promotion', async () => {
+    let currentNow = NOW;
+    const harness = makeHarness({ now: () => currentNow });
+    await authenticateWithExpiry(harness, currentNow + 120_000, currentNow);
+    harness.sessionFetch.mockClear();
+    prepareSuccessfulRefresh(harness, {
+      claimExpirySeconds: Math.ceil((currentNow + 3_600_000) / 1_000),
+    });
+    const featureResponse = deferred<Response>();
+    let featureCalls = 0;
+    harness.sessionFetch.mockImplementation(async (target) => {
+      if (String(target).endsWith('/srs/stats')) {
+        featureCalls += 1;
+        return featureCalls === 1 ? featureResponse.promise : response(200, {});
+      }
+      return response(200, {
+        authenticated: true,
+        user: { userId: 'user-123', email: 'person@example.com' },
+      });
+    });
+
+    const request = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
+    await vi.waitFor(() => expect(featureCalls).toBe(1));
+    currentNow += 121_000;
+    featureResponse.resolve(response(401, {}));
+
+    await expect(request).resolves.toMatchObject({ status: 200 });
+    expect(refreshRequests(harness)).toHaveLength(1);
+    expect(featureCalls).toBe(2);
+  });
+
+  it('returns session_changed when identity replacement supersedes waiting recovery', async () => {
+    let currentNow = NOW;
+    const harness = makeHarness({ now: () => currentNow });
+    await authenticateWithExpiry(harness, currentNow + 120_000, currentNow);
+    harness.sessionFetch.mockClear();
+    const refreshGate = deferred<{ status: number; data: unknown }>();
+    harness.tokenTransport.gate = refreshGate.promise;
+    const featureResponse = deferred<Response>();
+    harness.sessionFetch.mockImplementation(async (target) =>
+      String(target).endsWith('/srs/stats')
+        ? featureResponse.promise
+        : response(200, {
+            authenticated: true,
+            user: { userId: 'user-123', email: 'person@example.com' },
+          }),
+    );
+
+    const request = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
+    const expected = expect(request).rejects.toMatchObject({ code: 'session_changed' });
+    await vi.waitFor(() => expect(harness.sessionFetch).toHaveBeenCalledOnce());
+    currentNow += 121_000;
+    featureResponse.resolve(response(401, {}));
+    await vi.waitFor(() => expect(refreshRequests(harness)).toHaveLength(1));
+    const signingOut = harness.coordinator.signOut();
+    refreshGate.resolve(harness.tokenTransport.result);
+    await signingOut;
+    harness.tokenTransport.gate = undefined;
+    await harness.coordinator.startSignIn();
+    const replacement = harness.preferences.transaction();
+    harness.prepareSuccessfulExchange(replacement);
+    await harness.coordinator.completeCallback(callback(replacement));
+
+    await expected;
+  });
+
+  it('does not wait behind the feature request that initiated recovery', async () => {
+    let currentNow = NOW;
+    const harness = makeHarness({ now: () => currentNow });
+    await authenticateWithExpiry(harness, currentNow + 120_000, currentNow);
+    harness.sessionFetch.mockClear();
+    prepareSuccessfulRefresh(harness, {
+      claimExpirySeconds: Math.ceil((currentNow + 3_600_000) / 1_000),
+    });
+    const featureResponse = deferred<Response>();
+    let featureCalls = 0;
+    harness.sessionFetch.mockImplementation(async (target) => {
+      if (String(target).endsWith('/srs/stats')) {
+        featureCalls += 1;
+        return featureCalls === 1 ? featureResponse.promise : response(200, {});
+      }
+      return response(200, {
+        authenticated: true,
+        user: { userId: 'user-123', email: 'person@example.com' },
+      });
+    });
+
+    const request = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
+    await vi.waitFor(() => expect(featureCalls).toBe(1));
+    currentNow += 121_000;
+    featureResponse.resolve(response(401, {}));
+    await vi.waitFor(() => expect(refreshRequests(harness)).toHaveLength(1));
+
+    await expect(request).resolves.toMatchObject({ status: 200 });
+    expect(featureCalls).toBe(2);
+  });
+
   it('detaches an aborted caller while its peer completes the shared recovery', async () => {
     let currentNow = NOW;
     const harness = makeHarness({ now: () => currentNow });

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -3939,6 +3939,97 @@ describe('authenticated feature transport', () => {
     expect(harness.sessionStore.clearCalls).toBe(0);
   });
 
+  it('treats invalid-grant cleanup owned by expired-token recovery as terminal', async () => {
+    let currentNow = NOW;
+    const harness = makeHarness({ now: () => currentNow });
+    await authenticateWithExpiry(harness, currentNow + 120_000, currentNow);
+    harness.sessionFetch.mockClear();
+    harness.tokenTransport.result = { status: 400, data: { error: 'invalid_grant' } };
+    const featureResponse = deferred<Response>();
+    harness.sessionFetch.mockImplementation(async (target) =>
+      String(target).endsWith('/srs/stats')
+        ? featureResponse.promise
+        : response(200, {
+            authenticated: true,
+            user: { userId: 'user-123', email: 'person@example.com' },
+          }),
+    );
+
+    const request = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
+    await vi.waitFor(() => expect(harness.sessionFetch).toHaveBeenCalledOnce());
+    currentNow += 121_000;
+    featureResponse.resolve(response(401, {}));
+
+    await expect(request).resolves.toMatchObject({ status: 401 });
+    expect(refreshRequests(harness)).toHaveLength(1);
+    expect(harness.sessionStore.clearCalls).toBe(1);
+  });
+
+  it('joins an already-running proactive refresh after an expired-token 401', async () => {
+    let currentNow = NOW;
+    const harness = makeHarness({ now: () => currentNow });
+    await authenticateWithExpiry(harness, currentNow + 120_000, currentNow);
+    harness.sessionFetch.mockClear();
+    prepareSuccessfulRefresh(harness, {
+      claimExpirySeconds: Math.ceil((currentNow + 3_600_000) / 1_000),
+    });
+    const refreshGate = deferred<{ status: number; data: unknown }>();
+    harness.tokenTransport.gate = refreshGate.promise;
+    const featureResponse = deferred<Response>();
+    let featureCalls = 0;
+    harness.sessionFetch.mockImplementation(async (target) => {
+      if (String(target).endsWith('/srs/stats')) {
+        featureCalls += 1;
+        return featureCalls === 1 ? featureResponse.promise : response(200, {});
+      }
+      return response(200, {
+        authenticated: true,
+        user: { userId: 'user-123', email: 'person@example.com' },
+      });
+    });
+
+    const request = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
+    await vi.waitFor(() => expect(featureCalls).toBe(1));
+    currentNow += 61_000;
+    harness.app.emitState(true);
+    await vi.waitFor(() => expect(refreshRequests(harness)).toHaveLength(1));
+    currentNow += 60_000;
+    featureResponse.resolve(response(401, {}));
+    refreshGate.resolve(harness.tokenTransport.result);
+
+    await expect(request).resolves.toMatchObject({ status: 200 });
+    expect(refreshRequests(harness)).toHaveLength(1);
+  });
+
+  it('returns session_changed when sign-out supersedes a waiting expired-token recovery', async () => {
+    let currentNow = NOW;
+    const harness = makeHarness({ now: () => currentNow });
+    await authenticateWithExpiry(harness, currentNow + 120_000, currentNow);
+    harness.sessionFetch.mockClear();
+    const refreshGate = deferred<{ status: number; data: unknown }>();
+    harness.tokenTransport.gate = refreshGate.promise;
+    const featureResponse = deferred<Response>();
+    harness.sessionFetch.mockImplementation(async (target) =>
+      String(target).endsWith('/srs/stats')
+        ? featureResponse.promise
+        : response(200, {
+            authenticated: true,
+            user: { userId: 'user-123', email: 'person@example.com' },
+          }),
+    );
+
+    const request = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
+    await vi.waitFor(() => expect(harness.sessionFetch).toHaveBeenCalledOnce());
+    currentNow += 121_000;
+    featureResponse.resolve(response(401, {}));
+    await vi.waitFor(() => expect(refreshRequests(harness)).toHaveLength(1));
+    const signingOut = harness.coordinator.signOut();
+    refreshGate.resolve(harness.tokenTransport.result);
+
+    await expect(request).rejects.toMatchObject({ code: 'session_changed' });
+    await signingOut;
+  });
+
   it('detaches an aborted caller while its peer completes the shared recovery', async () => {
     let currentNow = NOW;
     const harness = makeHarness({ now: () => currentNow });
@@ -3988,11 +4079,12 @@ describe('authenticated feature transport', () => {
       claimExpirySeconds: Math.ceil((currentNow + 3_600_000) / 1_000),
     });
     const initialResponse = deferred<Response>();
+    const retryResponse = deferred<Response>();
     let featureCalls = 0;
     harness.sessionFetch.mockImplementation(async (target) => {
       if (String(target).endsWith('/srs/stats')) {
         featureCalls += 1;
-        return featureCalls === 1 ? initialResponse.promise : response(401, {});
+        return featureCalls === 1 ? initialResponse.promise : retryResponse.promise;
       }
       return response(200, {
         authenticated: true,
@@ -4004,6 +4096,9 @@ describe('authenticated feature transport', () => {
     await vi.waitFor(() => expect(featureCalls).toBe(1));
     currentNow += 2_000;
     initialResponse.resolve(response(401, {}));
+    await vi.waitFor(() => expect(featureCalls).toBe(2));
+    currentNow += 3_601_000;
+    retryResponse.resolve(response(401, {}));
 
     await expect(request).resolves.toMatchObject({ status: 401 });
     expect(refreshRequests(harness)).toHaveLength(1);

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -4099,7 +4099,11 @@ describe('authenticated feature transport', () => {
   });
 
   it('returns session_changed when identity replacement supersedes waiting recovery', async () => {
+    // Direct active-identity mutation is not a coordinator operation. The
+    // supported replacement boundary is local sign-out followed by a fresh,
+    // distinct-user OAuth session.
     let currentNow = NOW;
+    let replacementActive = false;
     const harness = makeHarness({ now: () => currentNow });
     await authenticateWithExpiry(harness, currentNow + 120_000, currentNow);
     harness.sessionFetch.mockClear();
@@ -4111,7 +4115,10 @@ describe('authenticated feature transport', () => {
         ? featureResponse.promise
         : response(200, {
             authenticated: true,
-            user: { userId: 'user-123', email: 'person@example.com' },
+            user: {
+              userId: replacementActive ? 'user-456' : 'user-123',
+              email: 'person@example.com',
+            },
           }),
     );
 
@@ -4124,13 +4131,30 @@ describe('authenticated feature transport', () => {
     const signingOut = harness.coordinator.signOut();
     refreshGate.resolve(harness.tokenTransport.result);
     await signingOut;
+    // The harness transaction store uses NOW as its persistence clock; reset
+    // the injected coordinator clock before beginning the replacement flow.
+    currentNow = NOW;
     harness.tokenTransport.gate = undefined;
     await harness.coordinator.startSignIn();
     const replacement = harness.preferences.transaction();
-    harness.prepareSuccessfulExchange(replacement);
+    replacementActive = true;
+    harness.tokenTransport.result = {
+      status: 200,
+      data: {
+        access_token: 'SECRET-replacement-access-token',
+        id_token: idToken(replacement, { sub: 'user-456' }),
+        refresh_token: 'SECRET-replacement-refresh-token',
+        expires_in: 3_600,
+      },
+    };
+    await harness.persist(replacement);
     await harness.coordinator.completeCallback(callback(replacement));
 
     await expected;
+    expect(harness.coordinator.state).toMatchObject({
+      phase: 'authenticated',
+      user: { userId: 'user-456', email: 'person@example.com' },
+    });
   });
 
   it('does not wait behind the feature request that initiated recovery', async () => {

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -3619,6 +3619,209 @@ describe('session verification', () => {
   });
 });
 
+describe('authenticated feature transport', () => {
+  it('rejects path escapes before network activity', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    const before = harness.sessionFetch.mock.calls.length;
+
+    for (const path of [
+      'https://evil.example/steal',
+      '//evil.example/steal',
+      '/api/srs/stats',
+      '../secret',
+      '%2e%2e/secret',
+      String.raw`..\secret`,
+      'srs/stats#fragment',
+    ]) {
+      await expect(harness.coordinator.requestAuthenticatedApi({ path })).rejects.toMatchObject({
+        code: 'invalid_request_path',
+      });
+    }
+
+    expect(harness.sessionFetch).toHaveBeenCalledTimes(before);
+  });
+
+  it.each(['Authorization', 'authorization', 'AUTHORIZATION', 'AuThOrIzAtIoN'])(
+    'rejects caller-owned %s',
+    async (header) => {
+      const harness = makeHarness();
+      await authenticate(harness);
+
+      await expect(
+        harness.coordinator.requestAuthenticatedApi({
+          path: 'srs/stats',
+          init: { headers: { [header]: 'Bearer attacker' } },
+        }),
+      ).rejects.toMatchObject({ code: 'invalid_request_headers' });
+    },
+  );
+
+  it.each(['https://vela.example/api', 'https://vela.example/api///'])(
+    'normalizes %s before resolving a feature path',
+    async (apiUrl) => {
+      const harness = makeHarness({ authConfig: { ...config, apiUrl } });
+      await authenticate(harness);
+      harness.sessionFetch.mockClear();
+      harness.sessionFetch.mockResolvedValueOnce(response(200, {}));
+
+      await harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
+
+      expect(String(harness.sessionFetch.mock.calls[0]?.[0])).toBe(
+        'https://vela.example/api/srs/stats',
+      );
+    },
+  );
+
+  it('rejects a resolved path outside the API prefix', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    const before = harness.sessionFetch.mock.calls.length;
+
+    await expect(
+      harness.coordinator.requestAuthenticatedApi({ path: '../api-evil/secret' }),
+    ).rejects.toMatchObject({ code: 'invalid_request_path' });
+
+    expect(harness.sessionFetch).toHaveBeenCalledTimes(before);
+  });
+
+  it('owns exactly one current Authorization header', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    harness.sessionFetch.mockClear();
+    harness.sessionFetch.mockResolvedValueOnce(response(200, {}));
+
+    await harness.coordinator.requestAuthenticatedApi({
+      path: 'srs/stats',
+      init: { headers: { 'X-Feature': 'due-reviews' } },
+    });
+
+    expect(harness.sessionFetch).toHaveBeenCalledOnce();
+    const headers = new Headers(harness.sessionFetch.mock.calls[0]?.[1]?.headers);
+    expect(headers.get('Authorization')).toBe(`Bearer ${idToken(activeTransaction)}`);
+    expect(headers.get('X-Feature')).toBe('due-reviews');
+  });
+
+  it('preserves a caller abort as AbortError', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    const caller = new AbortController();
+    harness.sessionFetch.mockImplementationOnce(
+      (_url, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(new Error('transport aborted')));
+        }),
+    );
+
+    const request = harness.coordinator.requestAuthenticatedApi({
+      path: 'srs/stats',
+      init: { signal: caller.signal },
+    });
+    caller.abort();
+
+    await expect(request).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('maps the bounded feature timeout to request_timeout', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    vi.useFakeTimers();
+    try {
+      harness.sessionFetch.mockImplementationOnce(
+        (_url, init) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => reject(new Error('timeout')));
+          }),
+      );
+
+      const request = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
+      const expected = expect(request).rejects.toMatchObject({ code: 'request_timeout' });
+      await vi.advanceTimersByTimeAsync(MOBILE_AUTH_NETWORK_TIMEOUT_MS);
+
+      await expected;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('propagates raw fetch rejection without mutating auth state', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    const before = { ...harness.coordinator.state };
+    const failure = new Error('feature transport failed');
+    harness.sessionFetch.mockRejectedValueOnce(failure);
+
+    await expect(harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' })).rejects.toBe(
+      failure,
+    );
+
+    expect(harness.coordinator.state).toEqual(before);
+  });
+
+  it.each([200, 500])('returns a non-401 response after refresh promotion (%i)', async (status) => {
+    let currentNow = Date.now();
+    const harness = makeHarness({ now: () => currentNow });
+    await authenticateWithExpiry(harness, currentNow + 30_000, currentNow);
+    harness.tokenTransport.result = {
+      status: 200,
+      data: {
+        access_token: 'SECRET-refreshed-access-token',
+        id_token: refreshedIdToken({ exp: Math.ceil((currentNow + 3_600_000) / 1_000) }),
+        expires_in: 3_600,
+      },
+    };
+    harness.sessionFetch.mockClear();
+    const featureResponse = deferred<Response>();
+    harness.sessionFetch.mockImplementation(async (target) => {
+      if (String(target).endsWith('/srs/stats')) return featureResponse.promise;
+      return response(200, {
+        authenticated: true,
+        user: { userId: 'user-123', email: null },
+      });
+    });
+
+    const request = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
+    await vi.waitFor(() => expect(harness.sessionFetch).toHaveBeenCalledOnce());
+    harness.app.emitState(true);
+    await vi.waitFor(() => expect(refreshRequests(harness)).toHaveLength(1));
+    await harness.flush();
+    featureResponse.resolve(response(status, {}));
+
+    await expect(request).resolves.toMatchObject({ status });
+  });
+
+  it('rejects a stale-generation 401 without cleanup', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    harness.sessionFetch.mockClear();
+    const featureResponse = deferred<Response>();
+    harness.sessionFetch.mockImplementationOnce(async () => featureResponse.promise);
+
+    const request = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
+    await vi.waitFor(() => expect(harness.sessionFetch).toHaveBeenCalledOnce());
+    await harness.coordinator.signOut();
+    featureResponse.resolve(response(401, {}));
+
+    await expect(request).rejects.toMatchObject({ code: 'session_changed' });
+    expect(harness.sessionStore.clearCalls).toBe(1);
+  });
+
+  it('does not let a pending feature fetch block sign-out or disposal', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    const featureResponse = deferred<Response>();
+    harness.sessionFetch.mockImplementationOnce(async () => featureResponse.promise);
+
+    const request = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
+    await vi.waitFor(() => expect(harness.sessionFetch).toHaveBeenCalledTimes(2));
+    await expect(harness.coordinator.retryCurrentOperation()).resolves.toBeUndefined();
+    await expect(harness.coordinator.signOut()).resolves.toBeUndefined();
+    await expect(harness.coordinator.dispose()).resolves.toBeUndefined();
+    featureResponse.resolve(response(200, {}));
+    await expect(request).resolves.toMatchObject({ status: 200 });
+  });
+});
+
 describe('serialization, disposal, and secret handling', () => {
   it('serializes duplicate callback completion so code exchange happens once', async () => {
     const tokenResponse = deferred<{ status: number; data: unknown }>();
@@ -3790,6 +3993,18 @@ describe('cross-boundary secret leakage regressions', () => {
       expectNoSecretLeak({
         consoleCalls: [],
         preferenceCalls: [],
+        renderedText: '',
+      }),
+    ).toThrow();
+  });
+
+  it('rejects feature authorization and rejected-path sentinels from every presentation surface', () => {
+    expect(() =>
+      expectNoSecretLeak({
+        consoleCalls: [],
+        preferenceCalls: [],
+        errorMessages: ['Bearer SECRET-caller-authorization'],
+        jsonSnapshots: [JSON.stringify({ path: 'https://evil.example/SECRET-rejected-path' })],
         renderedText: '',
       }),
     ).toThrow();

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -388,6 +388,7 @@ export function createMobileAuthCoordinator(
   async function observeFeatureRefresh(
     owner: ActiveSession,
     generation: number,
+    recovery: FeatureUnauthorizedRecovery,
   ): Promise<FeatureRefreshObservation> {
     await queueRefresh({ requireDue: false, owner, generation });
 
@@ -400,7 +401,7 @@ export function createMobileAuthCoordinator(
       return { kind: 'promoted', owner: active, generation: activeBundleGeneration };
     }
 
-    if (featureUnauthorizedRecovery?.terminalCleanupStarted === true) {
+    if (recovery.terminalCleanupStarted) {
       return { kind: 'terminal' };
     }
 
@@ -413,18 +414,33 @@ export function createMobileAuthCoordinator(
 
   function getOrCreateFeatureUnauthorizedRecovery(
     snapshot: AuthenticatedFeatureSnapshot,
+    forceTerminalCleanup = false,
   ): Promise<FeatureUnauthorizedRecoveryResult> {
     const existing = featureUnauthorizedRecovery;
     if (existing?.owner === snapshot.owner && existing.generation === snapshot.generation) {
       return existing.promise;
     }
 
-    let record!: FeatureUnauthorizedRecovery;
-    const promise = (async (): Promise<FeatureUnauthorizedRecoveryResult> => {
+    let resolve!: (result: FeatureUnauthorizedRecoveryResult) => void;
+    let reject!: (error: unknown) => void;
+    const promise = new Promise<FeatureUnauthorizedRecoveryResult>(
+      (resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+      },
+    );
+    const record: FeatureUnauthorizedRecovery = {
+      owner: snapshot.owner,
+      generation: snapshot.generation,
+      terminalCleanupStarted: false,
+      promise,
+    };
+    featureUnauthorizedRecovery = record;
+    void (async () => {
       try {
         let observation: FeatureRefreshObservation;
-        if (snapshot.expiresAt <= dependencies.now()) {
-          observation = await observeFeatureRefresh(snapshot.owner, snapshot.generation);
+        if (!forceTerminalCleanup && snapshot.expiresAt <= dependencies.now()) {
+          observation = await observeFeatureRefresh(snapshot.owner, snapshot.generation, record);
         } else {
           let cleanupStarted = false;
           await serialize(async () => {
@@ -443,33 +459,31 @@ export function createMobileAuthCoordinator(
 
         switch (observation.kind) {
           case 'promoted':
-            return { kind: 'refreshed' };
+            resolve({ kind: 'refreshed' });
+            return;
           case 'terminal':
           case 'superseded':
           case 'retryable_failure':
-            return observation;
+            resolve(observation);
+            return;
         }
+      } catch (error) {
+        reject(error);
       } finally {
         if (featureUnauthorizedRecovery === record) {
           featureUnauthorizedRecovery = undefined;
         }
       }
     })();
-    record = {
-      owner: snapshot.owner,
-      generation: snapshot.generation,
-      terminalCleanupStarted: false,
-      promise,
-    };
-    featureUnauthorizedRecovery = record;
     return promise;
   }
 
   async function waitForFeatureRecoveryOrCallerAbort(
     snapshot: AuthenticatedFeatureSnapshot,
     signal: AbortSignal | undefined,
+    forceTerminalCleanup = false,
   ): Promise<FeatureUnauthorizedRecoveryResult> {
-    const recovery = getOrCreateFeatureUnauthorizedRecovery(snapshot);
+    const recovery = getOrCreateFeatureUnauthorizedRecovery(snapshot, forceTerminalCleanup);
     if (!signal) {
       return recovery;
     }
@@ -530,7 +544,11 @@ export function createMobileAuthCoordinator(
     if (active !== snapshot.owner || activeBundleGeneration !== snapshot.generation) {
       throw new MobileAuthenticatedApiRequestError('session_changed');
     }
-    const recovery = await waitForFeatureRecoveryOrCallerAbort(snapshot, request.init?.signal);
+    const recovery = await waitForFeatureRecoveryOrCallerAbort(
+      snapshot,
+      request.init?.signal,
+      !allowRefreshRetry,
+    );
     switch (recovery.kind) {
       case 'refreshed':
         if (!allowRefreshRetry) {

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -79,6 +79,25 @@ type AuthenticatedFeatureSnapshot = {
   userId: string;
 };
 
+type FeatureRefreshObservation =
+  | { kind: 'promoted'; owner: ActiveSession; generation: number }
+  | { kind: 'terminal' }
+  | { kind: 'superseded' }
+  | { kind: 'retryable_failure' };
+
+type FeatureUnauthorizedRecoveryResult =
+  | { kind: 'refreshed' }
+  | { kind: 'terminal' }
+  | { kind: 'superseded' }
+  | { kind: 'retryable_failure' };
+
+type FeatureUnauthorizedRecovery = {
+  owner: ActiveSession;
+  generation: number;
+  terminalCleanupStarted: boolean;
+  promise: Promise<FeatureUnauthorizedRecoveryResult>;
+};
+
 type CleanupContext =
   | { kind: 'signOut' }
   | { kind: 'terminalSession' }
@@ -287,6 +306,7 @@ export function createMobileAuthCoordinator(
   let restoreRefreshToken: string | undefined;
   let cleanupContext: CleanupContext | undefined;
   let signOutPromise: Promise<void> | undefined;
+  let featureUnauthorizedRecovery: FeatureUnauthorizedRecovery | undefined;
   let initialized = false;
   let disposed = false;
   let disposalRequested = false;
@@ -365,8 +385,121 @@ export function createMobileAuthCoordinator(
     }
   }
 
-  async function requestAuthenticatedApi(
+  async function observeFeatureRefresh(
+    owner: ActiveSession,
+    generation: number,
+  ): Promise<FeatureRefreshObservation> {
+    await queueRefresh({ requireDue: false, owner, generation });
+
+    if (
+      active !== undefined &&
+      active.user.userId === owner.user.userId &&
+      activeBundleGeneration > generation &&
+      activeSessionIsUsable()
+    ) {
+      return { kind: 'promoted', owner: active, generation: activeBundleGeneration };
+    }
+
+    if (featureUnauthorizedRecovery?.terminalCleanupStarted === true) {
+      return { kind: 'terminal' };
+    }
+
+    if (unavailable() || active !== owner || activeBundleGeneration !== generation) {
+      return { kind: 'superseded' };
+    }
+
+    return { kind: 'retryable_failure' };
+  }
+
+  function getOrCreateFeatureUnauthorizedRecovery(
+    snapshot: AuthenticatedFeatureSnapshot,
+  ): Promise<FeatureUnauthorizedRecoveryResult> {
+    const existing = featureUnauthorizedRecovery;
+    if (existing?.owner === snapshot.owner && existing.generation === snapshot.generation) {
+      return existing.promise;
+    }
+
+    let record!: FeatureUnauthorizedRecovery;
+    const promise = (async (): Promise<FeatureUnauthorizedRecoveryResult> => {
+      try {
+        let observation: FeatureRefreshObservation;
+        if (snapshot.expiresAt <= dependencies.now()) {
+          observation = await observeFeatureRefresh(snapshot.owner, snapshot.generation);
+        } else {
+          let cleanupStarted = false;
+          await serialize(async () => {
+            if (
+              unavailable() ||
+              active !== snapshot.owner ||
+              activeBundleGeneration !== snapshot.generation
+            ) {
+              return;
+            }
+            cleanupStarted = true;
+            await terminalSessionCleanupUnlocked();
+          });
+          observation = cleanupStarted ? { kind: 'terminal' } : { kind: 'superseded' };
+        }
+
+        switch (observation.kind) {
+          case 'promoted':
+            return { kind: 'refreshed' };
+          case 'terminal':
+          case 'superseded':
+          case 'retryable_failure':
+            return observation;
+        }
+      } finally {
+        if (featureUnauthorizedRecovery === record) {
+          featureUnauthorizedRecovery = undefined;
+        }
+      }
+    })();
+    record = {
+      owner: snapshot.owner,
+      generation: snapshot.generation,
+      terminalCleanupStarted: false,
+      promise,
+    };
+    featureUnauthorizedRecovery = record;
+    return promise;
+  }
+
+  async function waitForFeatureRecoveryOrCallerAbort(
+    snapshot: AuthenticatedFeatureSnapshot,
+    signal: AbortSignal | undefined,
+  ): Promise<FeatureUnauthorizedRecoveryResult> {
+    const recovery = getOrCreateFeatureUnauthorizedRecovery(snapshot);
+    if (!signal) {
+      return recovery;
+    }
+
+    return new Promise<FeatureUnauthorizedRecoveryResult>((resolve, reject) => {
+      const abort = () => {
+        signal.removeEventListener('abort', abort);
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+      };
+      signal.addEventListener('abort', abort, { once: true });
+      if (signal.aborted) {
+        abort();
+        return;
+      }
+      void recovery.then(
+        (result) => {
+          signal.removeEventListener('abort', abort);
+          resolve(result);
+        },
+        (error: unknown) => {
+          signal.removeEventListener('abort', abort);
+          reject(error);
+        },
+      );
+    });
+  }
+
+  async function requestAuthenticatedApiInternal(
     request: MobileAuthenticatedApiRequest,
+    allowRefreshRetry: boolean,
   ): Promise<Response> {
     // Resolve caller-controlled URL and headers before consulting any session
     // material, so malformed requests can never trigger a bearer fetch.
@@ -397,7 +530,24 @@ export function createMobileAuthCoordinator(
     if (active !== snapshot.owner || activeBundleGeneration !== snapshot.generation) {
       throw new MobileAuthenticatedApiRequestError('session_changed');
     }
-    return response;
+    const recovery = await waitForFeatureRecoveryOrCallerAbort(snapshot, request.init?.signal);
+    switch (recovery.kind) {
+      case 'refreshed':
+        if (!allowRefreshRetry) {
+          return response;
+        }
+        return requestAuthenticatedApiInternal(request, false);
+      case 'terminal':
+        return response;
+      case 'superseded':
+        throw new MobileAuthenticatedApiRequestError('session_changed');
+      case 'retryable_failure':
+        throw new MobileAuthenticatedApiRequestError('session_recovery_pending');
+    }
+  }
+
+  function requestAuthenticatedApi(request: MobileAuthenticatedApiRequest): Promise<Response> {
+    return requestAuthenticatedApiInternal(request, true);
   }
 
   const transitions = {
@@ -866,6 +1016,14 @@ export function createMobileAuthCoordinator(
           : 'initializing';
     const cleanupUser =
       cleanupPhase === 'authenticated' ? (state.user ?? active?.user ?? null) : null;
+    const activeRecovery = featureUnauthorizedRecovery;
+    if (
+      activeRecovery !== undefined &&
+      activeRecovery.owner === active &&
+      activeRecovery.generation === activeBundleGeneration
+    ) {
+      activeRecovery.terminalCleanupStarted = true;
+    }
     clearActiveSession();
     const cleanupGeneration = activeBundleGeneration;
     pendingCandidate = undefined;

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -355,12 +355,9 @@ export function createMobileAuthCoordinator(
   async function dispatchAuthenticatedFeatureAttempt(
     request: MobileAuthenticatedApiRequest,
     snapshot: AuthenticatedFeatureSnapshot,
+    target: URL,
+    headers: Headers,
   ): Promise<Response> {
-    const target = resolveMobileApiUrl(
-      normalizeMobileApiBaseUrl(dependencies.config.apiUrl),
-      request.path,
-    );
-    const headers = normalizeAuthenticatedRequestHeaders(request.init?.headers);
     headers.set('Accept', headers.get('Accept') ?? 'application/json');
     headers.set('Authorization', `Bearer ${snapshot.idToken}`);
 
@@ -469,7 +466,7 @@ export function createMobileAuthCoordinator(
     void (async () => {
       try {
         let observation: FeatureRefreshObservation;
-        if (!forceTerminalCleanup && snapshot.expiresAt <= dependencies.now()) {
+        if (snapshot.expiresAt <= dependencies.now()) {
           observation = await observeFeatureRefresh(snapshot.owner, snapshot.generation, record);
         } else {
           let cleanupStarted = false;
@@ -547,8 +544,11 @@ export function createMobileAuthCoordinator(
   ): Promise<Response> {
     // Resolve caller-controlled URL and headers before consulting any session
     // material, so malformed requests can never trigger a bearer fetch.
-    resolveMobileApiUrl(normalizeMobileApiBaseUrl(dependencies.config.apiUrl), request.path);
-    normalizeAuthenticatedRequestHeaders(request.init?.headers);
+    const target = resolveMobileApiUrl(
+      normalizeMobileApiBaseUrl(dependencies.config.apiUrl),
+      request.path,
+    );
+    const baseHeaders = normalizeAuthenticatedRequestHeaders(request.init?.headers);
 
     const owner = active;
     if (unavailable() || !owner || !activeSessionIsUsable() || !state.sessionUsable) {
@@ -563,8 +563,14 @@ export function createMobileAuthCoordinator(
     };
 
     // The physical fetch stays outside serialize(), so it cannot hold up
-    // sign-out, retries, or disposal while it is pending.
-    const response = await dispatchAuthenticatedFeatureAttempt(request, snapshot);
+    // sign-out, retries, or disposal while it is pending. A fresh Headers copy
+    // is passed per dispatch because the helper mutates it (Accept/Authorization).
+    const response = await dispatchAuthenticatedFeatureAttempt(
+      request,
+      snapshot,
+      target,
+      new Headers(baseHeaders),
+    );
     if (response.status !== 401) {
       return response;
     }

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -1,3 +1,4 @@
+/* global HeadersInit */
 import { reactive, readonly, type InjectionKey } from 'vue';
 import {
   MOBILE_OAUTH_CALLBACK_URI,
@@ -275,6 +276,20 @@ function resolveMobileApiUrl(base: URL, relativePath: string): URL {
   return resolved;
 }
 
+function normalizeAuthenticatedRequestHeaders(headersInit?: HeadersInit): Headers {
+  let headers: Headers;
+  try {
+    headers = new Headers(headersInit);
+  } catch (error) {
+    throw new MobileAuthenticatedApiRequestError('invalid_request_headers', { cause: error });
+  }
+
+  if (headers.has('authorization')) {
+    throw new MobileAuthenticatedApiRequestError('invalid_request_headers');
+  }
+  return headers;
+}
+
 export function createMobileAuthCoordinator(
   dependencies: MobileAuthCoordinatorDependencies,
 ): MobileAuthCoordinator {
@@ -345,10 +360,7 @@ export function createMobileAuthCoordinator(
       normalizeMobileApiBaseUrl(dependencies.config.apiUrl),
       request.path,
     );
-    const headers = new Headers(request.init?.headers);
-    if (headers.has('authorization')) {
-      throw new MobileAuthenticatedApiRequestError('invalid_request_headers');
-    }
+    const headers = normalizeAuthenticatedRequestHeaders(request.init?.headers);
     headers.set('Accept', headers.get('Accept') ?? 'application/json');
     headers.set('Authorization', `Bearer ${snapshot.idToken}`);
 
@@ -536,10 +548,7 @@ export function createMobileAuthCoordinator(
     // Resolve caller-controlled URL and headers before consulting any session
     // material, so malformed requests can never trigger a bearer fetch.
     resolveMobileApiUrl(normalizeMobileApiBaseUrl(dependencies.config.apiUrl), request.path);
-    const callerHeaders = new Headers(request.init?.headers);
-    if (callerHeaders.has('authorization')) {
-      throw new MobileAuthenticatedApiRequestError('invalid_request_headers');
-    }
+    normalizeAuthenticatedRequestHeaders(request.init?.headers);
 
     const owner = active;
     if (unavailable() || !owner || !activeSessionIsUsable() || !state.sessionUsable) {

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -417,8 +417,26 @@ export function createMobileAuthCoordinator(
     forceTerminalCleanup = false,
   ): Promise<FeatureUnauthorizedRecoveryResult> {
     const existing = featureUnauthorizedRecovery;
-    if (existing?.owner === snapshot.owner && existing.generation === snapshot.generation) {
+    if (
+      !forceTerminalCleanup &&
+      existing?.owner === snapshot.owner &&
+      existing.generation === snapshot.generation
+    ) {
       return existing.promise;
+    }
+
+    if (forceTerminalCleanup) {
+      return serialize(async (): Promise<FeatureUnauthorizedRecoveryResult> => {
+        if (
+          unavailable() ||
+          active !== snapshot.owner ||
+          activeBundleGeneration !== snapshot.generation
+        ) {
+          return { kind: 'superseded' };
+        }
+        await terminalSessionCleanupUnlocked();
+        return { kind: 'terminal' };
+      });
     }
 
     let resolve!: (result: FeatureUnauthorizedRecoveryResult) => void;

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -244,7 +244,7 @@ function resolveMobileApiUrl(base: URL, relativePath: string): URL {
     } catch {
       throw new MobileAuthenticatedApiRequestError('invalid_request_path');
     }
-    if (decoded === '.' || decoded === '..' || decoded.includes('\\')) {
+    if (decoded === '.' || decoded === '..' || decoded.includes('/') || decoded.includes('\\')) {
       throw new MobileAuthenticatedApiRequestError('invalid_request_path');
     }
   }
@@ -334,9 +334,10 @@ export function createMobileAuthCoordinator(
 
     const controller = new AbortController();
     let timeoutExpired = false;
+    const callerSignal = request.init?.signal;
     const onCallerAbort = () => controller.abort();
-    request.init?.signal?.addEventListener('abort', onCallerAbort, { once: true });
-    if (request.init?.signal?.aborted) {
+    callerSignal?.addEventListener('abort', onCallerAbort, { once: true });
+    if (callerSignal?.aborted) {
       controller.abort();
     }
     const timeout = setTimeout(() => {
@@ -351,7 +352,7 @@ export function createMobileAuthCoordinator(
         signal: controller.signal,
       });
     } catch (error) {
-      if (request.init?.signal?.aborted) {
+      if (callerSignal?.aborted) {
         throw new DOMException('The operation was aborted.', 'AbortError');
       }
       if (timeoutExpired) {
@@ -360,7 +361,7 @@ export function createMobileAuthCoordinator(
       throw error;
     } finally {
       clearTimeout(timeout);
-      request.init?.signal?.removeEventListener('abort', onCallerAbort);
+      callerSignal?.removeEventListener('abort', onCallerAbort);
     }
   }
 
@@ -376,7 +377,7 @@ export function createMobileAuthCoordinator(
     }
 
     const owner = active;
-    if (!owner || !activeSessionIsUsable() || !state.sessionUsable) {
+    if (unavailable() || !owner || !activeSessionIsUsable() || !state.sessionUsable) {
       throw new MobileAuthenticatedApiRequestError('session_unavailable');
     }
     const snapshot: AuthenticatedFeatureSnapshot = {

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -389,18 +389,25 @@ export function createMobileAuthCoordinator(
       }
       throw error;
     } finally {
+      // Clear the feature-level timeout but do NOT remove the caller abort
+      // listener. fetch() resolves when response headers arrive, yet the API
+      // client consumes response.json() only after this function returns.
+      // Removing the bridge here would disconnect the caller's deadline (and
+      // TanStack cancellation) from the underlying response body, allowing a
+      // stalled body to outlive the deadline or resolve after cancellation.
+      // The listener stays registered so caller aborts during body
+      // consumption still propagate to the fetch's abort signal; it is
+      // cleaned up when the caller signal is GC'd or the caller removes its
+      // own listeners.
       clearTimeout(timeout);
-      callerSignal?.removeEventListener('abort', onCallerAbort);
     }
   }
 
-  async function observeFeatureRefresh(
+  function classifyFeatureRefreshOutcome(
     owner: ActiveSession,
     generation: number,
     recovery: FeatureUnauthorizedRecovery,
-  ): Promise<FeatureRefreshObservation> {
-    await queueRefresh({ requireDue: false, owner, generation });
-
+  ): FeatureRefreshObservation {
     if (
       active !== undefined &&
       active.user.userId === owner.user.userId &&
@@ -419,6 +426,15 @@ export function createMobileAuthCoordinator(
     }
 
     return { kind: 'retryable_failure' };
+  }
+
+  async function observeFeatureRefresh(
+    owner: ActiveSession,
+    generation: number,
+    recovery: FeatureUnauthorizedRecovery,
+  ): Promise<FeatureRefreshObservation> {
+    await queueRefresh({ requireDue: false, owner, generation });
+    return classifyFeatureRefreshOutcome(owner, generation, recovery);
   }
 
   function getOrCreateFeatureUnauthorizedRecovery(
@@ -469,19 +485,40 @@ export function createMobileAuthCoordinator(
         if (snapshot.expiresAt <= dependencies.now()) {
           observation = await observeFeatureRefresh(snapshot.owner, snapshot.generation, record);
         } else {
-          let cleanupStarted = false;
-          await serialize(async () => {
-            if (
-              unavailable() ||
-              active !== snapshot.owner ||
-              activeBundleGeneration !== snapshot.generation
-            ) {
-              return;
-            }
-            cleanupStarted = true;
-            await terminalSessionCleanupUnlocked();
-          });
-          observation = cleanupStarted ? { kind: 'terminal' } : { kind: 'superseded' };
+          // A 401 can arrive while a proactive/manual refresh is already
+          // running and the captured token is still technically valid. Join
+          // that in-flight refresh before applying the expired-versus-still-
+          // valid decision. Without joining, a successful refresh yields
+          // session_changed (instead of a retry with the promoted bundle)
+          // and a transient refresh failure deletes the durable credential
+          // (converting a retryable failure into a forced sign-out).
+          const inFlightRefresh = refreshPromise;
+          if (
+            inFlightRefresh !== undefined &&
+            active === snapshot.owner &&
+            activeBundleGeneration === snapshot.generation
+          ) {
+            await inFlightRefresh;
+            observation = classifyFeatureRefreshOutcome(
+              snapshot.owner,
+              snapshot.generation,
+              record,
+            );
+          } else {
+            let cleanupStarted = false;
+            await serialize(async () => {
+              if (
+                unavailable() ||
+                active !== snapshot.owner ||
+                activeBundleGeneration !== snapshot.generation
+              ) {
+                return;
+              }
+              cleanupStarted = true;
+              await terminalSessionCleanupUnlocked();
+            });
+            observation = cleanupStarted ? { kind: 'terminal' } : { kind: 'superseded' };
+          }
         }
 
         switch (observation.kind) {

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -564,7 +564,7 @@ export function createMobileAuthCoordinator(
     }
     const recovery = await waitForFeatureRecoveryOrCallerAbort(
       snapshot,
-      request.init?.signal,
+      request.init?.signal ?? undefined,
       !allowRefreshRetry,
     );
     switch (recovery.kind) {

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -1,6 +1,7 @@
 import { reactive, readonly, type InjectionKey } from 'vue';
 import {
   MOBILE_OAUTH_CALLBACK_URI,
+  MobileAuthenticatedApiRequestError,
   assertMobileAuthState,
   type AuthorizationCodeTokenBundle,
   type MobileAppAdapter,
@@ -12,6 +13,7 @@ import {
   type MobileAuthRetryAction,
   type MobileAuthState,
   type MobileAuthUser,
+  type MobileAuthenticatedApiRequest,
   type MobileBrowserAdapter,
   type MobileOAuthConfig,
   type MobileTokenTransportAdapter,
@@ -67,6 +69,14 @@ type PendingCandidate =
 type ActiveSession = {
   bundle: OAuthTokenBundleBase & { refreshToken: string };
   user: MobileAuthUser;
+};
+
+type AuthenticatedFeatureSnapshot = {
+  owner: ActiveSession;
+  generation: number;
+  idToken: string;
+  expiresAt: number;
+  userId: string;
 };
 
 type CleanupContext =
@@ -206,8 +216,44 @@ function parseSessionUser(value: unknown): { userId: string; email: string | nul
   return { userId, email };
 }
 
-function sessionUrl(apiUrl: string): string {
-  return `${apiUrl.replace(/\/+$/u, '')}/auth/session`;
+function normalizeMobileApiBaseUrl(apiUrl: string): URL {
+  const base = new URL(apiUrl);
+  base.search = '';
+  base.hash = '';
+  base.pathname = `${base.pathname.replace(/\/+$/u, '')}/`;
+  return base;
+}
+
+function resolveMobileApiUrl(base: URL, relativePath: string): URL {
+  if (
+    relativePath.length === 0 ||
+    relativePath.startsWith('/') ||
+    relativePath.startsWith('\\') ||
+    relativePath.includes('\\') ||
+    relativePath.includes('#') ||
+    /^[a-z][a-z\d+.-]*:/iu.test(relativePath) ||
+    relativePath.startsWith('//')
+  ) {
+    throw new MobileAuthenticatedApiRequestError('invalid_request_path');
+  }
+
+  for (const segment of relativePath.split('/')) {
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(segment);
+    } catch {
+      throw new MobileAuthenticatedApiRequestError('invalid_request_path');
+    }
+    if (decoded === '.' || decoded === '..' || decoded.includes('\\')) {
+      throw new MobileAuthenticatedApiRequestError('invalid_request_path');
+    }
+  }
+
+  const resolved = new URL(relativePath, base);
+  if (resolved.origin !== base.origin || !resolved.pathname.startsWith(base.pathname)) {
+    throw new MobileAuthenticatedApiRequestError('invalid_request_path');
+  }
+  return resolved;
 }
 
 export function createMobileAuthCoordinator(
@@ -269,6 +315,88 @@ export function createMobileAuthCoordinator(
 
   function unavailable(): boolean {
     return disposed || disposalRequested;
+  }
+
+  async function dispatchAuthenticatedFeatureAttempt(
+    request: MobileAuthenticatedApiRequest,
+    snapshot: AuthenticatedFeatureSnapshot,
+  ): Promise<Response> {
+    const target = resolveMobileApiUrl(
+      normalizeMobileApiBaseUrl(dependencies.config.apiUrl),
+      request.path,
+    );
+    const headers = new Headers(request.init?.headers);
+    if (headers.has('authorization')) {
+      throw new MobileAuthenticatedApiRequestError('invalid_request_headers');
+    }
+    headers.set('Accept', headers.get('Accept') ?? 'application/json');
+    headers.set('Authorization', `Bearer ${snapshot.idToken}`);
+
+    const controller = new AbortController();
+    let timeoutExpired = false;
+    const onCallerAbort = () => controller.abort();
+    request.init?.signal?.addEventListener('abort', onCallerAbort, { once: true });
+    if (request.init?.signal?.aborted) {
+      controller.abort();
+    }
+    const timeout = setTimeout(() => {
+      timeoutExpired = true;
+      controller.abort();
+    }, MOBILE_AUTH_NETWORK_TIMEOUT_MS);
+
+    try {
+      return await dependencies.fetch(target, {
+        ...request.init,
+        headers,
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (request.init?.signal?.aborted) {
+        throw new DOMException('The operation was aborted.', 'AbortError');
+      }
+      if (timeoutExpired) {
+        throw new MobileAuthenticatedApiRequestError('request_timeout', { cause: error });
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+      request.init?.signal?.removeEventListener('abort', onCallerAbort);
+    }
+  }
+
+  async function requestAuthenticatedApi(
+    request: MobileAuthenticatedApiRequest,
+  ): Promise<Response> {
+    // Resolve caller-controlled URL and headers before consulting any session
+    // material, so malformed requests can never trigger a bearer fetch.
+    resolveMobileApiUrl(normalizeMobileApiBaseUrl(dependencies.config.apiUrl), request.path);
+    const callerHeaders = new Headers(request.init?.headers);
+    if (callerHeaders.has('authorization')) {
+      throw new MobileAuthenticatedApiRequestError('invalid_request_headers');
+    }
+
+    const owner = active;
+    if (!owner || !activeSessionIsUsable() || !state.sessionUsable) {
+      throw new MobileAuthenticatedApiRequestError('session_unavailable');
+    }
+    const snapshot: AuthenticatedFeatureSnapshot = {
+      owner,
+      generation: activeBundleGeneration,
+      idToken: owner.bundle.idToken,
+      expiresAt: owner.bundle.expiresAt,
+      userId: owner.user.userId,
+    };
+
+    // The physical fetch stays outside serialize(), so it cannot hold up
+    // sign-out, retries, or disposal while it is pending.
+    const response = await dispatchAuthenticatedFeatureAttempt(request, snapshot);
+    if (response.status !== 401) {
+      return response;
+    }
+    if (active !== snapshot.owner || activeBundleGeneration !== snapshot.generation) {
+      throw new MobileAuthenticatedApiRequestError('session_changed');
+    }
+    return response;
   }
 
   const transitions = {
@@ -874,14 +1002,20 @@ export function createMobileAuthCoordinator(
     try {
       let response: Response;
       try {
-        response = await dependencies.fetch(sessionUrl(dependencies.config.apiUrl), {
-          method: 'GET',
-          headers: {
-            Accept: 'application/json',
-            Authorization: `Bearer ${candidate.bundle.idToken}`,
+        response = await dependencies.fetch(
+          resolveMobileApiUrl(
+            normalizeMobileApiBaseUrl(dependencies.config.apiUrl),
+            'auth/session',
+          ).toString(),
+          {
+            method: 'GET',
+            headers: {
+              Accept: 'application/json',
+              Authorization: `Bearer ${candidate.bundle.idToken}`,
+            },
+            signal: controller.signal,
           },
-          signal: controller.signal,
-        });
+        );
       } catch {
         if (!candidateIsCurrent(candidate)) {
           return;
@@ -1842,6 +1976,7 @@ export function createMobileAuthCoordinator(
       unavailable()
         ? Promise.resolve()
         : serialize(() => completeCallbackUnlocked(url).then(() => undefined)),
+    requestAuthenticatedApi,
     retryCurrentOperation,
     signOut,
     dispose,

--- a/apps/vela-mobile/src/services/mobile-query-auth-isolation.test.ts
+++ b/apps/vela-mobile/src/services/mobile-query-auth-isolation.test.ts
@@ -151,4 +151,46 @@ describe('mobile query auth isolation', () => {
     await settle();
     expect(clear).toHaveBeenCalledOnce();
   });
+
+  it('skips the global clear when a successor session starts during delayed cancellation', async () => {
+    const { state, queryClient, stop } = install();
+    stops.push(stop);
+    let resolveCancellation!: () => void;
+    const cancellation = new Promise<void>((resolve) => {
+      resolveCancellation = resolve;
+    });
+    const clear = vi.spyOn(queryClient, 'clear');
+    vi.spyOn(queryClient, 'cancelQueries').mockReturnValue(cancellation);
+
+    // Sign-out begins: the watcher captures signOutClear = true and starts
+    // awaiting cancelQueries(). Cancellation is delayed.
+    Object.assign(state, { operation: 'signingOut', sessionUsable: false });
+    await nextTick();
+    expect(clear).not.toHaveBeenCalled();
+
+    // While cancellation is pending, sign-out completes and a successor
+    // user signs in, populating their own cache entry.
+    Object.assign(state, {
+      phase: 'signedOut',
+      operation: 'idle',
+      sessionUsable: false,
+      user: null,
+    });
+    await nextTick();
+    Object.assign(state, {
+      phase: 'authenticated',
+      operation: 'idle',
+      sessionUsable: true,
+      user: { userId: 'user-2', email: null },
+    });
+    queryClient.setQueryData(srsKeys.stats('user-2'), { due: 7 });
+    await nextTick();
+
+    // Now the delayed cancellation resolves. The stale signOutClear flag
+    // must NOT cause clear() to erase the successor's freshly seeded cache.
+    resolveCancellation();
+    await settle();
+    expect(clear).not.toHaveBeenCalled();
+    expect(queryClient.getQueryData(srsKeys.stats('user-2'))).toEqual({ due: 7 });
+  });
 });

--- a/apps/vela-mobile/src/services/mobile-query-auth-isolation.test.ts
+++ b/apps/vela-mobile/src/services/mobile-query-auth-isolation.test.ts
@@ -62,7 +62,7 @@ describe('mobile query auth isolation', () => {
     Object.assign(state, { operation: 'refreshing', sessionUsable: false });
     await settle();
 
-    expect(cancelQueries).toHaveBeenCalledOnce();
+    expect(cancelQueries).toHaveBeenCalledWith({ queryKey: srsKeys.stats('user-1') });
     expect(clear).not.toHaveBeenCalled();
     expect(queryClient.getQueryData(srsKeys.stats('user-1'))).toEqual({ due: 4 });
   });
@@ -248,5 +248,174 @@ describe('mobile query auth isolation', () => {
     expect(queryClient.getQueryData(srsKeys.stats('user-2'))).toEqual({ due: 9 });
     // Global clear must not have erased the successor's cache.
     expect(clear).not.toHaveBeenCalled();
+  });
+
+  it('does not clear a successor cache when a no-prior-user cleanup retry resumes after successor sign-in', async () => {
+    // Begin from a signed-out cleanup state with no prior user, so the
+    // watcher's previousUserId === null fallback is the reachable branch.
+    const state = reactive<MobileAuthState>({
+      phase: 'signedOut',
+      operation: 'cleaningUp',
+      sessionUsable: false,
+      errorCode: 'session_cleanup_failed',
+      retryAction: null,
+      notice: null,
+      user: null,
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const stop = installMobileQueryAuthIsolation({ state, queryClient });
+    stops.push(stop);
+
+    const realCancelQueries = queryClient.cancelQueries.bind(queryClient);
+    let resolveCancellation!: () => void;
+    const cancellation = new Promise<void>((resolve) => {
+      resolveCancellation = resolve;
+    });
+    const clear = vi.spyOn(queryClient, 'clear');
+    // Delay only unscoped (global) cancelQueries() — the buggy fallback
+    // calls it with no queryKey. Scoped calls pass through so a successor
+    // fetchQuery is not blocked.
+    vi.spyOn(queryClient, 'cancelQueries').mockImplementation((args) => {
+      if (args && typeof args === 'object' && 'queryKey' in args && args.queryKey) {
+        return realCancelQueries(args);
+      }
+      return cancellation;
+    });
+
+    // A cleanup retry fires while still signed out with no prior user. The
+    // watcher captures signOutClear = true and previousUserId === null.
+    Object.assign(state, { operation: 'idle' });
+    // Let the cleanup callback start and suspend at the awaited (mocked)
+    // global cancelQueries(). The hazard requires the callback to be past
+    // its revalidation guard and parked at the await when the successor
+    // authenticates; otherwise the guard itself returns early.
+    await settle();
+    expect(clear).not.toHaveBeenCalled();
+
+    // During the delayed cancellation, a successor authenticates, seeds
+    // their cache, and starts an in-flight request.
+    Object.assign(state, {
+      phase: 'authenticated',
+      operation: 'idle',
+      sessionUsable: true,
+      errorCode: null,
+      user: { userId: 'user-2', email: null },
+    });
+    queryClient.setQueryData(srsKeys.stats('user-2'), { due: 7 });
+    await nextTick();
+
+    let signalAborted = false;
+    let resolveFetcher!: (value: { due: 9 }) => void;
+    const fetcherPromise = new Promise<{ due: 9 }>((resolve) => {
+      resolveFetcher = resolve;
+    });
+    const user2Fetch = queryClient.fetchQuery({
+      queryKey: srsKeys.stats('user-2'),
+      queryFn: ({ signal }) => {
+        signal.addEventListener('abort', () => {
+          signalAborted = true;
+        });
+        return fetcherPromise;
+      },
+    });
+    await settle();
+
+    // The delayed cancellation resolves. The stale no-prior-user fallback
+    // must NOT globally clear() and must NOT cancel the successor's request.
+    resolveCancellation();
+    await settle();
+
+    expect(clear).not.toHaveBeenCalled();
+    expect(signalAborted).toBe(false);
+    expect(queryClient.getQueryData(srsKeys.stats('user-2'))).toEqual({ due: 7 });
+
+    resolveFetcher({ due: 9 });
+    await expect(user2Fetch).resolves.toEqual({ due: 9 });
+    expect(queryClient.getQueryData(srsKeys.stats('user-2'))).toEqual({ due: 9 });
+  });
+
+  it('scopes unusable-recovery cancellation to the recovering user and does not abort a successor in-flight request', async () => {
+    const state = reactive<MobileAuthState>({
+      phase: 'authenticated',
+      operation: 'idle',
+      sessionUsable: true,
+      errorCode: null,
+      retryAction: null,
+      notice: null,
+      user: { userId: 'user-1', email: null },
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData(srsKeys.stats('user-1'), { due: 4 });
+    const stop = installMobileQueryAuthIsolation({ state, queryClient });
+    stops.push(stop);
+
+    const realCancelQueries = queryClient.cancelQueries.bind(queryClient);
+    let resolveCancellation!: () => void;
+    const cancellation = new Promise<void>((resolve) => {
+      resolveCancellation = resolve;
+    });
+    const clear = vi.spyOn(queryClient, 'clear');
+    // Delay only user-1's scoped cancellation; let other scoped calls and
+    // any successor fetchQuery pass through.
+    vi.spyOn(queryClient, 'cancelQueries').mockImplementation((args) => {
+      if (args && typeof args === 'object' && 'queryKey' in args && args.queryKey) {
+        const key = (args as { queryKey: unknown }).queryKey;
+        if (Array.isArray(key) && key.includes('user-1')) {
+          return cancellation;
+        }
+        return realCancelQueries(args);
+      }
+      // Unscoped cancelQueries() should not occur with the scoped fix.
+      return cancellation;
+    });
+
+    // User 1's session becomes recovering + unusable → cancelOnly fires,
+    // scoped to user-1, and awaits the delayed cancellation.
+    Object.assign(state, { operation: 'refreshing', sessionUsable: false });
+    // Let the cancelOnly callback start and suspend at the awaited (mocked)
+    // scoped cancelQueries(). The hazard requires the callback to be parked
+    // at the await when the identity changes; otherwise a later queued
+    // callback would see the new state and take a different branch.
+    await settle();
+
+    // During the delayed cancellation, identity changes to user-2 and
+    // user-2 starts an in-flight request.
+    Object.assign(state, {
+      operation: 'idle',
+      sessionUsable: true,
+      user: { userId: 'user-2', email: null },
+    });
+    await nextTick();
+
+    let signalAborted = false;
+    let resolveFetcher!: (value: { due: 9 }) => void;
+    const fetcherPromise = new Promise<{ due: 9 }>((resolve) => {
+      resolveFetcher = resolve;
+    });
+    const user2Fetch = queryClient.fetchQuery({
+      queryKey: srsKeys.stats('user-2'),
+      queryFn: ({ signal }) => {
+        signal.addEventListener('abort', () => {
+          signalAborted = true;
+        });
+        return fetcherPromise;
+      },
+    });
+    await settle();
+
+    // Resolve user-1's delayed cancellation. The stale cancelOnly callback
+    // must NOT abort user-2's in-flight request (scoped to user-1 only).
+    resolveCancellation();
+    await settle();
+
+    expect(clear).not.toHaveBeenCalled();
+    expect(signalAborted).toBe(false);
+
+    resolveFetcher({ due: 9 });
+    await expect(user2Fetch).resolves.toEqual({ due: 9 });
   });
 });

--- a/apps/vela-mobile/src/services/mobile-query-auth-isolation.test.ts
+++ b/apps/vela-mobile/src/services/mobile-query-auth-isolation.test.ts
@@ -67,23 +67,19 @@ describe('mobile query auth isolation', () => {
     expect(queryClient.getQueryData(srsKeys.stats('user-1'))).toEqual({ due: 4 });
   });
 
-  it('cancels then clears when sign-out starts', async () => {
+  it('cancels then removes prior user cache when sign-out starts', async () => {
     const { state, queryClient, stop } = install();
     stops.push(stop);
-    const events: string[] = [];
-    vi.spyOn(queryClient, 'cancelQueries').mockImplementation(async () => {
-      events.push('cancel');
-    });
-    const queryClientClear = queryClient.clear.bind(queryClient);
-    vi.spyOn(queryClient, 'clear').mockImplementation(() => {
-      events.push('clear');
-      queryClientClear();
-    });
+    const cancelQueries = vi.spyOn(queryClient, 'cancelQueries');
+    const removeQueries = vi.spyOn(queryClient, 'removeQueries');
+    const clear = vi.spyOn(queryClient, 'clear');
 
     Object.assign(state, { operation: 'signingOut', sessionUsable: false });
     await settle();
 
-    expect(events).toEqual(['cancel', 'clear']);
+    expect(cancelQueries).toHaveBeenCalledWith({ queryKey: srsKeys.stats('user-1') });
+    expect(removeQueries).toHaveBeenCalledWith({ queryKey: srsKeys.stats('user-1') });
+    expect(clear).not.toHaveBeenCalled();
     expect(queryClient.getQueryData(srsKeys.stats('user-1'))).toBeUndefined();
   });
 
@@ -133,23 +129,24 @@ describe('mobile query auth isolation', () => {
     expect(queryClient.getQueryData(srsKeys.stats('user-1'))).toEqual({ due: 4 });
   });
 
-  it('waits for cancellation before clearing cache', async () => {
+  it('waits for scoped cancellation before removing prior user cache', async () => {
     const { state, queryClient, stop } = install();
     stops.push(stop);
     let resolveCancellation!: () => void;
     const cancellation = new Promise<void>((resolve) => {
       resolveCancellation = resolve;
     });
-    const clear = vi.spyOn(queryClient, 'clear');
+    const removeQueries = vi.spyOn(queryClient, 'removeQueries');
     vi.spyOn(queryClient, 'cancelQueries').mockReturnValue(cancellation);
 
     Object.assign(state, { operation: 'signingOut', sessionUsable: false });
     await nextTick();
-    expect(clear).not.toHaveBeenCalled();
+    expect(removeQueries).not.toHaveBeenCalled();
 
     resolveCancellation();
     await settle();
-    expect(clear).toHaveBeenCalledOnce();
+    expect(removeQueries).toHaveBeenCalledWith({ queryKey: srsKeys.stats('user-1') });
+    expect(queryClient.getQueryData(srsKeys.stats('user-1'))).toBeUndefined();
   });
 
   it('skips the global clear when a successor session starts during delayed cancellation', async () => {
@@ -192,5 +189,64 @@ describe('mobile query auth isolation', () => {
     await settle();
     expect(clear).not.toHaveBeenCalled();
     expect(queryClient.getQueryData(srsKeys.stats('user-2'))).toEqual({ due: 7 });
+  });
+
+  it('does not abort successor in-flight query and removes prior user cache on delayed sign-out', async () => {
+    const { state, queryClient, stop } = install();
+    stops.push(stop);
+    const clear = vi.spyOn(queryClient, 'clear');
+
+    // Sign-out begins and completes — scoped cleanup removes only User 1's
+    // cache entry, without global cancelQueries()/clear().
+    Object.assign(state, { operation: 'signingOut', sessionUsable: false });
+    await settle();
+
+    // Sign-out completes and a successor signs in.
+    Object.assign(state, {
+      phase: 'signedOut',
+      operation: 'idle',
+      sessionUsable: false,
+      user: null,
+    });
+    await settle();
+    Object.assign(state, {
+      phase: 'authenticated',
+      operation: 'idle',
+      sessionUsable: true,
+      user: { userId: 'user-2', email: null },
+    });
+    await settle();
+
+    // Start an in-flight Home stats request for User 2.
+    let signalAborted = false;
+    let resolveFetcher!: (value: { due: 9 }) => void;
+    const fetcherPromise = new Promise<{ due: 9 }>((resolve) => {
+      resolveFetcher = resolve;
+    });
+    const user2Fetch = queryClient.fetchQuery({
+      queryKey: srsKeys.stats('user-2'),
+      queryFn: ({ signal }) => {
+        signal.addEventListener('abort', () => {
+          signalAborted = true;
+        });
+        return fetcherPromise;
+      },
+    });
+    await settle();
+
+    // User 2's in-flight request must not have been aborted by the
+    // sign-out cleanup callbacks.
+    expect(signalAborted).toBe(false);
+
+    // User 2's request resolves normally.
+    resolveFetcher({ due: 9 });
+    await expect(user2Fetch).resolves.toEqual({ due: 9 });
+
+    // User 1's cached data must be removed (no cross-user leak).
+    expect(queryClient.getQueryData(srsKeys.stats('user-1'))).toBeUndefined();
+    // User 2's resolved data must survive.
+    expect(queryClient.getQueryData(srsKeys.stats('user-2'))).toEqual({ due: 9 });
+    // Global clear must not have erased the successor's cache.
+    expect(clear).not.toHaveBeenCalled();
   });
 });

--- a/apps/vela-mobile/src/services/mobile-query-auth-isolation.test.ts
+++ b/apps/vela-mobile/src/services/mobile-query-auth-isolation.test.ts
@@ -1,0 +1,154 @@
+import { QueryClient } from '@tanstack/vue-query';
+import { srsKeys } from '@vela/common';
+import { nextTick, reactive } from 'vue';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { MobileAuthState } from '../auth/mobile-auth-contract';
+import { installMobileQueryAuthIsolation } from './mobile-query-auth-isolation';
+
+function authenticatedState(): MobileAuthState {
+  return {
+    phase: 'authenticated',
+    operation: 'idle',
+    sessionUsable: true,
+    errorCode: null,
+    retryAction: null,
+    notice: null,
+    user: { userId: 'user-1', email: null },
+  };
+}
+
+function install() {
+  const state = reactive(authenticatedState());
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  queryClient.setQueryData(srsKeys.stats('user-1'), { due: 4 });
+  const stop = installMobileQueryAuthIsolation({ state, queryClient });
+  return { state, queryClient, stop };
+}
+
+async function settle(): Promise<void> {
+  await nextTick();
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+describe('mobile query auth isolation', () => {
+  const stops: (() => void)[] = [];
+
+  afterEach(() => {
+    stops.splice(0).forEach((stop) => stop());
+  });
+
+  it('retains cached data during usable soft refresh', async () => {
+    const { state, queryClient, stop } = install();
+    stops.push(stop);
+    const cancelQueries = vi.spyOn(queryClient, 'cancelQueries');
+
+    Object.assign(state, { operation: 'refreshing', sessionUsable: true });
+    await settle();
+
+    expect(cancelQueries).not.toHaveBeenCalled();
+    expect(queryClient.getQueryData(srsKeys.stats('user-1'))).toEqual({ due: 4 });
+  });
+
+  it('cancels without clearing during unusable session recovery', async () => {
+    const { state, queryClient, stop } = install();
+    stops.push(stop);
+    const cancelQueries = vi.spyOn(queryClient, 'cancelQueries');
+    const clear = vi.spyOn(queryClient, 'clear');
+
+    Object.assign(state, { operation: 'refreshing', sessionUsable: false });
+    await settle();
+
+    expect(cancelQueries).toHaveBeenCalledOnce();
+    expect(clear).not.toHaveBeenCalled();
+    expect(queryClient.getQueryData(srsKeys.stats('user-1'))).toEqual({ due: 4 });
+  });
+
+  it('cancels then clears when sign-out starts', async () => {
+    const { state, queryClient, stop } = install();
+    stops.push(stop);
+    const events: string[] = [];
+    vi.spyOn(queryClient, 'cancelQueries').mockImplementation(async () => {
+      events.push('cancel');
+    });
+    const queryClientClear = queryClient.clear.bind(queryClient);
+    vi.spyOn(queryClient, 'clear').mockImplementation(() => {
+      events.push('clear');
+      queryClientClear();
+    });
+
+    Object.assign(state, { operation: 'signingOut', sessionUsable: false });
+    await settle();
+
+    expect(events).toEqual(['cancel', 'clear']);
+    expect(queryClient.getQueryData(srsKeys.stats('user-1'))).toBeUndefined();
+  });
+
+  it.each([
+    ['terminal signed-out state', { phase: 'signedOut', operation: 'idle', user: null }],
+    [
+      'cleanup failure',
+      {
+        phase: 'signedOut',
+        operation: 'cleaningUp',
+        sessionUsable: false,
+        errorCode: 'session_cleanup_failed',
+        user: null,
+      },
+    ],
+  ])('clears cached data for %s', async (_label, transition) => {
+    const { state, queryClient, stop } = install();
+    stops.push(stop);
+
+    Object.assign(state, transition);
+    await settle();
+
+    expect(queryClient.getQueryData(srsKeys.stats('user-1'))).toBeUndefined();
+  });
+
+  it('clears cached data when the authenticated identity changes', async () => {
+    const { state, queryClient, stop } = install();
+    stops.push(stop);
+
+    state.user = { userId: 'user-2', email: null };
+    await settle();
+
+    expect(queryClient.getQueryData(srsKeys.stats('user-1'))).toBeUndefined();
+  });
+
+  it('does not touch cache for ordinary app backgrounding state', async () => {
+    const { state, queryClient, stop } = install();
+    stops.push(stop);
+    const cancelQueries = vi.spyOn(queryClient, 'cancelQueries');
+    const clear = vi.spyOn(queryClient, 'clear');
+
+    state.notice = 'session_unusable';
+    await settle();
+
+    expect(cancelQueries).not.toHaveBeenCalled();
+    expect(clear).not.toHaveBeenCalled();
+    expect(queryClient.getQueryData(srsKeys.stats('user-1'))).toEqual({ due: 4 });
+  });
+
+  it('waits for cancellation before clearing cache', async () => {
+    const { state, queryClient, stop } = install();
+    stops.push(stop);
+    let resolveCancellation!: () => void;
+    const cancellation = new Promise<void>((resolve) => {
+      resolveCancellation = resolve;
+    });
+    const clear = vi.spyOn(queryClient, 'clear');
+    vi.spyOn(queryClient, 'cancelQueries').mockReturnValue(cancellation);
+
+    Object.assign(state, { operation: 'signingOut', sessionUsable: false });
+    await nextTick();
+    expect(clear).not.toHaveBeenCalled();
+
+    resolveCancellation();
+    await settle();
+    expect(clear).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/vela-mobile/src/services/mobile-query-auth-isolation.test.ts
+++ b/apps/vela-mobile/src/services/mobile-query-auth-isolation.test.ts
@@ -159,8 +159,8 @@ describe('mobile query auth isolation', () => {
     const clear = vi.spyOn(queryClient, 'clear');
     vi.spyOn(queryClient, 'cancelQueries').mockReturnValue(cancellation);
 
-    // Sign-out begins: the watcher captures signOutClear = true and starts
-    // awaiting cancelQueries(). Cancellation is delayed.
+    // Sign-out begins: the watcher captures signOutTransition = true and
+    // starts awaiting cancelQueries(). Cancellation is delayed.
     Object.assign(state, { operation: 'signingOut', sessionUsable: false });
     await nextTick();
     expect(clear).not.toHaveBeenCalled();
@@ -183,8 +183,9 @@ describe('mobile query auth isolation', () => {
     queryClient.setQueryData(srsKeys.stats('user-2'), { due: 7 });
     await nextTick();
 
-    // Now the delayed cancellation resolves. The stale signOutClear flag
-    // must NOT cause clear() to erase the successor's freshly seeded cache.
+    // Now the delayed cancellation resolves. The stale signOutTransition
+    // flag must NOT cause clear() to erase the successor's freshly seeded
+    // cache.
     resolveCancellation();
     await settle();
     expect(clear).not.toHaveBeenCalled();
@@ -252,7 +253,7 @@ describe('mobile query auth isolation', () => {
 
   it('does not clear a successor cache when a no-prior-user cleanup retry resumes after successor sign-in', async () => {
     // Begin from a signed-out cleanup state with no prior user, so the
-    // watcher's previousUserId === null fallback is the reachable branch.
+    // watcher's previousUserId === null branch is the reachable one.
     const state = reactive<MobileAuthState>({
       phase: 'signedOut',
       operation: 'cleaningUp',
@@ -268,34 +269,21 @@ describe('mobile query auth isolation', () => {
     const stop = installMobileQueryAuthIsolation({ state, queryClient });
     stops.push(stop);
 
-    const realCancelQueries = queryClient.cancelQueries.bind(queryClient);
-    let resolveCancellation!: () => void;
-    const cancellation = new Promise<void>((resolve) => {
-      resolveCancellation = resolve;
-    });
+    const cancelQueries = vi.spyOn(queryClient, 'cancelQueries');
     const clear = vi.spyOn(queryClient, 'clear');
-    // Delay only unscoped (global) cancelQueries() — the buggy fallback
-    // calls it with no queryKey. Scoped calls pass through so a successor
-    // fetchQuery is not blocked.
-    vi.spyOn(queryClient, 'cancelQueries').mockImplementation((args) => {
-      if (args && typeof args === 'object' && 'queryKey' in args && args.queryKey) {
-        return realCancelQueries(args);
-      }
-      return cancellation;
-    });
 
     // A cleanup retry fires while still signed out with no prior user. The
-    // watcher captures signOutClear = true and previousUserId === null.
+    // guard under test: with previousUserId === null the sign-out branch
+    // must issue no unscoped cancelQueries() and no clear() — there is no
+    // authenticated user key to remove, and any cache present belongs to a
+    // successor.
     Object.assign(state, { operation: 'idle' });
-    // Let the cleanup callback start and suspend at the awaited (mocked)
-    // global cancelQueries(). The hazard requires the callback to be past
-    // its revalidation guard and parked at the await when the successor
-    // authenticates; otherwise the guard itself returns early.
     await settle();
     expect(clear).not.toHaveBeenCalled();
+    expect(cancelQueries).not.toHaveBeenCalled();
 
-    // During the delayed cancellation, a successor authenticates, seeds
-    // their cache, and starts an in-flight request.
+    // A successor authenticates and seeds their cache. The prior cleanup
+    // must not have left any pending global clear that would erase it.
     Object.assign(state, {
       phase: 'authenticated',
       operation: 'idle',
@@ -304,36 +292,11 @@ describe('mobile query auth isolation', () => {
       user: { userId: 'user-2', email: null },
     });
     queryClient.setQueryData(srsKeys.stats('user-2'), { due: 7 });
-    await nextTick();
-
-    let signalAborted = false;
-    let resolveFetcher!: (value: { due: 9 }) => void;
-    const fetcherPromise = new Promise<{ due: 9 }>((resolve) => {
-      resolveFetcher = resolve;
-    });
-    const user2Fetch = queryClient.fetchQuery({
-      queryKey: srsKeys.stats('user-2'),
-      queryFn: ({ signal }) => {
-        signal.addEventListener('abort', () => {
-          signalAborted = true;
-        });
-        return fetcherPromise;
-      },
-    });
-    await settle();
-
-    // The delayed cancellation resolves. The stale no-prior-user fallback
-    // must NOT globally clear() and must NOT cancel the successor's request.
-    resolveCancellation();
     await settle();
 
     expect(clear).not.toHaveBeenCalled();
-    expect(signalAborted).toBe(false);
+    expect(cancelQueries).not.toHaveBeenCalled();
     expect(queryClient.getQueryData(srsKeys.stats('user-2'))).toEqual({ due: 7 });
-
-    resolveFetcher({ due: 9 });
-    await expect(user2Fetch).resolves.toEqual({ due: 9 });
-    expect(queryClient.getQueryData(srsKeys.stats('user-2'))).toEqual({ due: 9 });
   });
 
   it('scopes unusable-recovery cancellation to the recovering user and does not abort a successor in-flight request', async () => {

--- a/apps/vela-mobile/src/services/mobile-query-auth-isolation.ts
+++ b/apps/vela-mobile/src/services/mobile-query-auth-isolation.ts
@@ -49,6 +49,22 @@ export function installMobileQueryAuthIsolation(options: {
         .then(async () => {
           if (signOutClear) {
             await options.queryClient.cancelQueries();
+            // Revalidate the auth snapshot before globally clearing. This
+            // continuation can resume after sign-out has completed and a
+            // successor session has started loading; the captured
+            // signOutClear flag is then stale and clear() would erase the
+            // successor's freshly populated cache. During sign-out itself
+            // the old user may still be in the state — that is not a
+            // successor, so only skip when the state has moved past
+            // sign-out to an authenticated phase with a user.
+            const current = selectAuthQuerySnapshot(options.state);
+            const stillSignedOut =
+              current.phase === 'signedOut' ||
+              current.operation === 'signingOut' ||
+              current.operation === 'cleaningUp';
+            if (!stillSignedOut && current.userId !== null) {
+              return;
+            }
             options.queryClient.clear();
             return;
           }

--- a/apps/vela-mobile/src/services/mobile-query-auth-isolation.ts
+++ b/apps/vela-mobile/src/services/mobile-query-auth-isolation.ts
@@ -1,0 +1,54 @@
+import type { QueryClient } from '@tanstack/vue-query';
+import { watch, type WatchStopHandle } from 'vue';
+import type { MobileAuthState } from '../auth/mobile-auth-contract';
+import {
+  selectMobileFeatureSessionStatus,
+  type MobileFeatureSessionStatus,
+} from '../auth/mobile-feature-session-status';
+
+type AuthQuerySnapshot = {
+  phase: MobileAuthState['phase'];
+  operation: MobileAuthState['operation'];
+  userId: string | null;
+  featureStatus: MobileFeatureSessionStatus;
+};
+
+function selectAuthQuerySnapshot(state: Readonly<MobileAuthState>): AuthQuerySnapshot {
+  return {
+    phase: state.phase,
+    operation: state.operation,
+    userId: state.user?.userId ?? null,
+    featureStatus: selectMobileFeatureSessionStatus(state),
+  };
+}
+
+export function installMobileQueryAuthIsolation(options: {
+  state: Readonly<MobileAuthState>;
+  queryClient: QueryClient;
+}): WatchStopHandle {
+  let cleanupTail = Promise.resolve();
+
+  return watch(
+    () => selectAuthQuerySnapshot(options.state),
+    (next, previous) => {
+      const identityChanged = previous.userId !== next.userId;
+      const clearRequired =
+        identityChanged ||
+        next.phase === 'signedOut' ||
+        next.operation === 'signingOut' ||
+        next.operation === 'cleaningUp';
+      const cancelOnly =
+        next.featureStatus.kind === 'recovering' && !next.featureStatus.sessionUsable;
+
+      if (!clearRequired && !cancelOnly) return;
+
+      cleanupTail = cleanupTail
+        .catch(() => undefined)
+        .then(async () => {
+          await options.queryClient.cancelQueries();
+          if (clearRequired) options.queryClient.clear();
+        })
+        .catch(() => undefined);
+    },
+  );
+}

--- a/apps/vela-mobile/src/services/mobile-query-auth-isolation.ts
+++ b/apps/vela-mobile/src/services/mobile-query-auth-isolation.ts
@@ -1,4 +1,5 @@
 import type { QueryClient } from '@tanstack/vue-query';
+import { srsKeys } from '@vela/common';
 import { watch, type WatchStopHandle } from 'vue';
 import type { MobileAuthState } from '../auth/mobile-auth-contract';
 import {
@@ -31,22 +32,35 @@ export function installMobileQueryAuthIsolation(options: {
   return watch(
     () => selectAuthQuerySnapshot(options.state),
     (next, previous) => {
-      const identityChanged = previous.userId !== next.userId;
-      const clearRequired =
-        identityChanged ||
+      const previousUserId = previous.userId;
+      const identityChanged = previousUserId !== next.userId;
+      // A terminal sign-out wipes the whole cache (no successor user to keep).
+      const signOutClear =
         next.phase === 'signedOut' ||
         next.operation === 'signingOut' ||
         next.operation === 'cleaningUp';
       const cancelOnly =
         next.featureStatus.kind === 'recovering' && !next.featureStatus.sessionUsable;
 
-      if (!clearRequired && !cancelOnly) return;
+      if (!identityChanged && !signOutClear && !cancelOnly) return;
 
       cleanupTail = cleanupTail
         .catch(() => undefined)
         .then(async () => {
+          if (signOutClear) {
+            await options.queryClient.cancelQueries();
+            options.queryClient.clear();
+            return;
+          }
+          if (identityChanged && previousUserId !== null) {
+            // Scope removal to the prior user's key so an in-flight or freshly
+            // resolved request for the new user survives the identity handoff.
+            const priorUserKey = srsKeys.stats(previousUserId);
+            await options.queryClient.cancelQueries({ queryKey: priorUserKey });
+            options.queryClient.removeQueries({ queryKey: priorUserKey });
+            return;
+          }
           await options.queryClient.cancelQueries();
-          if (clearRequired) options.queryClient.clear();
         })
         .catch(() => undefined);
     },

--- a/apps/vela-mobile/src/services/mobile-query-auth-isolation.ts
+++ b/apps/vela-mobile/src/services/mobile-query-auth-isolation.ts
@@ -60,19 +60,16 @@ export function installMobileQueryAuthIsolation(options: {
               options.queryClient.removeQueries({ queryKey: priorUserKey });
               return;
             }
-            // No prior user (e.g. cleanup on a fresh signed-out state).
-            // Revalidate before globally clearing — a successor may have
-            // started during the await.
-            const current = selectAuthQuerySnapshot(options.state);
-            const stillSignedOut =
-              current.phase === 'signedOut' ||
-              current.operation === 'signingOut' ||
-              current.operation === 'cleaningUp';
-            if (!stillSignedOut && current.userId !== null) {
-              return;
-            }
-            await options.queryClient.cancelQueries();
-            options.queryClient.clear();
+            // No prior user (e.g. a cleanup retry on a fresh signed-out
+            // state). With no prior user there is no authenticated user key
+            // to remove, and every mobile query is user-scoped
+            // (srsKeys.stats(userId)), so any cache present belongs to a
+            // successor. A global cancelQueries()/clear() here would race a
+            // successor that authenticates during the await: the revalidation
+            // above ran before the await, but clear() runs after it
+            // unconditionally, erasing the successor's cache and detaching
+            // its observers. Do nothing — there is nothing legitimate to
+            // clean up.
             return;
           }
           if (identityChanged && previousUserId !== null) {
@@ -83,10 +80,14 @@ export function installMobileQueryAuthIsolation(options: {
             options.queryClient.removeQueries({ queryKey: priorUserKey });
             return;
           }
-          if (cancelOnly) {
-            // Unusable session recovery: cancel in-flight queries without
-            // clearing the cache.
-            await options.queryClient.cancelQueries();
+          if (cancelOnly && next.featureStatus.kind === 'recovering') {
+            // Unusable session recovery: cancel the recovering user's
+            // in-flight queries without clearing the cache. Scope to that
+            // user's key so a stale recovery callback queued behind other
+            // cleanup cannot abort a successor's requests after an identity
+            // change during the await.
+            const recoveringUserKey = srsKeys.stats(next.featureStatus.userId);
+            await options.queryClient.cancelQueries({ queryKey: recoveringUserKey });
             return;
           }
           // identityChanged && previousUserId === null: null → newUser

--- a/apps/vela-mobile/src/services/mobile-query-auth-isolation.ts
+++ b/apps/vela-mobile/src/services/mobile-query-auth-isolation.ts
@@ -48,15 +48,21 @@ export function installMobileQueryAuthIsolation(options: {
         .catch(() => undefined)
         .then(async () => {
           if (signOutClear) {
-            await options.queryClient.cancelQueries();
-            // Revalidate the auth snapshot before globally clearing. This
-            // continuation can resume after sign-out has completed and a
-            // successor session has started loading; the captured
-            // signOutClear flag is then stale and clear() would erase the
-            // successor's freshly populated cache. During sign-out itself
-            // the old user may still be in the state — that is not a
-            // successor, so only skip when the state has moved past
-            // sign-out to an authenticated phase with a user.
+            // When a prior user is known, scope the cancellation and
+            // removal to that user's key. This avoids globally cancelling
+            // a successor's in-flight queries when this stale continuation
+            // resumes after sign-out has completed and a successor session
+            // has started. A global cancelQueries()/clear() here would
+            // abort the successor's active requests and erase their cache.
+            if (previousUserId !== null) {
+              const priorUserKey = srsKeys.stats(previousUserId);
+              await options.queryClient.cancelQueries({ queryKey: priorUserKey });
+              options.queryClient.removeQueries({ queryKey: priorUserKey });
+              return;
+            }
+            // No prior user (e.g. cleanup on a fresh signed-out state).
+            // Revalidate before globally clearing — a successor may have
+            // started during the await.
             const current = selectAuthQuerySnapshot(options.state);
             const stillSignedOut =
               current.phase === 'signedOut' ||
@@ -65,6 +71,7 @@ export function installMobileQueryAuthIsolation(options: {
             if (!stillSignedOut && current.userId !== null) {
               return;
             }
+            await options.queryClient.cancelQueries();
             options.queryClient.clear();
             return;
           }
@@ -76,7 +83,15 @@ export function installMobileQueryAuthIsolation(options: {
             options.queryClient.removeQueries({ queryKey: priorUserKey });
             return;
           }
-          await options.queryClient.cancelQueries();
+          if (cancelOnly) {
+            // Unusable session recovery: cancel in-flight queries without
+            // clearing the cache.
+            await options.queryClient.cancelQueries();
+            return;
+          }
+          // identityChanged && previousUserId === null: null → newUser
+          // with no prior user to clean up. Nothing to do — a global
+          // cancellation here would abort the new user's own requests.
         })
         .catch(() => undefined);
     },

--- a/apps/vela-mobile/src/services/mobile-query-auth-isolation.ts
+++ b/apps/vela-mobile/src/services/mobile-query-auth-isolation.ts
@@ -34,20 +34,22 @@ export function installMobileQueryAuthIsolation(options: {
     (next, previous) => {
       const previousUserId = previous.userId;
       const identityChanged = previousUserId !== next.userId;
-      // A terminal sign-out wipes the whole cache (no successor user to keep).
-      const signOutClear =
+      // A terminal sign-out removes only the previous user's
+      // srsKeys.stats(previousUserId) cache entry; no removal occurs when
+      // there is no prior user.
+      const signOutTransition =
         next.phase === 'signedOut' ||
         next.operation === 'signingOut' ||
         next.operation === 'cleaningUp';
       const cancelOnly =
         next.featureStatus.kind === 'recovering' && !next.featureStatus.sessionUsable;
 
-      if (!identityChanged && !signOutClear && !cancelOnly) return;
+      if (!identityChanged && !signOutTransition && !cancelOnly) return;
 
       cleanupTail = cleanupTail
         .catch(() => undefined)
         .then(async () => {
-          if (signOutClear) {
+          if (signOutTransition) {
             // When a prior user is known, scope the cancellation and
             // removal to that user's key. This avoids globally cancelling
             // a successor's in-flight queries when this stale continuation

--- a/apps/vela-mobile/src/services/mobile-services.test.ts
+++ b/apps/vela-mobile/src/services/mobile-services.test.ts
@@ -1,0 +1,41 @@
+import type { App } from 'vue';
+import { describe, expect, it, vi } from 'vitest';
+import type { MobileAuthCoordinator } from '../auth/mobile-auth-contract';
+import {
+  MOBILE_API_CLIENT_KEY,
+  MOBILE_SRS_SERVICE_KEY,
+  provideMobileServices,
+} from './mobile-services';
+
+describe('mobile service provisioning', () => {
+  it('directly provides SRS services that delegate through the supplied coordinator', async () => {
+    const coordinator = {
+      state: {},
+      requestAuthenticatedApi: vi.fn().mockResolvedValue({
+        status: 200,
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          total_items: 0,
+          due_today: 0,
+          mastery_breakdown: { new: 0, learning: 0, reviewing: 0, mastered: 0 },
+          average_ease_factor: 0,
+          total_reviews: 0,
+          accuracy_rate: 0,
+        }),
+      }),
+    } as unknown as MobileAuthCoordinator;
+    const app = { provide: vi.fn() } as unknown as App;
+
+    provideMobileServices(app, coordinator);
+
+    const apiClient = (app.provide as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([key]) => key === MOBILE_API_CLIENT_KEY,
+    )?.[1];
+    const srsService = (app.provide as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([key]) => key === MOBILE_SRS_SERVICE_KEY,
+    )?.[1];
+    await expect(srsService.getStats()).resolves.toMatchObject({ due_today: 0 });
+    expect(apiClient).toBeDefined();
+    expect(coordinator.requestAuthenticatedApi).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/vela-mobile/src/services/mobile-services.ts
+++ b/apps/vela-mobile/src/services/mobile-services.ts
@@ -1,0 +1,15 @@
+import type { App, InjectionKey } from 'vue';
+import type { MobileAuthCoordinator } from '../auth/mobile-auth-contract';
+import { createMobileApiClient, type MobileApiClient } from './mobile-api-client';
+import { createMobileSrsService, type MobileSrsService } from './mobile-srs';
+
+export const MOBILE_API_CLIENT_KEY: InjectionKey<MobileApiClient> = Symbol('mobile-api-client');
+export const MOBILE_SRS_SERVICE_KEY: InjectionKey<MobileSrsService> = Symbol('mobile-srs-service');
+
+export function provideMobileServices(app: App, coordinator: MobileAuthCoordinator): void {
+  const apiClient = createMobileApiClient(coordinator);
+  const srsService = createMobileSrsService(apiClient);
+
+  app.provide(MOBILE_API_CLIENT_KEY, apiClient);
+  app.provide(MOBILE_SRS_SERVICE_KEY, srsService);
+}

--- a/apps/vela-mobile/src/services/mobile-srs.test.ts
+++ b/apps/vela-mobile/src/services/mobile-srs.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { MobileApiClient } from './mobile-api-client';
+import { createMobileSrsService } from './mobile-srs';
+
+const stats = {
+  total_items: 12,
+  due_today: 4,
+  mastery_breakdown: { new: 1, learning: 2, reviewing: 3, mastered: 6 },
+  average_ease_factor: 2.5,
+  total_reviews: 21,
+  accuracy_rate: 80,
+};
+
+describe('mobile SRS service', () => {
+  it('loads stats through the exact authenticated SRS path and caller signal', async () => {
+    const signal = new AbortController().signal;
+    const apiClient: MobileApiClient = { getJson: vi.fn().mockResolvedValue(stats) };
+
+    await expect(createMobileSrsService(apiClient).getStats({ signal })).resolves.toEqual(stats);
+    expect(apiClient.getJson).toHaveBeenCalledWith('srs/stats', { signal });
+  });
+
+  it('maps malformed stats to invalid_response', async () => {
+    const apiClient: MobileApiClient = { getJson: vi.fn().mockResolvedValue({ due_today: -1 }) };
+
+    await expect(createMobileSrsService(apiClient).getStats()).rejects.toMatchObject({
+      code: 'invalid_response',
+    });
+  });
+});

--- a/apps/vela-mobile/src/services/mobile-srs.ts
+++ b/apps/vela-mobile/src/services/mobile-srs.ts
@@ -1,0 +1,19 @@
+import { parseSrsStats, type SRSStats } from '@vela/common';
+import { MobileApiError, type MobileApiClient } from './mobile-api-client';
+
+export type MobileSrsService = {
+  getStats(options?: { signal?: AbortSignal }): Promise<SRSStats>;
+};
+
+export function createMobileSrsService(apiClient: MobileApiClient): MobileSrsService {
+  return {
+    async getStats(options = {}) {
+      const value = await apiClient.getJson('srs/stats', options);
+      try {
+        return parseSrsStats(value);
+      } catch (error) {
+        throw new MobileApiError('invalid_response', { cause: error });
+      }
+    },
+  };
+}

--- a/apps/vela-mobile/src/test/secret-leak-helpers.ts
+++ b/apps/vela-mobile/src/test/secret-leak-helpers.ts
@@ -22,6 +22,8 @@ export const LOG_AND_DOM_SENTINELS = [
   'SECRET-code-verifier',
   'SECRET-nonce',
   'SECRET-claim-email',
+  'Bearer SECRET-caller-authorization',
+  'https://evil.example/SECRET-rejected-path',
 ] as const;
 
 export const NON_SCHEMA_STORAGE_SENTINELS = [
@@ -30,6 +32,8 @@ export const NON_SCHEMA_STORAGE_SENTINELS = [
   'SECRET-raw-request',
   'SECRET-raw-response',
   'SECRET-native-exception',
+  'Bearer SECRET-caller-authorization',
+  'https://evil.example/SECRET-rejected-path',
 ] as const;
 
 export function searchable(value: unknown): string {
@@ -80,6 +84,8 @@ export function createSecretLeakAssertions(options: { installationKey: string })
   expectNoSecretLeak: (input: {
     consoleCalls: unknown[][];
     preferenceCalls: unknown[][];
+    errorMessages?: string[];
+    jsonSnapshots?: string[];
     renderedText?: string;
   }) => void;
   expectApprovedPreferenceWrites: (preferenceCalls: unknown[][]) => void;
@@ -136,10 +142,14 @@ export function createSecretLeakAssertions(options: { installationKey: string })
   function expectNoSecretLeak(input: {
     consoleCalls: unknown[][];
     preferenceCalls: unknown[][];
+    errorMessages?: string[];
+    jsonSnapshots?: string[];
     renderedText?: string;
   }): void {
     const logsAndDom = [
       searchable(input.consoleCalls),
+      ...(input.errorMessages ?? []),
+      ...(input.jsonSnapshots ?? []),
       input.renderedText ?? document.body.textContent ?? '',
     ].join('\n');
     const browserAndPreferenceStorage = [

--- a/apps/vela-mobile/vitest.config.ts
+++ b/apps/vela-mobile/vitest.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      '@vela/common': resolve(__dirname, '../../packages/common/src/index.ts'),
       src: resolve(__dirname, './src'),
       layouts: resolve(__dirname, './src/layouts'),
       pages: resolve(__dirname, './src/pages'),

--- a/apps/vela/src/services/srsService.test.ts
+++ b/apps/vela/src/services/srsService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { srsService } from './srsService';
+import { srsService, type SRSStats } from './srsService';
 import type { UserVocabularyProgress, Vocabulary } from 'src/types/database';
 
 // Mock API utility
@@ -63,6 +63,15 @@ describe('srsService', () => {
     first_learned_at: '2024-01-01T00:00:00Z',
     total_reviews: 1,
     correct_count: 1,
+  };
+
+  const statsResponse: SRSStats = {
+    total_items: 1,
+    due_today: 1,
+    mastery_breakdown: { new: 0, learning: 1, reviewing: 0, mastered: 0 },
+    average_ease_factor: 2.5,
+    total_reviews: 2,
+    accuracy_rate: 50,
   };
 
   describe('getDueItems', () => {
@@ -143,23 +152,9 @@ describe('srsService', () => {
 
   describe('getStats', () => {
     it('should fetch SRS statistics', async () => {
-      const mockStats = {
-        total_items: 100,
-        due_today: 15,
-        mastery_breakdown: {
-          new: 50,
-          learning: 30,
-          reviewing: 15,
-          mastered: 5,
-        },
-        average_ease_factor: 2.4,
-        total_reviews: 500,
-        accuracy_rate: 0.85,
-      };
-
       mockFetch.mockResolvedValue({
         ok: true,
-        json: vi.fn().mockResolvedValue(mockStats),
+        json: vi.fn().mockResolvedValue(statsResponse),
       });
 
       const result = await srsService.getStats();
@@ -170,7 +165,7 @@ describe('srsService', () => {
           Authorization: `Bearer ${mockIdToken}`,
         },
       });
-      expect(result).toEqual(mockStats);
+      expect(result).toEqual(statsResponse);
     });
 
     it('should filter stats by JLPT levels', async () => {

--- a/apps/vela/src/services/srsService.ts
+++ b/apps/vela/src/services/srsService.ts
@@ -1,23 +1,9 @@
+import type { SRSStats } from '@vela/common';
 import type { UserVocabularyProgress, Vocabulary, JLPTLevel } from 'src/types/database';
 import { getApiUrl } from 'src/utils/api';
 import { httpJsonAuth as httpJson } from 'src/utils/httpClient';
 
-/**
- * SRS statistics returned from the API
- */
-export interface SRSStats {
-  total_items: number;
-  due_today: number;
-  mastery_breakdown: {
-    new: number;
-    learning: number;
-    reviewing: number;
-    mastered: number;
-  };
-  average_ease_factor: number;
-  total_reviews: number;
-  accuracy_rate: number;
-}
+export type { SRSStats } from '@vela/common';
 
 /**
  * Due item with vocabulary data

--- a/bun.lock
+++ b/bun.lock
@@ -112,6 +112,8 @@
       "version": "0.0.1",
       "dependencies": {
         "@quasar/extras": "^1.16.4",
+        "@tanstack/vue-query": "^5.90.5",
+        "@vela/common": "workspace:*",
         "quasar": "^2.16.0",
         "vue": "^3.4.18",
         "vue-router": "^4.3.0",

--- a/docs/superpowers/plans/2026-07-30-mobile-authenticated-due-review-count.md
+++ b/docs/superpowers/plans/2026-07-30-mobile-authenticated-due-review-count.md
@@ -11,7 +11,7 @@
 ## Global Constraints
 
 - `$REPO_ROOT` is the repository root containing `apps/`, `packages/`, and `docs/`.
-- Author this plan on `agent/hpa-207-due-review-count-design-draft`. Implement the runtime work in a fresh worktree/branch based on the latest `main` that contains PR #52, using branch `codex/hpa-207-mobile-due-review-count`.
+- Author this plan on `agent/hpa-207-due-review-count-design-draft`. Implement the runtime work in a fresh worktree/branch based on the latest `main` after PR #52 has merged, using branch `codex/hpa-207-mobile-due-review-count`.
 - Treat `docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md` as the accepted behavioral contract.
 - Keep `apps/vela-mobile/src/services/mobile-auth.ts` as the only owner of active Cognito ID/access/refresh token material. Do not add `getIdToken()` or expose bearer headers outside the coordinator.
 - `requestAuthenticatedApi()` must execute feature transport outside `serialize()` / `operationTail`. Only refresh, verification, and cleanup mutations enter the serialized auth queue.
@@ -105,7 +105,7 @@ git worktree add ../Vela-hpa-207 -b codex/hpa-207-mobile-due-review-count origin
 cd ../Vela-hpa-207
 ```
 
-Expected: the new worktree is on `codex/hpa-207-mobile-due-review-count` with a clean working tree.
+Expected: PR #52 is merged into `origin/main`, and the new worktree is on `codex/hpa-207-mobile-due-review-count` with a clean working tree.
 
 - [ ] **Step 2: Confirm the accepted design is present**
 

--- a/docs/superpowers/plans/2026-07-30-mobile-authenticated-due-review-count.md
+++ b/docs/superpowers/plans/2026-07-30-mobile-authenticated-due-review-count.md
@@ -47,8 +47,8 @@
 - `apps/vela-mobile/src/services/mobile-srs.test.ts` — exact path/signal/parser tests.
 - `apps/vela-mobile/src/services/mobile-services.ts` — typed injection keys and direct service provisioning.
 - `apps/vela-mobile/src/services/mobile-services.test.ts` — provider construction tests.
-- `apps/vela-mobile/src/services/mobile-query-auth-isolation.ts` — cancel/clear lifecycle tied to auth identity.
-- `apps/vela-mobile/src/services/mobile-query-auth-isolation.test.ts` — cancellation, clear, retention, and identity tests.
+- `apps/vela-mobile/src/services/mobile-query-auth-isolation.ts` — scoped cancel/remove lifecycle tied to auth identity.
+- `apps/vela-mobile/src/services/mobile-query-auth-isolation.test.ts` — scoped cancellation, removal, retention, no-prior-user, and successor-race tests.
 - `apps/vela-mobile/src/composables/useDueReviewCount.ts` — due-count query, control-race retry, recovery refetch, and manual retry state.
 - `apps/vela-mobile/src/composables/useDueReviewCount.test.ts` — query/recovery/retry behavior.
 - `apps/vela-mobile/src/components/home/due-review-view.ts` — pure query/auth-state-to-presentation selector.
@@ -162,12 +162,10 @@ export function parseSrsStats(value: unknown): SRSStats;
 
 export const srsKeys: {
   all: readonly ['srs'];
-  stats(userId: string | null, jlpt?: number[]): readonly [
-    'srs',
-    'stats',
-    string | null,
-    number[] | undefined,
-  ];
+  stats(
+    userId: string | null,
+    jlpt?: number[],
+  ): readonly ['srs', 'stats', string | null, number[] | undefined];
 };
 ```
 
@@ -312,10 +310,7 @@ export function parseSrsStats(value: unknown): SRSStats {
       reviewing: nonNegativeInteger(mastery.reviewing, 'mastery_breakdown.reviewing'),
       mastered: nonNegativeInteger(mastery.mastered, 'mastery_breakdown.mastered'),
     },
-    average_ease_factor: finiteNonNegative(
-      root.average_ease_factor,
-      'average_ease_factor',
-    ),
+    average_ease_factor: finiteNonNegative(root.average_ease_factor, 'average_ease_factor'),
     total_reviews: nonNegativeInteger(root.total_reviews, 'total_reviews'),
     accuracy_rate: accuracyRate,
   };
@@ -694,7 +689,6 @@ export class MobileAuthenticatedApiRequestError extends Error {
 }
 ```
 
-
 - [ ] **Step 4: Implement the auth-owned selector**
 
 Create `apps/vela-mobile/src/auth/mobile-feature-session-status.ts`:
@@ -828,9 +822,9 @@ it('rejects path escapes before network activity', async () => {
     String.raw`..\secret`,
     'srs/stats#fragment',
   ]) {
-    await expect(
-      harness.coordinator.requestAuthenticatedApi({ path }),
-    ).rejects.toMatchObject({ code: 'invalid_request_path' });
+    await expect(harness.coordinator.requestAuthenticatedApi({ path })).rejects.toMatchObject({
+      code: 'invalid_request_path',
+    });
   }
 
   expect(harness.sessionFetch).toHaveBeenCalledTimes(before);
@@ -1141,11 +1135,7 @@ async function observeFeatureRefresh(
     return { kind: 'terminal' };
   }
 
-  if (
-    unavailable() ||
-    active !== owner ||
-    activeBundleGeneration !== generation
-  ) {
+  if (unavailable() || active !== owner || activeBundleGeneration !== generation) {
     return { kind: 'superseded' };
   }
 
@@ -1268,10 +1258,7 @@ export type MobileSrsService = {
 export const MOBILE_API_CLIENT_KEY: InjectionKey<MobileApiClient>;
 export const MOBILE_SRS_SERVICE_KEY: InjectionKey<MobileSrsService>;
 
-export function provideMobileServices(
-  app: App,
-  coordinator: MobileAuthCoordinator,
-): void;
+export function provideMobileServices(app: App, coordinator: MobileAuthCoordinator): void;
 ```
 
 - Consumed by Tasks 8–9.
@@ -1497,12 +1484,14 @@ Mock `focusManager.setFocused` through `vi.spyOn(focusManager, 'setFocused')`.
 Use a real `QueryClient` with a seeded `srsKeys.stats('user-1')` value. Cover:
 
 - soft refresh with `sessionUsable: true` retains cache;
-- recovering with `sessionUsable: false` cancels active queries but does not remove same-user cache;
-- sign-out start cancels, then clears;
-- terminal cleanup and cleanup failure clear;
-- identity change from user-1 to user-2 clears;
+- recovering with `sessionUsable: false` cancels only the recovering user's `srsKeys.stats(userId)` queries without removing same-user cache and without calling `queryClient.clear()`;
+- sign-out start cancels then removes only `srsKeys.stats(previousUserId)`; `queryClient.clear()` is never called;
+- terminal cleanup and cleanup failure remove only the prior user's `srsKeys.stats(previousUserId)` entry;
+- identity change from user-1 to user-2 removes only `srsKeys.stats('user-1')` and leaves user-2's cache intact;
+- sign-out or cleanup retry with no prior user (`previousUserId === null`) performs no cache mutation;
 - ordinary backgrounding causes no cache action;
-- cancellation resolves before `queryClient.clear()` is called.
+- scoped cancellation resolves before `removeQueries({ queryKey: srsKeys.stats(previousUserId) })` is called;
+- a stale sign-out callback parked at its `await cancelQueries()` does not abort a successor's in-flight request or erase its cache after the await resolves.
 
 - [ ] **Step 3: Run focused tests and verify failure**
 
@@ -1526,7 +1515,7 @@ focusManager.setFocused(event.isActive);
 
 Retain the existing single-registration promise and retry-after-registration-failure behavior. If either listener registration fails, remove any handle already created and reject so a later call can retry cleanly.
 
-- [ ] **Step 5: Implement cancel-then-clear isolation**
+- [ ] **Step 5: Implement scoped cancel-then-remove isolation**
 
 In `mobile-query-auth-isolation.ts`, watch a compact snapshot:
 
@@ -1542,19 +1531,23 @@ type AuthQuerySnapshot = {
 Serialize cleanup work through a local promise tail. Compute:
 
 ```ts
-const identityChanged = previous.userId !== next.userId;
-const clearRequired =
-  identityChanged ||
-  next.phase === 'signedOut' ||
-  next.operation === 'signingOut' ||
-  next.operation === 'cleaningUp';
-
-const cancelOnly =
-  next.featureStatus.kind === 'recovering' &&
-  !next.featureStatus.sessionUsable;
+const previousUserId = previous.userId;
+const identityChanged = previousUserId !== next.userId;
+const signOutTransition =
+  next.phase === 'signedOut' || next.operation === 'signingOut' || next.operation === 'cleaningUp';
+const cancelOnly = next.featureStatus.kind === 'recovering' && !next.featureStatus.sessionUsable;
 ```
 
-For `clearRequired`, await `queryClient.cancelQueries()` and then call `queryClient.clear()`. For `cancelOnly`, await cancellation without clearing. Do nothing for usable soft recovery and backgrounding.
+Branch behavior (never call `queryClient.clear()`):
+
+- `signOutTransition` with `previousUserId !== null`: `await queryClient.cancelQueries({ queryKey: srsKeys.stats(previousUserId) })` then `queryClient.removeQueries({ queryKey: srsKeys.stats(previousUserId) })`.
+- `signOutTransition` with `previousUserId === null`: do nothing—there is no authenticated user key to remove, and any cache present belongs to a successor that may authenticate during the await.
+- `identityChanged` with `previousUserId !== null`: same scoped cancel-then-remove of `srsKeys.stats(previousUserId)`.
+- `identityChanged` with `previousUserId === null` (null → new user): do nothing.
+- `cancelOnly` (recovering + `sessionUsable: false`): `await queryClient.cancelQueries({ queryKey: srsKeys.stats(next.featureStatus.userId) })` scoped to the recovering user, without removing cache.
+- Usable soft recovery and backgrounding: do nothing.
+
+The scoped cancel-then-remove (rather than a global `cancelQueries()` / `clear()`) is what prevents a stale sign-out or recovery callback, parked at its `await cancelQueries()` when a successor session starts, from aborting the successor's in-flight requests or erasing its freshly seeded cache after the await resolves.
 
 - [ ] **Step 6: Install isolation once from App**
 
@@ -1693,15 +1686,12 @@ export function retryDueCountQuery(failureCount: number, error: unknown): boolea
 Compute enablement:
 
 ```ts
-const sessionStatus = computed(() =>
-  selectMobileFeatureSessionStatus(coordinator.state),
-);
+const sessionStatus = computed(() => selectMobileFeatureSessionStatus(coordinator.state));
 
 const queryEnabled = computed(
   () =>
     sessionStatus.value.kind === 'usable' ||
-    (sessionStatus.value.kind === 'recovering' &&
-      sessionStatus.value.sessionUsable),
+    (sessionStatus.value.kind === 'recovering' && sessionStatus.value.sessionUsable),
 );
 ```
 
@@ -1710,11 +1700,7 @@ Use:
 ```ts
 useQuery({
   queryKey: computed(() =>
-    srsKeys.stats(
-      sessionStatus.value.kind === 'unavailable'
-        ? null
-        : sessionStatus.value.userId,
-    ),
+    srsKeys.stats(sessionStatus.value.kind === 'unavailable' ? null : sessionStatus.value.userId),
   ),
   enabled: queryEnabled,
   queryFn: ({ signal }) => fetchStatsWithSessionRaceRecovery(signal),
@@ -1889,10 +1875,7 @@ Implement:
 
 ```ts
 export function selectDueReviewView(input: DueReviewViewInput): DueReviewView {
-  const refreshing =
-    input.isFetching &&
-    input.stats !== undefined &&
-    !input.manualRetryPending;
+  const refreshing = input.isFetching && input.stats !== undefined && !input.manualRetryPending;
 
   if (input.sessionRecoveryPending) {
     if (input.stats === undefined) {
@@ -1958,9 +1941,7 @@ Implement a focused surface:
 <template>
   <q-page class="q-pa-lg">
     <section class="due-review" aria-labelledby="due-review-heading">
-      <h1 id="due-review-heading" class="text-h5 text-weight-bold">
-        Today’s review
-      </h1>
+      <h1 id="due-review-heading" class="text-h5 text-weight-bold">Today’s review</h1>
 
       <div
         v-if="view.kind === 'loading'"
@@ -1987,9 +1968,7 @@ Implement a focused surface:
                 : `${view.count} words are due for review.`
           }}
         </p>
-        <p v-if="view.refreshing" role="status" aria-live="polite">
-          Refreshing review count…
-        </p>
+        <p v-if="view.refreshing" role="status" aria-live="polite">Refreshing review count…</p>
       </template>
 
       <div v-else role="alert">

--- a/docs/superpowers/plans/2026-07-30-mobile-authenticated-due-review-count.md
+++ b/docs/superpowers/plans/2026-07-30-mobile-authenticated-due-review-count.md
@@ -2057,8 +2057,7 @@ git commit -m "feat(mobile): show authenticated due count"
 
 **Files:**
 
-- Modify only if evidence requires it:
-  - `docs/superpowers/plans/2026-07-30-mobile-authenticated-due-review-count.md` — check off completed steps during execution.
+- Modify only external tracking surfaces unless verification exposes a runtime defect:
   - HPA-207 Linear issue — attach or comment the verification matrix.
   - Implementation PR body — summarize automated and Simulator evidence.
 
@@ -2172,17 +2171,16 @@ Sign-out                 Count disappears immediately
 Account isolation        Later account never sees prior count
 ```
 
-- [ ] **Step 8: Commit plan bookkeeping only**
-
-Mark the completed checkboxes in this plan, then commit only the plan file:
+- [ ] **Step 8: Verify the runtime branch is clean and push it**
 
 ```bash
 cd $REPO_ROOT
-git add docs/superpowers/plans/2026-07-30-mobile-authenticated-due-review-count.md
-git commit -m "docs: record HPA-207 verification"
+git status --short
+git log --oneline --decorate -10
+git push -u origin codex/hpa-207-mobile-due-review-count
 ```
 
-Do not stage generated Xcode files, environment files, build output, coverage HTML, or unrelated changes.
+Expected: `git status --short` is empty, the task commits are visible, and the branch pushes successfully.
 
 - [ ] **Step 9: Create the implementation PR body and open the draft PR**
 
@@ -2211,10 +2209,9 @@ Physical-development-iPhone verification remains required before HPA-207 closes.
 ## Tracking
 
 - Linear: HPA-207
-- Design: PR #52
+- Design and plan: PR #52
 EOF
 
-git push -u origin codex/hpa-207-mobile-due-review-count
 gh pr create \
   --draft \
   --base main \

--- a/docs/superpowers/plans/2026-07-30-mobile-authenticated-due-review-count.md
+++ b/docs/superpowers/plans/2026-07-30-mobile-authenticated-due-review-count.md
@@ -1,0 +1,2230 @@
+# Authenticated Mobile Due-Review Count Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver the HPA-207 vertical slice in which a restored, authenticated iOS user reaches Home and sees the current `due_today` value from `GET /api/srs/stats`, with bounded latency, generation-safe authentication recovery, user-scoped cache isolation, and accessible loading/error/retry states.
+
+**Architecture:** Keep `MobileAuthCoordinator` as the sole owner of Cognito token material. Add an authenticated feature-request operation that performs ordinary feature I/O outside the coordinator mutation queue, enters serialized auth work only for current-generation 401 recovery, and reports stable typed outcomes. Layer a mobile JSON client and SRS service over that boundary, manage server state with a mobile TanStack Query client keyed by user identity, and map query/auth state through pure selectors before rendering Home.
+
+**Tech Stack:** TypeScript 5.6, Vue 3, Quasar 2, Capacitor 7, TanStack Vue Query 5.90.x, Vitest 3, Vue Test Utils, Bun 1.3.1, `@vela/common`.
+
+## Global Constraints
+
+- `$REPO_ROOT` is the repository root containing `apps/`, `packages/`, and `docs/`.
+- Author this plan on `agent/hpa-207-due-review-count-design-draft`. Implement the runtime work in a fresh worktree/branch based on the latest `main` that contains PR #52, using branch `codex/hpa-207-mobile-due-review-count`.
+- Treat `docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md` as the accepted behavioral contract.
+- Keep `apps/vela-mobile/src/services/mobile-auth.ts` as the only owner of active Cognito ID/access/refresh token material. Do not add `getIdToken()` or expose bearer headers outside the coordinator.
+- `requestAuthenticatedApi()` must execute feature transport outside `serialize()` / `operationTail`. Only refresh, verification, and cleanup mutations enter the serialized auth queue.
+- Return every non-401 HTTP response even when auth generation changed while the request was in flight. Generation checks guard only 401-driven auth mutation.
+- A stale-generation 401 must never refresh, clean up, or otherwise mutate the replacement session.
+- Concurrent current-generation 401s for one owner/generation share one recovery decision. Each feature request retries its own request at most once after verified promotion.
+- Never infer refresh success from `queueRefresh(): Promise<void>` settlement. Derive `promoted`, recovery-owned `terminal`, `superseded`, or `retryable_failure` from explicit postconditions in that order.
+- Keep the coordinator's physical fetch safety cap at `MOBILE_AUTH_NETWORK_TIMEOUT_MS` (15 seconds). Apply `MOBILE_DUE_COUNT_EXECUTION_TIMEOUT_MS = 8_000` to one full due-count query execution, including one recovery wait, one feature retry, and JSON body consumption.
+- TanStack automatic retries apply only to `MobileApiError('network')` and `MobileApiError('server')`, with `failureCount < 2`.
+- Use `srsKeys.stats(userId, jlpt)` for user-specific stats. Do not change `srsKeys.due`, `progress`, or `allProgress` beyond adding the identity-scope warning required by the design.
+- Add `@vela/common` source aliases to both mobile Quasar and Vitest configuration so per-app commands never consume stale `packages/common/dist`.
+- Do not migrate the web SRS card to TanStack Query. The web service only imports/re-exports the shared contract.
+- Do not add review-session navigation, due-card retrieval, offline persistence, connectivity plugins, polling, background tasks, Android support, or backend route changes.
+- Do not log tokens, Authorization headers, request objects, raw auth/API payloads, path values rejected by the safety boundary, decoded claims, or native/plugin exceptions.
+- Maintain the mobile package's configured 95% line-coverage threshold.
+- Automated tests, typecheck, lint, production mobile build, and iOS Simulator flow are merge gates. Physical-development-iPhone evidence is an HPA-207 closure gate, not an implementation-PR merge gate.
+
+---
+
+## File Structure
+
+### New files
+
+- `packages/common/src/contracts/srs.ts` — shared `SRSStats` type and strict runtime parser.
+- `packages/common/src/contracts/srs.test.ts` — parser acceptance/rejection matrix.
+- `apps/vela-mobile/src/boot/query.ts` — mobile `QueryClient` singleton and `VueQueryPlugin` boot.
+- `apps/vela-mobile/src/boot/query.test.ts` — singleton/plugin wiring tests.
+- `apps/vela-mobile/src/auth/mobile-feature-session-status.ts` — auth-owned semantic selector for feature consumers.
+- `apps/vela-mobile/src/auth/mobile-feature-session-status.test.ts` — selector state matrix.
+- `apps/vela-mobile/src/services/mobile-api-client.ts` — bounded JSON client and feature-facing error normalization.
+- `apps/vela-mobile/src/services/mobile-api-client.test.ts` — deadline, cancellation, raw rejection, HTTP, and body-read tests.
+- `apps/vela-mobile/src/services/mobile-srs.ts` — `srs/stats` service over the mobile JSON client.
+- `apps/vela-mobile/src/services/mobile-srs.test.ts` — exact path/signal/parser tests.
+- `apps/vela-mobile/src/services/mobile-services.ts` — typed injection keys and direct service provisioning.
+- `apps/vela-mobile/src/services/mobile-services.test.ts` — provider construction tests.
+- `apps/vela-mobile/src/services/mobile-query-auth-isolation.ts` — cancel/clear lifecycle tied to auth identity.
+- `apps/vela-mobile/src/services/mobile-query-auth-isolation.test.ts` — cancellation, clear, retention, and identity tests.
+- `apps/vela-mobile/src/composables/useDueReviewCount.ts` — due-count query, control-race retry, recovery refetch, and manual retry state.
+- `apps/vela-mobile/src/composables/useDueReviewCount.test.ts` — query/recovery/retry behavior.
+- `apps/vela-mobile/src/components/home/due-review-view.ts` — pure query/auth-state-to-presentation selector.
+- `apps/vela-mobile/src/components/home/due-review-view.test.ts` — exhaustive presentation matrix.
+
+### Existing files to modify
+
+- `packages/common/src/keys.ts`
+- `packages/common/src/keys.test.ts`
+- `packages/common/src/index.ts`
+- `apps/vela/src/services/srsService.ts`
+- `apps/vela/src/services/srsService.test.ts`
+- `CLAUDE.md`
+- `apps/vela-mobile/package.json`
+- `bun.lock`
+- `apps/vela-mobile/quasar.config.ts`
+- `apps/vela-mobile/vitest.config.ts`
+- `apps/vela-mobile/src/boot/boot-files.ts`
+- `apps/vela-mobile/src/boot/boot-files.test.ts`
+- `apps/vela-mobile/src/boot/capacitor-lifecycle.ts`
+- `apps/vela-mobile/src/boot/capacitor-lifecycle.test.ts`
+- `apps/vela-mobile/src/boot/mobile-auth.ts`
+- `apps/vela-mobile/src/boot/mobile-auth.test.ts`
+- `apps/vela-mobile/src/auth/mobile-auth-contract.ts`
+- `apps/vela-mobile/src/services/mobile-auth.ts`
+- `apps/vela-mobile/src/services/mobile-auth.test.ts`
+- `apps/vela-mobile/src/test/secret-leak-helpers.ts`
+- `apps/vela-mobile/src/App.vue`
+- `apps/vela-mobile/src/App.test.ts`
+- `apps/vela-mobile/src/pages/HomePage.vue`
+- `apps/vela-mobile/src/pages/HomePage.test.ts`
+- Coordinator fixture files that construct a `MobileAuthCoordinator` literal:
+  - `apps/vela-mobile/src/pages/MorePage.test.ts`
+  - `apps/vela-mobile/src/pages/StubPages.test.ts`
+  - `apps/vela-mobile/src/components/mobile/MobileAuthGate.navigation.test.ts`
+  - `apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts`
+
+### Files to inspect but not modify unless a test proves drift
+
+- `apps/vela-api/src/routes/srs.ts` — source of the production stats shape.
+- `apps/vela-api/src/middleware/auth.ts` — already accepts both web and mobile client IDs.
+- `packages/cdk/lib/api-stack.ts` — already injects `COGNITO_MOBILE_CLIENT_ID`.
+- `apps/vela-mobile/src/components/mobile/MobileAuthGate.vue` — remains the owner of blocking auth recovery UI.
+- `apps/vela-mobile/src/components/mobile/mobile-auth-gate-view.ts` — protected-content gating remains based on `sessionUsable`.
+
+## Execution Preflight
+
+- [ ] **Step 1: Create an isolated implementation worktree**
+
+```bash
+cd $REPO_ROOT
+git fetch origin main
+git worktree add ../Vela-hpa-207 -b codex/hpa-207-mobile-due-review-count origin/main
+cd ../Vela-hpa-207
+```
+
+Expected: the new worktree is on `codex/hpa-207-mobile-due-review-count` with a clean working tree.
+
+- [ ] **Step 2: Confirm the accepted design is present**
+
+```bash
+test -f docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
+git status --short
+```
+
+Expected: the design file exists and `git status --short` is empty.
+
+- [ ] **Step 3: Install the pinned workspace dependencies**
+
+```bash
+bun install --frozen-lockfile
+```
+
+Expected: exit 0 with no lockfile changes before Task 2.
+
+---
+
+### Task 1: Share the SRS Stats Contract and User-Scope the Stats Key
+
+**Files:**
+
+- Create: `packages/common/src/contracts/srs.ts`
+- Create: `packages/common/src/contracts/srs.test.ts`
+- Modify: `packages/common/src/keys.ts`
+- Modify: `packages/common/src/keys.test.ts`
+- Modify: `packages/common/src/index.ts`
+- Modify: `apps/vela/src/services/srsService.ts`
+- Modify: `apps/vela/src/services/srsService.test.ts`
+- Modify: `CLAUDE.md`
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+export interface SRSStats {
+  total_items: number;
+  due_today: number;
+  mastery_breakdown: {
+    new: number;
+    learning: number;
+    reviewing: number;
+    mastered: number;
+  };
+  average_ease_factor: number;
+  total_reviews: number;
+  accuracy_rate: number;
+}
+
+export function parseSrsStats(value: unknown): SRSStats;
+
+export const srsKeys: {
+  all: readonly ['srs'];
+  stats(userId: string | null, jlpt?: number[]): readonly [
+    'srs',
+    'stats',
+    string | null,
+    number[] | undefined,
+  ];
+};
+```
+
+- Consumed by Tasks 6–9 through `MobileSrsService`, `useDueReviewCount()`, and the Home presentation selector.
+
+- [ ] **Step 1: Write the failing parser tests**
+
+Create `packages/common/src/contracts/srs.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { parseSrsStats, type SRSStats } from './srs';
+
+const validStats: SRSStats = {
+  total_items: 12,
+  due_today: 3,
+  mastery_breakdown: {
+    new: 2,
+    learning: 4,
+    reviewing: 3,
+    mastered: 3,
+  },
+  average_ease_factor: 2.47,
+  total_reviews: 31,
+  accuracy_rate: 87,
+};
+
+describe('parseSrsStats', () => {
+  it('parses the complete production response and ignores additive fields', () => {
+    expect(parseSrsStats({ ...validStats, generated_at: '2026-07-30T00:00:00Z' })).toEqual(
+      validStats,
+    );
+  });
+
+  it.each([
+    ['total_items', { ...validStats, total_items: -1 }],
+    ['due_today', { ...validStats, due_today: 1.5 }],
+    [
+      'mastery_breakdown.new',
+      {
+        ...validStats,
+        mastery_breakdown: { ...validStats.mastery_breakdown, new: Number.NaN },
+      },
+    ],
+    ['average_ease_factor', { ...validStats, average_ease_factor: Number.POSITIVE_INFINITY }],
+    ['accuracy_rate', { ...validStats, accuracy_rate: 101 }],
+  ])('rejects invalid %s', (field, value) => {
+    expect(() => parseSrsStats(value)).toThrow(`invalid_srs_stats:${field}`);
+  });
+
+  it('rejects a missing nested field', () => {
+    const { mastered: _mastered, ...mastery_breakdown } = validStats.mastery_breakdown;
+    expect(() => parseSrsStats({ ...validStats, mastery_breakdown })).toThrow(
+      'invalid_srs_stats:mastery_breakdown.mastered',
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Update the stats-key tests first**
+
+Replace the existing `stats` cases in `packages/common/src/keys.test.ts` with:
+
+```ts
+it('stats scopes the tuple by user and jlpt', () => {
+  expect(srsKeys.stats('user-1', [2, 3])).toEqual(['srs', 'stats', 'user-1', [2, 3]]);
+});
+
+it('stats preserves null user and undefined jlpt', () => {
+  expect(srsKeys.stats(null)).toEqual(['srs', 'stats', null, undefined]);
+});
+
+it('stats produces distinct keys for distinct users', () => {
+  expect(srsKeys.stats('user-1')).not.toEqual(srsKeys.stats('user-2'));
+});
+```
+
+- [ ] **Step 3: Run the focused tests and verify they fail**
+
+```bash
+cd $REPO_ROOT/packages/common
+bun run test:unit -- src/contracts/srs.test.ts src/keys.test.ts
+```
+
+Expected: FAIL because `contracts/srs.ts` does not exist and `srsKeys.stats` still accepts only JLPT levels.
+
+- [ ] **Step 4: Implement the shared parser**
+
+Create `packages/common/src/contracts/srs.ts`:
+
+```ts
+export interface SRSStats {
+  total_items: number;
+  due_today: number;
+  mastery_breakdown: {
+    new: number;
+    learning: number;
+    reviewing: number;
+    mastered: number;
+  };
+  average_ease_factor: number;
+  total_reviews: number;
+  accuracy_rate: number;
+}
+
+function record(value: unknown, field: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new TypeError(`invalid_srs_stats:${field}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function nonNegativeInteger(value: unknown, field: string): number {
+  if (!Number.isInteger(value) || (value as number) < 0) {
+    throw new TypeError(`invalid_srs_stats:${field}`);
+  }
+  return value as number;
+}
+
+function finiteNonNegative(value: unknown, field: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw new TypeError(`invalid_srs_stats:${field}`);
+  }
+  return value;
+}
+
+export function parseSrsStats(value: unknown): SRSStats {
+  const root = record(value, 'root');
+  const mastery = record(root.mastery_breakdown, 'mastery_breakdown');
+  const accuracyRate = finiteNonNegative(root.accuracy_rate, 'accuracy_rate');
+
+  if (accuracyRate > 100) {
+    throw new TypeError('invalid_srs_stats:accuracy_rate');
+  }
+
+  return {
+    total_items: nonNegativeInteger(root.total_items, 'total_items'),
+    due_today: nonNegativeInteger(root.due_today, 'due_today'),
+    mastery_breakdown: {
+      new: nonNegativeInteger(mastery.new, 'mastery_breakdown.new'),
+      learning: nonNegativeInteger(mastery.learning, 'mastery_breakdown.learning'),
+      reviewing: nonNegativeInteger(mastery.reviewing, 'mastery_breakdown.reviewing'),
+      mastered: nonNegativeInteger(mastery.mastered, 'mastery_breakdown.mastered'),
+    },
+    average_ease_factor: finiteNonNegative(
+      root.average_ease_factor,
+      'average_ease_factor',
+    ),
+    total_reviews: nonNegativeInteger(root.total_reviews, 'total_reviews'),
+    accuracy_rate: accuracyRate,
+  };
+}
+```
+
+- [ ] **Step 5: Export the contract and change the stats key**
+
+Update `packages/common/src/index.ts` so its header names `@vela/common`, mentions domain contracts, and add:
+
+```ts
+export { parseSrsStats, type SRSStats } from './contracts/srs';
+```
+
+Update `packages/common/src/keys.ts`:
+
+```ts
+export const srsKeys = {
+  all: ['srs'] as const,
+  // Identity-unscoped legacy keys. Do not use these for mobile user data until
+  // their identity and cache-isolation contract is redesigned.
+  due: (limit?: number, jlpt?: number[]) => [...srsKeys.all, 'due', limit, jlpt] as const,
+  stats: (userId: string | null, jlpt?: number[]) =>
+    [...srsKeys.all, 'stats', userId, jlpt] as const,
+  progress: (vocabularyId: string) => [...srsKeys.all, 'progress', vocabularyId] as const,
+  allProgress: () => [...srsKeys.all, 'all'] as const,
+};
+```
+
+- [ ] **Step 6: Remove the web duplicate without changing web behavior**
+
+At the top of `apps/vela/src/services/srsService.ts`, add:
+
+```ts
+import type { SRSStats } from '@vela/common';
+export type { SRSStats } from '@vela/common';
+```
+
+Delete the local `SRSStats` interface and leave `getStats()` and every HTTP call unchanged.
+
+In `apps/vela/src/services/srsService.test.ts`, type the existing successful stats fixture through the service re-export:
+
+```ts
+import { srsService, type SRSStats } from './srsService';
+
+const statsResponse: SRSStats = {
+  total_items: 1,
+  due_today: 1,
+  mastery_breakdown: { new: 0, learning: 1, reviewing: 0, mastered: 0 },
+  average_ease_factor: 2.5,
+  total_reviews: 2,
+  accuracy_rate: 50,
+};
+```
+
+Use `statsResponse` in the existing `getStats` test so the re-export is compile-checked.
+
+- [ ] **Step 7: Correct the stale repository guidance**
+
+In `CLAUDE.md`, mark the mobile-audience verifier prerequisite as completed and state that `initializeAuthVerifier()` already accepts `[webClientId, mobileClientId]`. Do not change the remaining mobile-authentication guidance.
+
+- [ ] **Step 8: Run shared and web service tests**
+
+```bash
+cd $REPO_ROOT/packages/common
+bun run test:unit -- src/contracts/srs.test.ts src/keys.test.ts
+
+cd $REPO_ROOT/apps/vela
+bun vitest run src/services/srsService.test.ts
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd $REPO_ROOT
+git add \
+  packages/common/src/contracts/srs.ts \
+  packages/common/src/contracts/srs.test.ts \
+  packages/common/src/keys.ts \
+  packages/common/src/keys.test.ts \
+  packages/common/src/index.ts \
+  apps/vela/src/services/srsService.ts \
+  apps/vela/src/services/srsService.test.ts \
+  CLAUDE.md
+git commit -m "feat(common): share SRS stats contract"
+```
+
+---
+
+### Task 2: Add Mobile Query Dependencies, Source Aliases, and Query Boot
+
+**Files:**
+
+- Modify: `apps/vela-mobile/package.json`
+- Modify: `bun.lock`
+- Modify: `apps/vela-mobile/quasar.config.ts`
+- Modify: `apps/vela-mobile/vitest.config.ts`
+- Create: `apps/vela-mobile/src/boot/query.ts`
+- Create: `apps/vela-mobile/src/boot/query.test.ts`
+- Modify: `apps/vela-mobile/src/boot/boot-files.ts`
+- Modify: `apps/vela-mobile/src/boot/boot-files.test.ts`
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+export const mobileQueryClient: QueryClient;
+```
+
+- Boot order:
+
+```text
+main
+query
+mobile-auth
+capacitor-lifecycle
+diagnostic-cold-entry
+```
+
+- Consumed by Tasks 7–9.
+
+- [ ] **Step 1: Write the failing boot tests**
+
+Create `apps/vela-mobile/src/boot/query.test.ts`:
+
+```ts
+import { VueQueryPlugin } from '@tanstack/vue-query';
+import { describe, expect, it, vi } from 'vitest';
+import queryBoot, { mobileQueryClient } from './query';
+
+describe('mobile query boot', () => {
+  it('installs the exported singleton into Vue Query', () => {
+    const app = { use: vi.fn() };
+
+    queryBoot({ app } as never);
+
+    expect(app.use).toHaveBeenCalledWith(VueQueryPlugin, {
+      queryClient: mobileQueryClient,
+    });
+  });
+});
+```
+
+Update every expected array in `apps/vela-mobile/src/boot/boot-files.test.ts` to insert `'query'` immediately after `'main'`.
+
+- [ ] **Step 2: Run the boot tests and verify they fail**
+
+```bash
+cd $REPO_ROOT/apps/vela-mobile
+bun run test:unit -- src/boot/query.test.ts src/boot/boot-files.test.ts
+```
+
+Expected: FAIL because `query.ts` does not exist and boot ordering has not changed.
+
+- [ ] **Step 3: Add exact workspace dependencies**
+
+Update `apps/vela-mobile/package.json` dependencies:
+
+```json
+{
+  "@tanstack/vue-query": "^5.90.5",
+  "@vela/common": "workspace:*",
+  "@quasar/extras": "^1.16.4",
+  "quasar": "^2.16.0",
+  "vue": "^3.4.18",
+  "vue-router": "^4.3.0"
+}
+```
+
+Then refresh the root lockfile:
+
+```bash
+cd $REPO_ROOT
+bun install
+```
+
+Expected: `bun.lock` changes and resolves the workspace package plus TanStack Vue Query.
+
+- [ ] **Step 4: Add source aliases to both mobile toolchains**
+
+In `apps/vela-mobile/quasar.config.ts`, add to `build.alias`:
+
+```ts
+'@vela/common': resolve(__dirname, '../../packages/common/src/index.ts'),
+```
+
+In `apps/vela-mobile/vitest.config.ts`, add to `resolve.alias`:
+
+```ts
+'@vela/common': resolve(__dirname, '../../packages/common/src/index.ts'),
+```
+
+- [ ] **Step 5: Implement the query boot and ordering**
+
+Create `apps/vela-mobile/src/boot/query.ts`:
+
+```ts
+import { createQueryClient } from '@vela/common';
+import { VueQueryPlugin } from '@tanstack/vue-query';
+import { defineBoot } from '#q-app/wrappers';
+
+export const mobileQueryClient = createQueryClient();
+
+export default defineBoot(({ app }) => {
+  app.use(VueQueryPlugin, { queryClient: mobileQueryClient });
+});
+```
+
+Update `getMobileBootFiles()`:
+
+```ts
+return [
+  'main',
+  'query',
+  'mobile-auth',
+  ...(flags.isCapacitor ? ['capacitor-lifecycle'] : []),
+  ...(flags.isDevelopment ? ['diagnostic-cold-entry'] : []),
+];
+```
+
+- [ ] **Step 6: Prove per-app tests use source instead of stale `dist`**
+
+```bash
+cd $REPO_ROOT
+rm -rf packages/common/dist
+
+cd apps/vela-mobile
+bun run test:unit -- src/boot/query.test.ts src/boot/boot-files.test.ts
+bun run typecheck
+```
+
+Expected: both commands PASS even though `packages/common/dist` is absent.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd $REPO_ROOT
+git add \
+  apps/vela-mobile/package.json \
+  bun.lock \
+  apps/vela-mobile/quasar.config.ts \
+  apps/vela-mobile/vitest.config.ts \
+  apps/vela-mobile/src/boot/query.ts \
+  apps/vela-mobile/src/boot/query.test.ts \
+  apps/vela-mobile/src/boot/boot-files.ts \
+  apps/vela-mobile/src/boot/boot-files.test.ts
+git commit -m "feat(mobile): bootstrap query state"
+```
+
+---
+
+### Task 3: Define the Authenticated Request Contract and Feature Session Selector
+
+**Files:**
+
+- Modify: `apps/vela-mobile/src/auth/mobile-auth-contract.ts`
+- Create: `apps/vela-mobile/src/auth/mobile-feature-session-status.ts`
+- Create: `apps/vela-mobile/src/auth/mobile-feature-session-status.test.ts`
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+export type MobileAuthenticatedApiRequest = {
+  path: string;
+  init?: Omit<RequestInit, 'headers'> & { headers?: HeadersInit };
+};
+
+export type MobileAuthenticatedApiRequestErrorCode =
+  | 'invalid_request_path'
+  | 'invalid_request_headers'
+  | 'request_timeout'
+  | 'session_unavailable'
+  | 'session_changed'
+  | 'session_recovery_pending';
+
+export class MobileAuthenticatedApiRequestError extends Error {
+  readonly code: MobileAuthenticatedApiRequestErrorCode;
+}
+
+export type MobileFeatureSessionStatus =
+  | { kind: 'usable'; userId: string }
+  | { kind: 'recovering'; userId: string; sessionUsable: boolean }
+  | { kind: 'unavailable' };
+
+export function selectMobileFeatureSessionStatus(
+  state: Readonly<MobileAuthState>,
+): MobileFeatureSessionStatus;
+```
+
+- Task 4 adds `requestAuthenticatedApi()` to `MobileAuthCoordinator` together with the real implementation.
+- Consumed by Tasks 4–9.
+
+- [ ] **Step 1: Write the selector matrix first**
+
+Create `apps/vela-mobile/src/auth/mobile-feature-session-status.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import type { MobileAuthState } from './mobile-auth-contract';
+import { selectMobileFeatureSessionStatus } from './mobile-feature-session-status';
+
+const authenticated: MobileAuthState = {
+  phase: 'authenticated',
+  operation: 'idle',
+  sessionUsable: true,
+  errorCode: null,
+  retryAction: null,
+  notice: null,
+  user: { userId: 'user-1', email: null },
+};
+
+describe('selectMobileFeatureSessionStatus', () => {
+  it('returns usable for a verified idle session', () => {
+    expect(selectMobileFeatureSessionStatus(authenticated)).toEqual({
+      kind: 'usable',
+      userId: 'user-1',
+    });
+  });
+
+  it.each([
+    [{ ...authenticated, operation: 'refreshing' as const }, true],
+    [
+      {
+        ...authenticated,
+        sessionUsable: false,
+        errorCode: 'session_refresh_failed' as const,
+        retryAction: 'refresh' as const,
+      },
+      false,
+    ],
+  ])('returns recovering and preserves capability', (state, sessionUsable) => {
+    expect(selectMobileFeatureSessionStatus(state)).toEqual({
+      kind: 'recovering',
+      userId: 'user-1',
+      sessionUsable,
+    });
+  });
+
+  it.each([
+    { ...authenticated, phase: 'signedOut' as const, sessionUsable: false, user: null },
+    { ...authenticated, operation: 'signingOut' as const, sessionUsable: false },
+    { ...authenticated, operation: 'cleaningUp' as const, sessionUsable: false },
+  ])('returns unavailable for blocking auth state', (state) => {
+    expect(selectMobileFeatureSessionStatus(state)).toEqual({ kind: 'unavailable' });
+  });
+});
+```
+
+- [ ] **Step 2: Run the selector test and verify it fails**
+
+```bash
+cd $REPO_ROOT/apps/vela-mobile
+bun run test:unit -- src/auth/mobile-feature-session-status.test.ts
+```
+
+Expected: FAIL because the selector file and new request contract do not exist.
+
+- [ ] **Step 3: Add the public request types**
+
+Append the request/error types to `mobile-auth-contract.ts`, implement the error class exactly as:
+
+```ts
+export class MobileAuthenticatedApiRequestError extends Error {
+  constructor(
+    readonly code: MobileAuthenticatedApiRequestErrorCode,
+    options?: { cause?: unknown },
+  ) {
+    super(code, options);
+    this.name = 'MobileAuthenticatedApiRequestError';
+  }
+}
+```
+
+
+- [ ] **Step 4: Implement the auth-owned selector**
+
+Create `apps/vela-mobile/src/auth/mobile-feature-session-status.ts`:
+
+```ts
+import type { MobileAuthState } from './mobile-auth-contract';
+
+export type MobileFeatureSessionStatus =
+  | { kind: 'usable'; userId: string }
+  | { kind: 'recovering'; userId: string; sessionUsable: boolean }
+  | { kind: 'unavailable' };
+
+export function selectMobileFeatureSessionStatus(
+  state: Readonly<MobileAuthState>,
+): MobileFeatureSessionStatus {
+  const userId = state.user?.userId;
+  if (state.phase !== 'authenticated' || !userId) {
+    return { kind: 'unavailable' };
+  }
+
+  const recovering =
+    state.operation === 'refreshing' ||
+    state.operation === 'persisting' ||
+    state.operation === 'verifying' ||
+    state.retryAction === 'refresh' ||
+    state.retryAction === 'persist' ||
+    state.retryAction === 'verify';
+
+  if (recovering) {
+    return { kind: 'recovering', userId, sessionUsable: state.sessionUsable };
+  }
+
+  if (
+    state.operation === 'idle' &&
+    state.sessionUsable &&
+    state.errorCode === null &&
+    state.retryAction === null &&
+    state.notice === null
+  ) {
+    return { kind: 'usable', userId };
+  }
+
+  return { kind: 'unavailable' };
+}
+```
+
+- [ ] **Step 5: Run selector and contract tests**
+
+```bash
+cd $REPO_ROOT/apps/vela-mobile
+bun run test:unit -- src/auth/mobile-feature-session-status.test.ts
+bun run typecheck
+```
+
+Expected: PASS. `MobileAuthCoordinator` has not changed yet, so existing coordinator fixtures remain valid.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd $REPO_ROOT
+git add \
+  apps/vela-mobile/src/auth/mobile-auth-contract.ts \
+  apps/vela-mobile/src/auth/mobile-feature-session-status.ts \
+  apps/vela-mobile/src/auth/mobile-feature-session-status.test.ts
+git commit -m "feat(mobile): define feature auth contracts"
+```
+
+---
+
+### Task 4: Implement Safe Feature Transport Outside the Auth Mutation Queue
+
+**Files:**
+
+- Modify: `apps/vela-mobile/src/auth/mobile-auth-contract.ts`
+- Modify: `apps/vela-mobile/src/services/mobile-auth.ts`
+- Modify: `apps/vela-mobile/src/services/mobile-auth.test.ts`
+- Modify: `apps/vela-mobile/src/test/secret-leak-helpers.ts`
+- Modify typed coordinator fixtures:
+  - `apps/vela-mobile/src/App.test.ts`
+  - `apps/vela-mobile/src/pages/MorePage.test.ts`
+  - `apps/vela-mobile/src/pages/StubPages.test.ts`
+  - `apps/vela-mobile/src/components/mobile/MobileAuthGate.navigation.test.ts`
+  - `apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts`
+
+**Interfaces:**
+
+- Produces internal helpers:
+
+```ts
+function normalizeMobileApiBaseUrl(apiUrl: string): URL;
+function resolveMobileApiUrl(baseUrl: URL, relativePath: string): URL;
+
+type AuthenticatedFeatureSnapshot = {
+  owner: ActiveSession;
+  generation: number;
+  idToken: string;
+  expiresAt: number;
+  userId: string;
+};
+
+async function dispatchAuthenticatedFeatureAttempt(
+  request: MobileAuthenticatedApiRequest,
+  snapshot: AuthenticatedFeatureSnapshot,
+): Promise<Response>;
+```
+
+- `MobileAuthCoordinator` gains:
+
+```ts
+requestAuthenticatedApi(request: MobileAuthenticatedApiRequest): Promise<Response>;
+```
+
+- Public `requestAuthenticatedApi()` handles validation, one physical fetch, timeout, cancellation, non-401 response ordering, and stale-401 rejection. Task 5 adds current-generation 401 recovery.
+
+- [ ] **Step 1: Add failing transport-boundary tests**
+
+Extend `mobile-auth.test.ts` with cases that prove:
+
+```ts
+it('rejects path escapes before network activity', async () => {
+  const harness = makeHarness();
+  await authenticate(harness);
+  const before = harness.sessionFetch.mock.calls.length;
+
+  for (const path of [
+    'https://evil.example/steal',
+    '//evil.example/steal',
+    '/api/srs/stats',
+    '../secret',
+    '%2e%2e/secret',
+    String.raw`..\secret`,
+    'srs/stats#fragment',
+  ]) {
+    await expect(
+      harness.coordinator.requestAuthenticatedApi({ path }),
+    ).rejects.toMatchObject({ code: 'invalid_request_path' });
+  }
+
+  expect(harness.sessionFetch).toHaveBeenCalledTimes(before);
+});
+
+it.each(['Authorization', 'authorization', 'AUTHORIZATION', 'AuThOrIzAtIoN'])(
+  'rejects caller-owned %s',
+  async (header) => {
+    const harness = makeHarness();
+    await authenticate(harness);
+
+    await expect(
+      harness.coordinator.requestAuthenticatedApi({
+        path: 'srs/stats',
+        init: { headers: { [header]: 'Bearer attacker' } },
+      }),
+    ).rejects.toMatchObject({ code: 'invalid_request_headers' });
+  },
+);
+```
+
+Add tests for:
+
+- base `https://vela.example/api` and `https://vela.example/api///` both resolve to `/api/srs/stats`;
+- `/api-evil/secret` is rejected for base `/api/`;
+- the coordinator supplies exactly one `Authorization: Bearer <current-id-token>`;
+- caller abort stays an `AbortError`;
+- 15-second attempt timeout becomes `request_timeout`;
+- raw fetch rejection propagates without auth-state mutation;
+- a 200 and a 500 both return after concurrent successful refresh promotion;
+- a stale-generation 401 becomes `session_changed` without cleanup;
+- a pending feature fetch does not block `signOut()`, `retryCurrentOperation()`, or `dispose()`.
+
+- [ ] **Step 2: Run the focused coordinator tests and verify failure**
+
+```bash
+cd $REPO_ROOT/apps/vela-mobile
+bun run test:unit -- src/services/mobile-auth.test.ts
+```
+
+Expected: FAIL because the public method and safety boundary are not implemented.
+
+- [ ] **Step 3: Implement URL normalization and path containment**
+
+Add these coordinator-local helpers in `mobile-auth.ts`:
+
+```ts
+function normalizeMobileApiBaseUrl(apiUrl: string): URL {
+  const base = new URL(apiUrl);
+  base.search = '';
+  base.hash = '';
+  base.pathname = `${base.pathname.replace(/\/+$/u, '')}/`;
+  return base;
+}
+
+function resolveMobileApiUrl(base: URL, relativePath: string): URL {
+  if (
+    relativePath.length === 0 ||
+    relativePath.startsWith('/') ||
+    relativePath.startsWith('\\') ||
+    relativePath.includes('\\') ||
+    relativePath.includes('#') ||
+    /^[a-z][a-z\d+.-]*:/iu.test(relativePath) ||
+    relativePath.startsWith('//')
+  ) {
+    throw new MobileAuthenticatedApiRequestError('invalid_request_path');
+  }
+
+  const resolved = new URL(relativePath, base);
+  if (resolved.origin !== base.origin || !resolved.pathname.startsWith(base.pathname)) {
+    throw new MobileAuthenticatedApiRequestError('invalid_request_path');
+  }
+
+  return resolved;
+}
+```
+
+Before resolving, decode each path segment once:
+
+```ts
+for (const segment of relativePath.split('/')) {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(segment);
+  } catch {
+    throw new MobileAuthenticatedApiRequestError('invalid_request_path');
+  }
+  if (decoded === '.' || decoded === '..' || decoded.includes('\\')) {
+    throw new MobileAuthenticatedApiRequestError('invalid_request_path');
+  }
+}
+```
+
+Keep the parsed-origin and trailing-pathname check as the final boundary.
+
+Replace `sessionUrl()` with:
+
+```ts
+const apiBaseUrl = normalizeMobileApiBaseUrl(dependencies.config.apiUrl);
+resolveMobileApiUrl(apiBaseUrl, 'auth/session');
+```
+
+- [ ] **Step 4: Implement case-insensitive header ownership**
+
+Create caller headers through `new Headers(request.init?.headers)`, reject `headers.has('authorization')`, then set:
+
+```ts
+headers.set('Accept', headers.get('Accept') ?? 'application/json');
+headers.set('Authorization', `Bearer ${snapshot.idToken}`);
+```
+
+Never include header contents in thrown errors or logs.
+
+- [ ] **Step 5: Implement one bounded feature fetch outside `serialize()`**
+
+Add `dispatchAuthenticatedFeatureAttempt()` with:
+
+```ts
+const controller = new AbortController();
+let timeoutExpired = false;
+
+const onCallerAbort = () => controller.abort();
+request.init?.signal?.addEventListener('abort', onCallerAbort, { once: true });
+
+const timeout = setTimeout(() => {
+  timeoutExpired = true;
+  controller.abort();
+}, MOBILE_AUTH_NETWORK_TIMEOUT_MS);
+
+try {
+  return await dependencies.fetch(target, {
+    ...request.init,
+    headers,
+    signal: controller.signal,
+  });
+} catch (error) {
+  if (request.init?.signal?.aborted) {
+    throw new DOMException('The operation was aborted.', 'AbortError');
+  }
+  if (timeoutExpired) {
+    throw new MobileAuthenticatedApiRequestError('request_timeout', { cause: error });
+  }
+  throw error;
+} finally {
+  clearTimeout(timeout);
+  request.init?.signal?.removeEventListener('abort', onCallerAbort);
+}
+```
+
+`requestAuthenticatedApi()` must synchronously snapshot `active`, `activeBundleGeneration`, ID token, expiry, and user before starting this helper. Do not call `serialize()` around the feature fetch.
+
+After the response:
+
+```ts
+if (response.status !== 401) return response;
+if (active !== snapshot.owner || activeBundleGeneration !== snapshot.generation) {
+  throw new MobileAuthenticatedApiRequestError('session_changed');
+}
+return response; // Task 5 replaces this current-generation branch with shared recovery.
+```
+
+- [ ] **Step 6: Add the method to the coordinator interface and typed fixtures**
+
+Add `requestAuthenticatedApi()` to `MobileAuthCoordinator` in `mobile-auth-contract.ts`.
+
+Add this fail-closed member to every typed coordinator fixture listed in this task:
+
+```ts
+requestAuthenticatedApi: vi
+  .fn()
+  .mockRejectedValue(new MobileAuthenticatedApiRequestError('session_unavailable')),
+```
+
+The real coordinator returned by `createMobileAuthCoordinator()` uses the implementation from Step 5.
+
+- [ ] **Step 7: Extend secret-leak assertions**
+
+Add sentinel Authorization header and rejected-path values to the existing secret-leak helper input, then assert they do not appear in console calls, error messages, rendered state, or JSON snapshots.
+
+- [ ] **Step 8: Run coordinator and secret tests**
+
+```bash
+cd $REPO_ROOT/apps/vela-mobile
+bun run test:unit -- src/services/mobile-auth.test.ts src/services/mobile-auth-disposal.test.ts
+```
+
+Expected: PASS, including non-blocking auth operation tests and non-401 ordering.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd $REPO_ROOT
+git add \
+  apps/vela-mobile/src/auth/mobile-auth-contract.ts \
+  apps/vela-mobile/src/services/mobile-auth.ts \
+  apps/vela-mobile/src/services/mobile-auth.test.ts \
+  apps/vela-mobile/src/test/secret-leak-helpers.ts \
+  apps/vela-mobile/src/App.test.ts \
+  apps/vela-mobile/src/pages/MorePage.test.ts \
+  apps/vela-mobile/src/pages/StubPages.test.ts \
+  apps/vela-mobile/src/components/mobile/MobileAuthGate.navigation.test.ts \
+  apps/vela-mobile/src/components/mobile/MobileAuthGate.test.ts
+git commit -m "feat(mobile): add safe authenticated transport"
+```
+
+---
+
+### Task 5: Add Explicit, Single-Flight 401 Recovery
+
+**Files:**
+
+- Modify: `apps/vela-mobile/src/services/mobile-auth.ts`
+- Modify: `apps/vela-mobile/src/services/mobile-auth.test.ts`
+
+**Interfaces:**
+
+- Produces internal types:
+
+```ts
+type FeatureRefreshObservation =
+  | { kind: 'promoted'; owner: ActiveSession; generation: number }
+  | { kind: 'terminal' }
+  | { kind: 'superseded' }
+  | { kind: 'retryable_failure' };
+
+type FeatureUnauthorizedRecoveryResult =
+  | { kind: 'refreshed' }
+  | { kind: 'terminal' }
+  | { kind: 'superseded' }
+  | { kind: 'retryable_failure' };
+```
+
+- Finalizes `requestAuthenticatedApi()` behavior for current-generation 401.
+
+- [ ] **Step 1: Add failing refresh-observation tests**
+
+Add coordinator tests for these exact outcomes:
+
+```text
+app inactive queueRefresh no-op              -> retryable_failure
+pending candidate queueRefresh no-op          -> retryable_failure
+verified same-user generation promotion      -> promoted
+recovery-owned invalid-grant cleanup          -> terminal
+ordinary sign-out while waiting               -> superseded
+identity replacement while waiting            -> superseded
+```
+
+Also add concurrent tests proving:
+
+- two expired-token 401s start one refresh and each retry once;
+- two still-valid-token 401s enqueue one terminal cleanup;
+- one caller abort detaches without cancelling the peer recovery;
+- an already-running proactive refresh is joined;
+- a retry 401 performs terminal cleanup but never performs another refresh;
+- recovery never waits behind its own feature request.
+
+- [ ] **Step 2: Run the focused tests and verify failure**
+
+```bash
+cd $REPO_ROOT/apps/vela-mobile
+bun run test:unit -- src/services/mobile-auth.test.ts
+```
+
+Expected: FAIL because current-generation 401 is still returned directly.
+
+- [ ] **Step 3: Add the guarded recovery record**
+
+Inside `createMobileAuthCoordinator()` add:
+
+```ts
+type FeatureUnauthorizedRecovery = {
+  owner: ActiveSession;
+  generation: number;
+  terminalCleanupStarted: boolean;
+  promise: Promise<FeatureUnauthorizedRecoveryResult>;
+};
+
+let featureUnauthorizedRecovery: FeatureUnauthorizedRecovery | undefined;
+```
+
+Immediately before `terminalSessionCleanupUnlocked()` clears the active session, mark `terminalCleanupStarted = true` only when the recovery record still matches the current owner/generation. Sign-out and disposal use different cleanup paths and must not set this flag.
+
+- [ ] **Step 4: Implement explicit refresh observation**
+
+Implement:
+
+```ts
+async function observeFeatureRefresh(
+  owner: ActiveSession,
+  generation: number,
+): Promise<FeatureRefreshObservation> {
+  await queueRefresh({ requireDue: false, owner, generation });
+
+  if (
+    active !== undefined &&
+    active.user.userId === owner.user.userId &&
+    activeBundleGeneration > generation &&
+    activeSessionIsUsable()
+  ) {
+    return {
+      kind: 'promoted',
+      owner: active,
+      generation: activeBundleGeneration,
+    };
+  }
+
+  if (featureUnauthorizedRecovery?.terminalCleanupStarted === true) {
+    return { kind: 'terminal' };
+  }
+
+  if (
+    unavailable() ||
+    active !== owner ||
+    activeBundleGeneration !== generation
+  ) {
+    return { kind: 'superseded' };
+  }
+
+  return { kind: 'retryable_failure' };
+}
+```
+
+Keep this normative precedence: promoted, recovery-owned terminal, superseded, retryable failure.
+
+- [ ] **Step 5: Implement one recovery promise per owner/generation**
+
+Create `getOrCreateFeatureUnauthorizedRecovery(snapshot)`:
+
+- reuse the existing record only when both owner and generation match;
+- if the captured token expired, call `observeFeatureRefresh()`;
+- if the captured token was still valid, enqueue exactly one guarded `terminalSessionCleanupUnlocked()` through `serialize()`;
+- clear the record in `finally` only if it is still the active record;
+- map `promoted` to `refreshed`, preserving the other outcomes.
+
+Do not wrap the feature caller itself in `serialize()`.
+
+- [ ] **Step 6: Finalize request retry behavior**
+
+Refactor the public method through an internal helper:
+
+```ts
+async function requestAuthenticatedApiInternal(
+  request: MobileAuthenticatedApiRequest,
+  allowRefreshRetry: boolean,
+): Promise<Response>;
+```
+
+For a current-generation 401:
+
+```ts
+const recovery = await waitForFeatureRecoveryOrCallerAbort(snapshot, request.init?.signal);
+
+switch (recovery.kind) {
+  case 'refreshed':
+    if (!allowRefreshRetry) return response;
+    return requestAuthenticatedApiInternal(request, false);
+  case 'terminal':
+    return response;
+  case 'superseded':
+    throw new MobileAuthenticatedApiRequestError('session_changed');
+  case 'retryable_failure':
+    throw new MobileAuthenticatedApiRequestError('session_recovery_pending');
+}
+```
+
+If the supplied signal aborts while recovery remains in flight, detach that caller and preserve `AbortError`; do not cancel the shared recovery. Task 6 owns the eight-second feature deadline and maps a deadline-triggered abort to `session_recovery_pending` only when the auth-owned session selector reports active recovery. Direct user/TanStack cancellation remains `AbortError`.
+
+- [ ] **Step 7: Run the coordinator suite**
+
+```bash
+cd $REPO_ROOT/apps/vela-mobile
+bun run test:unit -- src/services/mobile-auth.test.ts src/services/mobile-auth-disposal.test.ts
+```
+
+Expected: PASS with one refresh/cleanup per generation, no self-deadlock, and no credential deletion on retryable/no-op refresh.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd $REPO_ROOT
+git add apps/vela-mobile/src/services/mobile-auth.ts apps/vela-mobile/src/services/mobile-auth.test.ts
+git commit -m "feat(mobile): recover authenticated 401 requests"
+```
+
+---
+
+### Task 6: Add the Bounded JSON Client, SRS Service, and Service Provisioning
+
+**Files:**
+
+- Create: `apps/vela-mobile/src/services/mobile-api-client.ts`
+- Create: `apps/vela-mobile/src/services/mobile-api-client.test.ts`
+- Create: `apps/vela-mobile/src/services/mobile-srs.ts`
+- Create: `apps/vela-mobile/src/services/mobile-srs.test.ts`
+- Create: `apps/vela-mobile/src/services/mobile-services.ts`
+- Create: `apps/vela-mobile/src/services/mobile-services.test.ts`
+- Modify: `apps/vela-mobile/src/boot/mobile-auth.ts`
+- Modify: `apps/vela-mobile/src/boot/mobile-auth.test.ts`
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+export type MobileApiErrorCode =
+  | 'invalid_request'
+  | 'session_unavailable'
+  | 'session_changed'
+  | 'session_recovery_pending'
+  | 'unauthorized'
+  | 'forbidden'
+  | 'network'
+  | 'server'
+  | 'invalid_response';
+
+export class MobileApiError extends Error {
+  readonly code: MobileApiErrorCode;
+}
+
+export const MOBILE_DUE_COUNT_EXECUTION_TIMEOUT_MS = 8_000;
+
+export type MobileApiClient = {
+  getJson(path: string, options?: { signal?: AbortSignal }): Promise<unknown>;
+};
+
+export function createMobileApiClient(
+  coordinator: MobileAuthCoordinator,
+  timeoutMs?: number,
+): MobileApiClient;
+
+export type MobileSrsService = {
+  getStats(options?: { signal?: AbortSignal }): Promise<SRSStats>;
+};
+
+export const MOBILE_API_CLIENT_KEY: InjectionKey<MobileApiClient>;
+export const MOBILE_SRS_SERVICE_KEY: InjectionKey<MobileSrsService>;
+
+export function provideMobileServices(
+  app: App,
+  coordinator: MobileAuthCoordinator,
+): void;
+```
+
+- Consumed by Tasks 8–9.
+
+- [ ] **Step 1: Write failing API client tests**
+
+Create tests covering:
+
+- 200 JSON response;
+- final 401 -> `unauthorized`;
+- 403 -> `forbidden`;
+- 404/409/500 -> `server`;
+- invalid path/header coordinator errors -> `invalid_request`;
+- `session_unavailable`, `session_changed`, `session_recovery_pending` preserve their codes;
+- raw `TypeError` -> `network`;
+- coordinator `request_timeout` -> `network`;
+- execution deadline outside auth recovery -> `network`;
+- execution deadline while coordinator reports pending recovery -> `session_recovery_pending`;
+- caller abort remains `AbortError`;
+- stalled `response.json()` -> `network`;
+- timers and listeners are cleared in every branch.
+
+Use fake timers:
+
+```ts
+vi.useFakeTimers();
+const promise = client.getJson('srs/stats');
+await vi.advanceTimersByTimeAsync(MOBILE_DUE_COUNT_EXECUTION_TIMEOUT_MS);
+await expect(promise).rejects.toMatchObject({ code: 'network' });
+vi.useRealTimers();
+```
+
+- [ ] **Step 2: Write failing SRS and provisioning tests**
+
+`mobile-srs.test.ts` must assert exact path and signal:
+
+```ts
+expect(apiClient.getJson).toHaveBeenCalledWith('srs/stats', { signal });
+```
+
+It must also prove malformed stats become `invalid_response`.
+
+`mobile-services.test.ts` must assert `app.provide()` receives a service whose `getStats()` delegates through the supplied coordinator; it must not call Vue `inject()`.
+
+- [ ] **Step 3: Run tests and verify failure**
+
+```bash
+cd $REPO_ROOT/apps/vela-mobile
+bun run test:unit -- \
+  src/services/mobile-api-client.test.ts \
+  src/services/mobile-srs.test.ts \
+  src/services/mobile-services.test.ts
+```
+
+Expected: FAIL because the service files do not exist.
+
+- [ ] **Step 4: Implement the feature-facing error and deadline client**
+
+In `mobile-api-client.ts`, create one caller-linked `AbortController` and one deadline timer before invoking the coordinator. Keep the same signal alive through `response.json()`.
+
+Track `callerAborted` and `deadlineExpired` separately. Map errors exactly:
+
+```ts
+function mapCoordinatorError(
+  error: unknown,
+  context: {
+    callerAborted: boolean;
+    deadlineExpired: boolean;
+    coordinator: MobileAuthCoordinator;
+  },
+): never {
+  const { callerAborted, deadlineExpired, coordinator } = context;
+
+  if (error instanceof MobileAuthenticatedApiRequestError) {
+    if (error.code === 'invalid_request_path' || error.code === 'invalid_request_headers') {
+      throw new MobileApiError('invalid_request', { cause: error });
+    }
+    if (error.code === 'request_timeout') {
+      throw new MobileApiError('network', { cause: error });
+    }
+    throw new MobileApiError(error.code, { cause: error });
+  }
+
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    if (callerAborted) throw error;
+    if (
+      deadlineExpired &&
+      selectMobileFeatureSessionStatus(coordinator.state).kind === 'recovering'
+    ) {
+      throw new MobileApiError('session_recovery_pending', { cause: error });
+    }
+    throw new MobileApiError('network', { cause: error });
+  }
+
+  throw new MobileApiError('network', { cause: error });
+}
+```
+
+The deadline controller must abort with a local flag; it must not encode deadline semantics into the public coordinator request contract.
+
+After the response:
+
+```ts
+if (response.status === 401) throw new MobileApiError('unauthorized');
+if (response.status === 403) throw new MobileApiError('forbidden');
+if (!response.ok) throw new MobileApiError('server');
+```
+
+Read JSON before clearing the deadline. If the deadline controller fired, classify the body failure as `network`. Never log raw content.
+
+- [ ] **Step 5: Implement the SRS service**
+
+Create `mobile-srs.ts`:
+
+```ts
+import { parseSrsStats, type SRSStats } from '@vela/common';
+import { MobileApiError, type MobileApiClient } from './mobile-api-client';
+
+export type MobileSrsService = {
+  getStats(options?: { signal?: AbortSignal }): Promise<SRSStats>;
+};
+
+export function createMobileSrsService(apiClient: MobileApiClient): MobileSrsService {
+  return {
+    async getStats(options = {}) {
+      const value = await apiClient.getJson('srs/stats', options);
+      try {
+        return parseSrsStats(value);
+      } catch (error) {
+        throw new MobileApiError('invalid_response', { cause: error });
+      }
+    },
+  };
+}
+```
+
+- [ ] **Step 6: Implement direct service provisioning**
+
+Create `MOBILE_API_CLIENT_KEY` and `MOBILE_SRS_SERVICE_KEY` in `mobile-services.ts`, construct the API client and SRS service from the coordinator, and call `app.provide()` for both.
+
+Update `boot/mobile-auth.ts` ordering:
+
+```ts
+app.provide(MOBILE_AUTH_KEY, coordinator);
+provideMobileServices(app, coordinator);
+void coordinator.initialize();
+```
+
+Update `mobile-auth.test.ts` to assert provisioning receives the same coordinator instance and occurs before `initialize()`.
+
+- [ ] **Step 7: Run the service and boot tests**
+
+```bash
+cd $REPO_ROOT/apps/vela-mobile
+bun run test:unit -- \
+  src/services/mobile-api-client.test.ts \
+  src/services/mobile-srs.test.ts \
+  src/services/mobile-services.test.ts \
+  src/boot/mobile-auth.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd $REPO_ROOT
+git add \
+  apps/vela-mobile/src/services/mobile-api-client.ts \
+  apps/vela-mobile/src/services/mobile-api-client.test.ts \
+  apps/vela-mobile/src/services/mobile-srs.ts \
+  apps/vela-mobile/src/services/mobile-srs.test.ts \
+  apps/vela-mobile/src/services/mobile-services.ts \
+  apps/vela-mobile/src/services/mobile-services.test.ts \
+  apps/vela-mobile/src/boot/mobile-auth.ts \
+  apps/vela-mobile/src/boot/mobile-auth.test.ts
+git commit -m "feat(mobile): add due-count API services"
+```
+
+---
+
+### Task 7: Bridge Native Focus and Enforce Auth-Driven Query Isolation
+
+**Files:**
+
+- Modify: `apps/vela-mobile/src/boot/capacitor-lifecycle.ts`
+- Modify: `apps/vela-mobile/src/boot/capacitor-lifecycle.test.ts`
+- Create: `apps/vela-mobile/src/services/mobile-query-auth-isolation.ts`
+- Create: `apps/vela-mobile/src/services/mobile-query-auth-isolation.test.ts`
+- Modify: `apps/vela-mobile/src/App.vue`
+- Modify: `apps/vela-mobile/src/App.test.ts`
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+export function installMobileQueryAuthIsolation(options: {
+  state: Readonly<MobileAuthState>;
+  queryClient: QueryClient;
+}): WatchStopHandle;
+```
+
+- Native lifecycle updates `focusManager.setFocused(isActive)`.
+
+- Consumed by Task 8.
+
+- [ ] **Step 1: Update lifecycle tests first**
+
+Extend the fake adapter to support both `'resume'` and `'appStateChange'`. Assert:
+
+```ts
+expect(addListener).toHaveBeenCalledWith('resume', expect.any(Function));
+expect(addListener).toHaveBeenCalledWith('appStateChange', expect.any(Function));
+expect(setFocused).toHaveBeenNthCalledWith(1, false);
+expect(setFocused).toHaveBeenNthCalledWith(2, true);
+```
+
+Mock `focusManager.setFocused` through `vi.spyOn(focusManager, 'setFocused')`.
+
+- [ ] **Step 2: Write failing auth-isolation tests**
+
+Use a real `QueryClient` with a seeded `srsKeys.stats('user-1')` value. Cover:
+
+- soft refresh with `sessionUsable: true` retains cache;
+- recovering with `sessionUsable: false` cancels active queries but does not remove same-user cache;
+- sign-out start cancels, then clears;
+- terminal cleanup and cleanup failure clear;
+- identity change from user-1 to user-2 clears;
+- ordinary backgrounding causes no cache action;
+- cancellation resolves before `queryClient.clear()` is called.
+
+- [ ] **Step 3: Run focused tests and verify failure**
+
+```bash
+cd $REPO_ROOT/apps/vela-mobile
+bun run test:unit -- \
+  src/boot/capacitor-lifecycle.test.ts \
+  src/services/mobile-query-auth-isolation.test.ts \
+  src/App.test.ts
+```
+
+Expected: FAIL because lifecycle focus and the isolation installer do not exist.
+
+- [ ] **Step 4: Implement native focus integration**
+
+Change the lifecycle adapter overloads to register both listeners. Keep `recordAppResume()` on `'resume'`; on `'appStateChange'` call:
+
+```ts
+focusManager.setFocused(event.isActive);
+```
+
+Retain the existing single-registration promise and retry-after-registration-failure behavior. If either listener registration fails, remove any handle already created and reject so a later call can retry cleanly.
+
+- [ ] **Step 5: Implement cancel-then-clear isolation**
+
+In `mobile-query-auth-isolation.ts`, watch a compact snapshot:
+
+```ts
+type AuthQuerySnapshot = {
+  phase: MobileAuthState['phase'];
+  operation: MobileAuthState['operation'];
+  userId: string | null;
+  featureStatus: MobileFeatureSessionStatus;
+};
+```
+
+Serialize cleanup work through a local promise tail. Compute:
+
+```ts
+const identityChanged = previous.userId !== next.userId;
+const clearRequired =
+  identityChanged ||
+  next.phase === 'signedOut' ||
+  next.operation === 'signingOut' ||
+  next.operation === 'cleaningUp';
+
+const cancelOnly =
+  next.featureStatus.kind === 'recovering' &&
+  !next.featureStatus.sessionUsable;
+```
+
+For `clearRequired`, await `queryClient.cancelQueries()` and then call `queryClient.clear()`. For `cancelOnly`, await cancellation without clearing. Do nothing for usable soft recovery and backgrounding.
+
+- [ ] **Step 6: Install isolation once from App**
+
+Update `App.vue`:
+
+```ts
+<script setup lang="ts">
+import { inject, onUnmounted } from 'vue';
+import { mobileQueryClient } from './boot/query';
+import MobileAuthGate from './components/mobile/MobileAuthGate.vue';
+import { MOBILE_AUTH_KEY } from './services/mobile-auth';
+import { installMobileQueryAuthIsolation } from './services/mobile-query-auth-isolation';
+
+const coordinator = inject(MOBILE_AUTH_KEY);
+if (!coordinator) throw new Error('Mobile auth coordinator was not provided');
+
+const stopIsolation = installMobileQueryAuthIsolation({
+  state: coordinator.state,
+  queryClient: mobileQueryClient,
+});
+onUnmounted(stopIsolation);
+</script>
+```
+
+Update `App.test.ts` to install a fresh test QueryClient by mocking `mobileQueryClient`, add the new coordinator method, and assert sign-out removes seeded due-count data before protected Home can remount.
+
+- [ ] **Step 7: Run lifecycle/isolation/App tests**
+
+```bash
+cd $REPO_ROOT/apps/vela-mobile
+bun run test:unit -- \
+  src/boot/capacitor-lifecycle.test.ts \
+  src/services/mobile-query-auth-isolation.test.ts \
+  src/App.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd $REPO_ROOT
+git add \
+  apps/vela-mobile/src/boot/capacitor-lifecycle.ts \
+  apps/vela-mobile/src/boot/capacitor-lifecycle.test.ts \
+  apps/vela-mobile/src/services/mobile-query-auth-isolation.ts \
+  apps/vela-mobile/src/services/mobile-query-auth-isolation.test.ts \
+  apps/vela-mobile/src/App.vue \
+  apps/vela-mobile/src/App.test.ts
+git commit -m "feat(mobile): isolate authenticated query state"
+```
+
+---
+
+### Task 8: Implement the Due-Count Query and Recovery Semantics
+
+**Files:**
+
+- Create: `apps/vela-mobile/src/composables/useDueReviewCount.ts`
+- Create: `apps/vela-mobile/src/composables/useDueReviewCount.test.ts`
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+export type UseDueReviewCountResult = {
+  stats: ComputedRef<SRSStats | undefined>;
+  error: ComputedRef<MobileApiError | null>;
+  sessionStatus: ComputedRef<MobileFeatureSessionStatus>;
+  isInitialPending: ComputedRef<boolean>;
+  isFetching: ComputedRef<boolean>;
+  sessionRecoveryPending: ComputedRef<boolean>;
+  manualRetryPending: Readonly<Ref<boolean>>;
+  retry(): Promise<void>;
+};
+
+export function retryDueCountQuery(failureCount: number, error: unknown): boolean;
+export function useDueReviewCount(): UseDueReviewCountResult;
+```
+
+- Consumed by Task 9.
+
+- [ ] **Step 1: Build a composable test host**
+
+In `useDueReviewCount.test.ts`, mount a minimal component with:
+
+- a fresh `QueryClient` installed through `VueQueryPlugin`;
+- reactive `MobileAuthState` provided through `MOBILE_AUTH_KEY`;
+- a fake `MobileSrsService` provided through `MOBILE_SRS_SERVICE_KEY`;
+- `retry: false` on the test client unless the case explicitly tests the predicate.
+
+Capture the composable return from `setup()` so tests can drive state and await `flushPromises()`.
+
+- [ ] **Step 2: Write failing behavior tests**
+
+Cover:
+
+- no request during restoration;
+- exactly one initial request when restored auth becomes usable;
+- query key contains the current user ID;
+- first same-user `session_changed` silently retries once;
+- first dispatch-time `session_unavailable` silently retries once when the same user remains usable;
+- repeated control race becomes a visible manually retryable error;
+- `session_recovery_pending` with cached data keeps the cached count;
+- `session_recovery_pending` without cache exposes recovery loading;
+- same-user `recovering -> usable` refetches once;
+- recovering-but-unusable disables the query;
+- user change selects a different key;
+- manual retry preserves the prior error surface and is distinct from background fetching;
+- `retryDueCountQuery` returns true only for network/server at failure counts 0 and 1.
+
+- [ ] **Step 3: Run the composable tests and verify failure**
+
+```bash
+cd $REPO_ROOT/apps/vela-mobile
+bun run test:unit -- src/composables/useDueReviewCount.test.ts
+```
+
+Expected: FAIL because the composable does not exist.
+
+- [ ] **Step 4: Implement exact retry policy and query enablement**
+
+```ts
+export const DUE_COUNT_RETRY_LIMIT = 2;
+
+export function retryDueCountQuery(failureCount: number, error: unknown): boolean {
+  return (
+    error instanceof MobileApiError &&
+    (error.code === 'network' || error.code === 'server') &&
+    failureCount < DUE_COUNT_RETRY_LIMIT
+  );
+}
+```
+
+Compute enablement:
+
+```ts
+const sessionStatus = computed(() =>
+  selectMobileFeatureSessionStatus(coordinator.state),
+);
+
+const queryEnabled = computed(
+  () =>
+    sessionStatus.value.kind === 'usable' ||
+    (sessionStatus.value.kind === 'recovering' &&
+      sessionStatus.value.sessionUsable),
+);
+```
+
+Use:
+
+```ts
+useQuery({
+  queryKey: computed(() =>
+    srsKeys.stats(
+      sessionStatus.value.kind === 'unavailable'
+        ? null
+        : sessionStatus.value.userId,
+    ),
+  ),
+  enabled: queryEnabled,
+  queryFn: ({ signal }) => fetchStatsWithSessionRaceRecovery(signal),
+  refetchOnMount: 'always',
+  refetchOnWindowFocus: 'always',
+  retry: retryDueCountQuery,
+});
+```
+
+- [ ] **Step 5: Implement one silent control-flow retry**
+
+`fetchStatsWithSessionRaceRecovery()` captures the starting user ID. When the service throws `session_changed` or `session_unavailable`, retry once only when:
+
+- the query signal is not aborted;
+- `selectMobileFeatureSessionStatus()` still reports the same user;
+- the status remains usable or recovering with `sessionUsable: true`.
+
+After one retry, rethrow any repeated failure so the UI has a manual recovery path.
+
+- [ ] **Step 6: Implement pending-recovery refetch and manual retry state**
+
+Derive `sessionRecoveryPending` from the query error code. Watch only `MobileFeatureSessionStatus`; when the same user transitions from `recovering` to `usable` after a pending recovery error, call `query.refetch()` once.
+
+Normalize presentation errors before returning the composable result:
+
+```ts
+const sessionRecoveryPending = computed(
+  () =>
+    query.error.value instanceof MobileApiError &&
+    query.error.value.code === 'session_recovery_pending',
+);
+
+const visibleError = computed<MobileApiError | null>(() => {
+  const error = retainedManualError.value ?? query.error.value;
+  if (!(error instanceof MobileApiError)) return null;
+  if (error.code === 'session_recovery_pending' || error.code === 'unauthorized') {
+    return null;
+  }
+  return error;
+});
+```
+
+Return `visibleError` as the public `error` field. This prevents pending auth recovery from being rendered as a Home error and lets the auth gate own unauthorized presentation.
+
+For manual retry:
+
+```ts
+const manualRetryPending = ref(false);
+const retainedManualError = ref<MobileApiError | null>(null);
+
+async function retry(): Promise<void> {
+  if (manualRetryPending.value) return;
+  retainedManualError.value =
+    query.error.value instanceof MobileApiError ? query.error.value : null;
+  manualRetryPending.value = true;
+  try {
+    await query.refetch();
+  } finally {
+    manualRetryPending.value = false;
+    retainedManualError.value = null;
+  }
+}
+```
+
+Expose the retained error while manual retry is pending so the existing failure surface does not disappear.
+
+- [ ] **Step 7: Run composable tests**
+
+```bash
+cd $REPO_ROOT/apps/vela-mobile
+bun run test:unit -- src/composables/useDueReviewCount.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd $REPO_ROOT
+git add \
+  apps/vela-mobile/src/composables/useDueReviewCount.ts \
+  apps/vela-mobile/src/composables/useDueReviewCount.test.ts
+git commit -m "feat(mobile): query due-review count"
+```
+
+---
+
+### Task 9: Add the Pure View Selector and Accessible Home Surface
+
+**Files:**
+
+- Create: `apps/vela-mobile/src/components/home/due-review-view.ts`
+- Create: `apps/vela-mobile/src/components/home/due-review-view.test.ts`
+- Modify: `apps/vela-mobile/src/pages/HomePage.vue`
+- Modify: `apps/vela-mobile/src/pages/HomePage.test.ts`
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+export type DueReviewView =
+  | { kind: 'loading'; recoveringSession: boolean }
+  | { kind: 'zero'; refreshing: boolean }
+  | { kind: 'positive'; count: number; refreshing: boolean }
+  | {
+      kind: 'blocking_error';
+      message: string;
+      retrying: boolean;
+      canRetry: boolean;
+    }
+  | {
+      kind: 'cached_error';
+      count: number;
+      message: string;
+      retrying: boolean;
+      canRetry: boolean;
+    };
+
+export function selectDueReviewView(input: DueReviewViewInput): DueReviewView;
+```
+
+- [ ] **Step 1: Write the exhaustive selector tests**
+
+Create a table covering:
+
+- initial loading;
+- session-recovery loading;
+- zero and positive values;
+- zero/positive background refresh;
+- blocking network error;
+- cached positive and cached-zero stale error;
+- manual retry retaining blocking/cached kind;
+- `invalid_request` with `canRetry: false`;
+- `invalid_response` with `canRetry: true`;
+- repeated session control race mapped to generic manual recovery;
+- cancellation ignored;
+- unauthorized omitted because Home is gated away.
+
+Use exact copy constants in the selector tests so the page and accessibility tests share one source of truth.
+
+- [ ] **Step 2: Run selector tests and verify failure**
+
+```bash
+cd $REPO_ROOT/apps/vela-mobile
+bun run test:unit -- src/components/home/due-review-view.test.ts
+```
+
+Expected: FAIL because the selector does not exist.
+
+- [ ] **Step 3: Implement the pure selector**
+
+Define:
+
+```ts
+export type DueReviewViewInput = {
+  stats: SRSStats | undefined;
+  error: MobileApiError | null;
+  isInitialPending: boolean;
+  isFetching: boolean;
+  sessionRecoveryPending: boolean;
+  manualRetryPending: boolean;
+};
+
+const NETWORK_MESSAGE =
+  'Vela couldn’t load your review count. Check your connection and try again.';
+const GENERIC_MESSAGE = 'Vela couldn’t load your review count. Please try again.';
+const STALE_MESSAGE = 'This count may be out of date.';
+```
+
+Implement:
+
+```ts
+export function selectDueReviewView(input: DueReviewViewInput): DueReviewView {
+  const refreshing =
+    input.isFetching &&
+    input.stats !== undefined &&
+    !input.manualRetryPending;
+
+  if (input.sessionRecoveryPending) {
+    if (input.stats === undefined) {
+      return { kind: 'loading', recoveringSession: true };
+    }
+    if (input.stats.due_today === 0) {
+      return { kind: 'zero', refreshing: false };
+    }
+    return {
+      kind: 'positive',
+      count: input.stats.due_today,
+      refreshing: false,
+    };
+  }
+
+  if (input.error && input.stats !== undefined) {
+    return {
+      kind: 'cached_error',
+      count: input.stats.due_today,
+      message: STALE_MESSAGE,
+      retrying: input.manualRetryPending,
+      canRetry: input.error.code !== 'invalid_request',
+    };
+  }
+
+  if (input.error) {
+    return {
+      kind: 'blocking_error',
+      message: input.error.code === 'network' ? NETWORK_MESSAGE : GENERIC_MESSAGE,
+      retrying: input.manualRetryPending,
+      canRetry: input.error.code !== 'invalid_request',
+    };
+  }
+
+  if (input.stats?.due_today === 0) {
+    return { kind: 'zero', refreshing };
+  }
+
+  if (input.stats && input.stats.due_today > 0) {
+    return { kind: 'positive', count: input.stats.due_today, refreshing };
+  }
+
+  if (input.isInitialPending) {
+    return { kind: 'loading', recoveringSession: false };
+  }
+
+  return {
+    kind: 'blocking_error',
+    message: GENERIC_MESSAGE,
+    retrying: false,
+    canRetry: true,
+  };
+}
+```
+
+Cancellation and unauthorized errors must be removed by the composable/gate before calling this selector.
+
+- [ ] **Step 4: Replace the scaffold Home page**
+
+Implement a focused surface:
+
+```vue
+<template>
+  <q-page class="q-pa-lg">
+    <section class="due-review" aria-labelledby="due-review-heading">
+      <h1 id="due-review-heading" class="text-h5 text-weight-bold">
+        Today’s review
+      </h1>
+
+      <div
+        v-if="view.kind === 'loading'"
+        role="status"
+        aria-live="polite"
+        class="text-center q-py-xl"
+      >
+        <q-spinner size="40px" color="primary" />
+        <p class="q-mt-md">
+          {{ view.recoveringSession ? 'Refreshing your session…' : 'Loading your review count…' }}
+        </p>
+      </div>
+
+      <template v-else-if="view.kind === 'zero' || view.kind === 'positive'">
+        <p class="due-review__count" aria-live="polite">
+          {{ view.kind === 'zero' ? 0 : view.count }}
+        </p>
+        <p>
+          {{
+            view.kind === 'zero'
+              ? 'You’re caught up for now.'
+              : view.count === 1
+                ? '1 word is due for review.'
+                : `${view.count} words are due for review.`
+          }}
+        </p>
+        <p v-if="view.refreshing" role="status" aria-live="polite">
+          Refreshing review count…
+        </p>
+      </template>
+
+      <div v-else role="alert">
+        <template v-if="view.kind === 'cached_error'">
+          <p class="due-review__count">{{ view.count }}</p>
+        </template>
+        <p>{{ view.message }}</p>
+        <q-btn
+          v-if="view.canRetry"
+          color="primary"
+          label="Retry"
+          :loading="view.retrying"
+          :disable="view.retrying"
+          :aria-label="view.retrying ? 'Retrying review count' : 'Retry review count'"
+          @click="retry"
+        />
+      </div>
+    </section>
+  </q-page>
+</template>
+```
+
+Do not render app version, environment chip, M1 label, or Start Review.
+
+- [ ] **Step 5: Replace Home component tests**
+
+Keep the existing `QLayout`/`QPageContainer` host pattern. Mock `useDueReviewCount()` with reactive refs and cover:
+
+- accessible loading and recovery loading;
+- zero;
+- singular and plural positive;
+- background refresh retains count;
+- blocking network error and Retry click;
+- cached positive and zero errors retain count and stale warning;
+- manual retry disables/loads button with correct aria label;
+- invalid request has no Retry;
+- no scaffold/version/environment/Start Review copy.
+
+- [ ] **Step 6: Run selector and Home tests**
+
+```bash
+cd $REPO_ROOT/apps/vela-mobile
+bun run test:unit -- \
+  src/components/home/due-review-view.test.ts \
+  src/pages/HomePage.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd $REPO_ROOT
+git add \
+  apps/vela-mobile/src/components/home/due-review-view.ts \
+  apps/vela-mobile/src/components/home/due-review-view.test.ts \
+  apps/vela-mobile/src/pages/HomePage.vue \
+  apps/vela-mobile/src/pages/HomePage.test.ts
+git commit -m "feat(mobile): show authenticated due count"
+```
+
+---
+
+### Task 10: Run Merge Gates and Record the Closure Matrix
+
+**Files:**
+
+- Modify only if evidence requires it:
+  - `docs/superpowers/plans/2026-07-30-mobile-authenticated-due-review-count.md` — check off completed steps during execution.
+  - HPA-207 Linear issue — attach or comment the verification matrix.
+  - Implementation PR body — summarize automated and Simulator evidence.
+
+**Interfaces:**
+
+- Produces no runtime interface.
+- Produces merge-gate evidence and a clearly separated physical-device closure gate.
+
+- [ ] **Step 1: Run focused package tests**
+
+```bash
+cd $REPO_ROOT/packages/common
+bun run test:unit
+
+cd $REPO_ROOT/apps/vela
+bun vitest run src/services/srsService.test.ts
+
+cd $REPO_ROOT/apps/vela-mobile
+bun run test:unit
+```
+
+Expected: all PASS.
+
+- [ ] **Step 2: Run mobile coverage**
+
+```bash
+cd $REPO_ROOT/apps/vela-mobile
+bun run test:coverage
+```
+
+Expected: PASS with line coverage at or above 95%.
+
+- [ ] **Step 3: Run typecheck and lint**
+
+```bash
+cd $REPO_ROOT
+bun run typecheck --filter=@vela/mobile
+bun run lint --filter=@vela/common --filter=@vela/mobile --filter=@vela/app
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 4: Run a production mobile build**
+
+```bash
+cd $REPO_ROOT
+VITE_MOBILE_API_URL=https://example.invalid/api/ \
+VITE_COGNITO_USER_POOL_ID=us-east-1_example \
+VITE_COGNITO_MOBILE_USER_POOL_CLIENT_ID=mobile-client \
+VITE_COGNITO_OAUTH_DOMAIN=example.auth.us-east-1.amazoncognito.com \
+VITE_AWS_REGION=us-east-1 \
+bun run build:mobile
+```
+
+Expected: production Quasar build exits 0 and resolves `@vela/common` from source.
+
+- [ ] **Step 5: Run repository hygiene checks**
+
+```bash
+cd $REPO_ROOT
+bunx prettier --check \
+  packages/common/src/contracts/srs.ts \
+  packages/common/src/contracts/srs.test.ts \
+  packages/common/src/keys.ts \
+  packages/common/src/keys.test.ts \
+  packages/common/src/index.ts \
+  apps/vela/src/services/srsService.ts \
+  apps/vela-mobile/src \
+  apps/vela-mobile/quasar.config.ts \
+  apps/vela-mobile/vitest.config.ts \
+  CLAUDE.md
+git diff --check
+git status --short
+```
+
+Expected: Prettier and `git diff --check` pass; status contains only intentional implementation changes before the final commit.
+
+- [ ] **Step 6: Verify the approximately 27-second bound under fake timers**
+
+Run the dedicated latency test:
+
+```bash
+cd $REPO_ROOT/apps/vela-mobile
+bun vitest run src/composables/useDueReviewCount.test.ts -t "bounds persistent network failure"
+```
+
+Expected: PASS, showing three eight-second attempts plus one-second and two-second retry delays settle within 27 seconds.
+
+- [ ] **Step 7: Complete the iOS Simulator merge gate**
+
+Use a configured development environment:
+
+```bash
+cd $REPO_ROOT/apps/vela-mobile
+bun run dev:ios
+```
+
+Record:
+
+```text
+Scenario                 Result
+Fresh sign-in            Home loads authenticated count
+Relaunch restoration     No Google prompt; Home count loads
+Positive due count       Matches web/API at recorded time
+Zero due count           Shows 0 and "caught up for now"
+Network failure          Blocking failure appears within documented bound
+Retry                    Loads after connectivity restoration
+Foreground resume        Refetch occurs
+Rejected token           Home disappears; auth recovery appears
+Sign-out                 Count disappears immediately
+Account isolation        Later account never sees prior count
+```
+
+- [ ] **Step 8: Commit plan bookkeeping only**
+
+Mark the completed checkboxes in this plan, then commit only the plan file:
+
+```bash
+cd $REPO_ROOT
+git add docs/superpowers/plans/2026-07-30-mobile-authenticated-due-review-count.md
+git commit -m "docs: record HPA-207 verification"
+```
+
+Do not stage generated Xcode files, environment files, build output, coverage HTML, or unrelated changes.
+
+- [ ] **Step 9: Create the implementation PR body and open the draft PR**
+
+```bash
+cat > /tmp/hpa-207-pr-body.md <<'EOF'
+## Summary
+
+- add a shared validated SRS stats contract and user-scoped stats query key
+- add generation-safe authenticated mobile feature requests with single-flight 401 recovery
+- add bounded mobile API/SRS services and TanStack Query cache isolation
+- replace the mobile Home scaffold with accessible due-count loading, success, failure, and retry states
+
+## Validation
+
+- `packages/common`: unit tests passed
+- `apps/vela`: `srsService` tests passed
+- `apps/vela-mobile`: unit suite and 95% coverage gate passed
+- mobile typecheck and targeted lint passed
+- production mobile build passed
+- iOS Simulator verification matrix completed
+
+## Closure gate
+
+Physical-development-iPhone verification remains required before HPA-207 closes. It is not a merge gate for this implementation PR.
+
+## Tracking
+
+- Linear: HPA-207
+- Design: PR #52
+EOF
+
+git push -u origin codex/hpa-207-mobile-due-review-count
+gh pr create \
+  --draft \
+  --base main \
+  --head codex/hpa-207-mobile-due-review-count \
+  --title "feat(mobile): show authenticated due-review count" \
+  --body-file /tmp/hpa-207-pr-body.md
+```
+
+- [ ] **Step 10: Complete the physical-iPhone closure gate after merge readiness**
+
+On a configured development iPhone, repeat fresh sign-in, relaunch restoration, positive/zero count, network failure, retry, foreground resume, rejected token, and sign-out. Record device model, iOS version, build SHA, account, timestamp, API/web comparison value, and result on HPA-207.
+
+Do not close HPA-207 until this evidence is attached, even if the implementation PR has merged.

--- a/docs/superpowers/plans/2026-07-30-mobile-authenticated-due-review-count.md
+++ b/docs/superpowers/plans/2026-07-30-mobile-authenticated-due-review-count.md
@@ -2225,3 +2225,10 @@ gh pr create \
 On a configured development iPhone, repeat fresh sign-in, relaunch restoration, positive/zero count, network failure, retry, foreground resume, rejected token, and sign-out. Record device model, iOS version, build SHA, account, timestamp, API/web comparison value, and result on HPA-207.
 
 Do not close HPA-207 until this evidence is attached, even if the implementation PR has merged.
+
+## Execution Handoff
+
+After PR #52 is reviewed and merged, execute this plan using one of these required paths:
+
+1. **Subagent-Driven (recommended):** use `superpowers:subagent-driven-development`, dispatch a fresh implementation subagent per task, and run the required two-stage review between tasks.
+2. **Inline Execution:** use `superpowers:executing-plans`, execute task batches in one session, and stop at the documented review checkpoints.

--- a/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
+++ b/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
@@ -45,7 +45,9 @@ interface SRSStats {
 }
 ```
 
-The web application owns an equivalent interface and a web-specific SRS service. `@vela/common` already owns `srsKeys`, but its stats key is not scoped by authenticated user. The mobile app does not yet install TanStack Query, and Home still renders the M1 scaffold.
+The web application owns an equivalent interface and a web-specific SRS service. `@vela/common` already owns the `srsKeys` factory, but `srsKeys.stats()` has no production callers and is not user-scoped. HPA-207 makes mobile the first production consumer of that key; it does not migrate the web stats card to TanStack Query.
+
+The mobile app does not yet install TanStack Query, and Home still renders the M1 scaffold.
 
 ## Approved Decisions
 
@@ -54,19 +56,23 @@ The web application owns an equivalent interface and a web-specific SRS service.
 | Product scope | Display only the authenticated due-review count and required states |
 | Backend | Reuse `GET /api/srs/stats` unchanged |
 | Shared contract | Move the complete `SRSStats` response contract into `@vela/common` |
-| Contract validation | Parse the complete payload at the mobile service boundary before caching |
+| Shared package scope | Update the `@vela/common` module header so it describes shared query utilities and contracts rather than `@vela/query` only |
+| Query key | Change `srsKeys.stats()` to include authenticated user ID; mobile is its first production consumer |
 | Token ownership | ID tokens remain private to the mobile auth coordinator |
 | Feature request surface | Add a coordinator-owned authenticated request operation; do not add `getIdToken()` |
-| URL safety | Permit only paths beneath the configured Vela API base URL |
+| Coordinator failure contract | Throw a typed coordinator error for invalid paths, unavailable sessions, and stale-session responses; return HTTP responses, including final 401 responses, to the mobile API client |
+| URL safety | Use one trailing-slash-preserving API URL builder for `/auth/session` and feature paths; require relative paths contained beneath the configured API prefix |
+| Header ownership | Reject caller-supplied `Authorization` headers case-insensitively before applying the coordinator-owned bearer token |
 | Unauthorized response | A current-session 401 enters auth recovery or terminal cleanup; Home never renders an unauthorized-data state |
 | Expiry race | If the request token expires in flight, refresh and retry once before declaring the session unusable |
 | Stale request race | A response from an older auth generation cannot invalidate a replacement session |
 | Server state | Install TanStack Query in Vela Mobile |
-| Query key | Include authenticated user ID in the stats key |
+| Automatic retry | Use an explicit `(failureCount, error) => boolean` predicate; retry only `network` and `server` errors, at most twice |
 | Foreground refresh | Bridge native app active state to TanStack Query focus state |
 | Home re-entry | Refetch whenever Home mounts, even if cached data is still fresh |
+| Manual retry | Track manual retry separately from background fetching so `retrying` and `refreshing` are never inferred from the same flag |
 | Cache isolation | Disable immediately when auth is unusable, user-scope keys, and clear mobile query state on sign-out or identity loss |
-| Cached refetch failure | Keep the last verified count visible with a non-blocking retry message |
+| Cached zero | A cached zero remains eligible for the same stale-data warning as any other cached count because time or another client can make reviews due |
 | Review navigation | Do not add a Start Review action in HPA-207 |
 | Platform | Native iOS remains the authenticated runtime for this milestone |
 
@@ -76,14 +82,15 @@ HPA-207 includes:
 
 - a shared SRS statistics contract and parser;
 - a user-scoped stats query key;
-- a coordinator-owned authenticated request capability;
+- a coordinator-owned authenticated request capability with an explicit failure contract;
+- a shared, boundary-safe mobile API URL builder;
 - a mobile JSON API client with normalized failures;
 - a mobile SRS stats service;
 - TanStack Query bootstrap;
 - native foreground-to-query-focus integration;
 - auth-driven query lifecycle and cache cleanup;
 - a minimal Home due-count presentation;
-- unit/component tests for services, query behavior, auth isolation, and view states; and
+- unit/component tests for services, retry policy, query behavior, auth isolation, and view states; and
 - Simulator and physical-device verification evidence.
 
 ## Non-goals
@@ -91,6 +98,7 @@ HPA-207 includes:
 - starting, resuming, or completing a review session;
 - fetching individual due cards;
 - dashboard parity with the web application;
+- migrating the web SRS stats card to TanStack Query;
 - daily goals, streaks, mastery summaries, or learning shortcuts;
 - persistent offline query storage or offline due-deck generation;
 - a new connectivity plugin, background polling, or background tasks;
@@ -122,7 +130,7 @@ Mobile SRS service requests "srs/stats"
 Mobile API client delegates authenticated transport
                     |
                     v
-Coordinator attaches current in-memory Cognito ID token
+Coordinator applies current in-memory Cognito ID token
                     |
                     v
 GET {VITE_MOBILE_API_URL}srs/stats
@@ -151,7 +159,7 @@ sessionUsable becomes false if recovery cannot continue
 MobileAuthGate hides Home and query state is cleared
 ```
 
-### One token owner
+### One token owner and explicit request failures
 
 `apps/vela-mobile/src/services/mobile-auth.ts` remains the only owner of active Cognito token material.
 
@@ -161,9 +169,24 @@ The coordinator contract gains a request operation instead of a token accessor:
 export type MobileAuthenticatedApiRequest = {
   path: string;
   init?: Omit<RequestInit, 'headers'> & {
-    headers?: Record<string, string>;
+    headers?: HeadersInit;
   };
 };
+
+export type MobileAuthenticatedApiRequestErrorCode =
+  | 'invalid_request_path'
+  | 'session_unavailable'
+  | 'session_changed';
+
+export class MobileAuthenticatedApiRequestError extends Error {
+  constructor(
+    readonly code: MobileAuthenticatedApiRequestErrorCode,
+    options?: { cause?: unknown },
+  ) {
+    super(code, options);
+    this.name = 'MobileAuthenticatedApiRequestError';
+  }
+}
 
 export type MobileAuthCoordinator = {
   state: Readonly<MobileAuthState>;
@@ -177,40 +200,102 @@ export type MobileAuthCoordinator = {
 };
 ```
 
+The request operation has these observable outcomes:
+
+| Outcome | Coordinator result |
+| --- | --- |
+| Path violates the mobile API containment contract | Throw `MobileAuthenticatedApiRequestError('invalid_request_path')` before network activity |
+| No usable current session before dispatch | Throw `MobileAuthenticatedApiRequestError('session_unavailable')` before network activity |
+| Caller aborts | Preserve the platform `AbortError`; do not mutate auth state |
+| Fetch rejects for another reason | Propagate the transport error; the mobile API client classifies it as `network` |
+| Active owner or generation changes before response handling | Throw `MobileAuthenticatedApiRequestError('session_changed')`; do not mutate the replacement session |
+| Non-401 HTTP response | Return the `Response` unchanged |
+| Final current-generation 401 after recovery rules | Complete the required auth transition, then return the final 401 `Response` for client classification |
+
 Feature code never receives an ID token. The coordinator constructs the request, owns `Authorization`, and performs the fetch through its injected transport.
 
-The method rejects without network activity unless the coordinator is initialized, not disposing, authenticated, session-usable, and backed by an active verified bundle and user.
+### Shared API URL normalization and containment
 
-Callers cannot override `Authorization`.
+Replace the narrow `sessionUrl()` string helper with one coordinator-local URL boundary used by both session verification and feature requests:
 
-### URL containment
+```ts
+function normalizeMobileApiBaseUrl(apiUrl: string): URL;
+function resolveMobileApiUrl(baseUrl: URL, relativePath: string): URL;
+```
 
-The mobile API base URL ends at the API prefix, for example `https://vela.example/api/`.
+`normalizeMobileApiBaseUrl()`:
 
-`requestAuthenticatedApi()` accepts a relative path such as `srs/stats`. It rejects:
+- parses the configured absolute API URL;
+- removes search and hash components;
+- normalizes the API pathname to exactly one trailing `/`; and
+- preserves that trailing separator for boundary comparisons.
+
+For example:
+
+```text
+https://vela.example/api     -> https://vela.example/api/
+https://vela.example/api///  -> https://vela.example/api/
+```
+
+`resolveMobileApiUrl()` accepts a non-empty relative path such as `auth/session` or `srs/stats`. It rejects:
 
 - absolute URLs;
 - scheme-relative URLs;
-- root-relative paths that could escape `/api/`;
-- `.` or `..` path segments; and
-- any result whose origin or base-path prefix differs from `config.api.url`.
+- every root-relative path, including `/api/srs/stats`;
+- backslash-prefixed or backslash-separated escape attempts;
+- raw or percent-encoded traversal that normalizes outside the API base pathname;
+- a resolved origin different from the configured API origin;
+- a resolved pathname that does not begin with the normalized trailing-slash API pathname; and
+- URL fragments.
 
-This prevents a future feature service from sending an ID token to an unrelated host or non-API route.
+The implementation must compare parsed URL origin and pathname boundaries rather than using a base string with its trailing slash removed. With a base pathname of `/api/`, `/api-evil/secret` is outside the boundary and must fail.
+
+The existing `/auth/session` request becomes:
+
+```ts
+resolveMobileApiUrl(apiBaseUrl, 'auth/session');
+```
+
+The due-count request becomes:
+
+```ts
+resolveMobileApiUrl(apiBaseUrl, 'srs/stats');
+```
+
+This avoids two normalization conventions inside the coordinator and prevents accidental bearer-token delivery to another host or same-origin non-API route.
+
+### Case-insensitive Authorization ownership
+
+HTTP header names are case-insensitive. The coordinator converts caller headers through the platform `Headers` implementation before inspection:
+
+```ts
+const headers = new Headers(request.init?.headers);
+if (headers.has('authorization')) {
+  throw new MobileAuthenticatedApiRequestError('invalid_request_path');
+}
+headers.set('Authorization', `Bearer ${idToken}`);
+```
+
+The implementation may use a dedicated `invalid_request_headers` code instead of reusing `invalid_request_path` if that produces a clearer contract during implementation planning. The important design requirement is stable typed rejection before network activity.
+
+Tests must cover `Authorization`, `authorization`, `AUTHORIZATION`, and at least one mixed-case spelling.
 
 ### Auth generation and 401 handling
 
-Every request captures the active session owner and `activeBundleGeneration` before dispatch.
+Every request captures the active session owner, ID-token expiry, and `activeBundleGeneration` before dispatch.
 
 When the response arrives:
 
-1. Disposal or caller abort terminates the request without auth mutation.
-2. If the active owner or generation changed, reject as a stale-session request without mutating current auth state.
+1. Caller abort terminates without auth mutation.
+2. If the active owner or generation changed, throw `session_changed` without mutating current auth state.
 3. Return every non-401 response to the feature client.
 4. For a current-generation 401, recheck the captured token expiry.
 5. If the token expired in flight, queue the existing refresh path and retry the feature request once after verified promotion.
-6. If the token was still valid when rejected, or the one retry also returns 401, perform terminal session cleanup.
-7. If refresh fails transiently, retain the existing HPA-206 retry state. Protected content remains usable only while the prior verified token remains valid.
-8. If refresh proves the durable credential unusable, use the existing terminal cleanup path.
+6. The retried request captures the promoted owner and generation and may not recursively retry again.
+7. If the token was still valid when rejected, or the one retry also returns 401, perform terminal session cleanup.
+8. After cleanup begins or completes, return the final 401 response so the API client can classify `unauthorized` while the gate removes protected content.
+9. If refresh fails transiently, retain the existing HPA-206 retry state. Protected content remains usable only while the prior verified token remains valid.
+10. If refresh proves the durable credential unusable, use the existing terminal cleanup path.
 
 A 403 is not proof that the Cognito credential is invalid and remains a feature-level API error.
 
@@ -236,13 +321,22 @@ export interface SRSStats {
 export function parseSrsStats(value: unknown): SRSStats;
 ```
 
-The parser requires all count fields to be non-negative integers, `average_ease_factor` to be finite and non-negative, `accuracy_rate` to be finite and between 0 and 100, and every nested field to exist. Unknown additional fields are ignored.
+The parser requires:
 
-The web SRS service imports and re-exports `SRSStats`, preserving its public service type while removing the duplicate contract.
+- all count fields to be non-negative integers;
+- `average_ease_factor` to be finite and non-negative;
+- `accuracy_rate` to be finite and between 0 and 100; and
+- every required nested field to exist.
 
-### User-scoped query key
+Unknown additional fields are ignored so the API can add backward-compatible metadata later.
 
-Change the shared key to:
+The web SRS service imports and re-exports `SRSStats`, preserving its public service type while removing the duplicate contract. The web card continues its current direct-service loading behavior.
+
+Update the top-level comment in `packages/common/src/index.ts` so the package describes shared query configuration, query keys, domain contracts, and lightweight utilities rather than identifying itself as `@vela/query` only.
+
+### User-scoped stats key
+
+Change the shared factory to:
 
 ```ts
 srsKeys.stats(userId: string | null, jlpt?: number[])
@@ -254,23 +348,15 @@ It produces:
 ['srs', 'stats', userId, jlpt]
 ```
 
-HPA-207 supplies `MobileAuthUser.userId` and no JLPT filter. User identity in the key is the correctness boundary; cache clearing is defense-in-depth cleanup.
+HPA-207 supplies `MobileAuthUser.userId` and no JLPT filter.
+
+The user ID is the cache correctness boundary. Explicit cache clearing remains defense-in-depth cleanup. This signature change does not imply that the web app now caches SRS stats; mobile is the first production caller.
 
 ### Mobile API client
 
 Create `apps/vela-mobile/src/services/mobile-api-client.ts`.
 
-It:
-
-- accepts a relative path and request options;
-- delegates authenticated transport to the coordinator;
-- sends `Accept: application/json`;
-- parses successful JSON;
-- preserves the TanStack Query abort signal;
-- classifies failures without UI copy; and
-- never logs authorization headers, token-bearing objects, or raw identity responses.
-
-Use this stable error union:
+Use a stable feature-facing error type:
 
 ```ts
 export type MobileApiErrorCode =
@@ -281,13 +367,34 @@ export type MobileApiErrorCode =
   | 'network'
   | 'server'
   | 'invalid_response';
+
+export class MobileApiError extends Error {
+  constructor(
+    readonly code: MobileApiErrorCode,
+    options?: { cause?: unknown },
+  ) {
+    super(code, options);
+    this.name = 'MobileApiError';
+  }
+}
 ```
 
-| Outcome | Classification |
+The client:
+
+- accepts a relative path and request options;
+- delegates authenticated transport to the coordinator;
+- sends `Accept: application/json`;
+- parses successful JSON;
+- preserves the TanStack Query abort signal;
+- classifies failures without UI copy; and
+- never logs authorization headers, token-bearing objects, or raw identity responses.
+
+| Coordinator/HTTP outcome | Client classification |
 | --- | --- |
 | Caller abort | Preserve abort semantics; no visible error |
-| No usable session before dispatch | `session_unavailable` |
-| Session generation changes | `session_changed` |
+| `MobileAuthenticatedApiRequestError('session_unavailable')` | `MobileApiError('session_unavailable')` |
+| `MobileAuthenticatedApiRequestError('session_changed')` | `MobileApiError('session_changed')` |
+| Invalid internal request path/header | Treat as `invalid_response`; this is a programmer/configuration defect and must be covered by tests |
 | Final 401 after coordinator recovery | `unauthorized` |
 | 403 | `forbidden` |
 | Fetch rejection without caller abort | `network` |
@@ -308,15 +415,37 @@ export type MobileSrsService = {
 
 `getStats()` calls `srs/stats`, forwards the abort signal, and runs `parseSrsStats()` before returning.
 
-Create `apps/vela-mobile/src/services/mobile-services.ts` with typed injection keys and a provider function that accepts the already-created auth coordinator. The existing `mobile-auth` boot creates the coordinator, provides it, calls the mobile-services provider, and only then starts initialization. This avoids exposing a coordinator singleton or relying on cross-boot injection lookup.
+Create `apps/vela-mobile/src/services/mobile-services.ts` with typed injection keys and a provider function:
 
-Tests can provide deterministic fake services without mocking global fetch.
+```ts
+export function provideMobileServices(
+  app: App,
+  coordinator: MobileAuthCoordinator,
+): void;
+```
 
-### TanStack Query bootstrap
+The existing `mobile-auth` boot:
+
+1. creates the coordinator;
+2. provides `MOBILE_AUTH_KEY`;
+3. calls `provideMobileServices(app, coordinator)` with the coordinator directly; and
+4. starts coordinator initialization.
+
+`mobile-services.ts` does not use `inject()` and does not import the QueryClient. Tests can provide deterministic fake services without mocking global fetch.
+
+### QueryClient bootstrap and wiring
 
 Add workspace dependencies on `@vela/common` and `@tanstack/vue-query` to `@vela/mobile`.
 
-Create `apps/vela-mobile/src/boot/query.ts` to create a QueryClient through `createQueryClient()`, install `VueQueryPlugin`, and export the mobile query client for lifecycle and auth-isolation wiring.
+Create `apps/vela-mobile/src/boot/query.ts`:
+
+```ts
+export const mobileQueryClient = createQueryClient();
+
+export default defineBoot(({ app }) => {
+  app.use(VueQueryPlugin, { queryClient: mobileQueryClient });
+});
+```
 
 The boot order becomes:
 
@@ -328,9 +457,31 @@ capacitor-lifecycle (Capacitor only)
 diagnostic-cold-entry (development only)
 ```
 
-All boot files finish before `App.vue` mounts. The due-count query overrides only slice-specific behavior:
+The wiring mechanisms are intentionally distinct:
+
+- `mobileQueryClient` is a module singleton imported by lifecycle/auth-isolation infrastructure.
+- `VueQueryPlugin` provides that same instance to TanStack Query composables.
+- `MobileAuthCoordinator` and `MobileSrsService` use typed Vue application injection.
+- `mobile-auth` boot passes the coordinator directly to `provideMobileServices()`; no boot file tries to recover another boot file's provided value through component injection.
+- `App.vue` injects the coordinator and imports `mobileQueryClient` to install auth/cache isolation once.
+
+### Due-count query and exact automatic retry policy
+
+Create `apps/vela-mobile/src/composables/useDueReviewCount.ts`.
+
+The query configuration is:
 
 ```ts
+const DUE_COUNT_RETRY_LIMIT = 2;
+
+export function retryDueCountQuery(failureCount: number, error: unknown): boolean {
+  return (
+    error instanceof MobileApiError &&
+    (error.code === 'network' || error.code === 'server') &&
+    failureCount < DUE_COUNT_RETRY_LIMIT
+  );
+}
+
 useQuery({
   queryKey: computed(() => srsKeys.stats(userId.value)),
   enabled: computed(() => sessionUsable.value && userId.value !== null),
@@ -341,9 +492,11 @@ useQuery({
 });
 ```
 
-The shared stale and garbage-collection defaults remain. `always` is required because Home activation and foreground resume must refresh even while data is nominally fresh.
+TanStack Query invokes the retry predicate as `(failureCount, error)`. `failureCount < 2` permits two retries, matching the existing shared numeric default while preventing retries for auth, authorization, validation, cancellation, or stale-session failures.
 
-Automatic retries apply only to network and server failures, up to the shared retry limit. They do not apply to cancellation, session-unavailable, session-changed, unauthorized, forbidden, or invalid-response errors. A user may still manually retry visible `forbidden` or `invalid_response` failures; the distinction is that they are not repeated automatically.
+Tests must verify the predicate directly for every `MobileApiErrorCode`, including that a final 401-derived `unauthorized` error receives zero automatic retries.
+
+The shared stale and garbage-collection defaults remain. `refetchOnMount: 'always'` and `refetchOnWindowFocus: 'always'` are required because Home activation and foreground resume must refresh even while data is nominally fresh.
 
 ### Native foreground integration
 
@@ -357,11 +510,15 @@ Keep existing resume diagnostics behavior. Tests cover inactive and active trans
 
 ### Auth and cache isolation
 
-Create `apps/vela-mobile/src/services/mobile-query-auth-isolation.ts` and install it once from `App.vue` after the QueryClient and coordinator have been provided.
+Create `apps/vela-mobile/src/services/mobile-query-auth-isolation.ts` and install it once from `App.vue`.
 
-It watches `sessionUsable`, `user?.userId`, `operation`, and `phase`.
+`App.vue`:
 
-Rules:
+- injects `MOBILE_AUTH_KEY`;
+- imports the `mobileQueryClient` module singleton; and
+- calls the installer with both explicit dependencies.
+
+The isolation rules are:
 
 1. Queries are enabled only with a usable session and user ID.
 2. A usable-to-unusable transition immediately stops Home from selecting authenticated data.
@@ -369,14 +526,32 @@ Rules:
 4. Failed durable sign-out cleanup still leaves query data cleared.
 5. A soft in-session refresh failure does not clear while `sessionUsable` remains true.
 6. Ordinary backgrounding does not clear.
+7. Cancellation completes before cache removal so an older response cannot repopulate the cache afterward.
 
 Clearing the complete QueryClient is acceptable in M1 because all current mobile server state is authenticated and user-specific.
 
-### Due-count composable
+### Manual retry versus background refresh
 
-Create `apps/vela-mobile/src/composables/useDueReviewCount.ts`.
+The composable owns a local `manualRetryPending` ref in addition to TanStack Query state.
 
-It injects the auth coordinator and SRS service, derives user ID, owns the query configuration, and returns query state plus an explicit `retry()` action. It contains no display copy and performs no navigation.
+Its `retry()` operation:
+
+1. returns immediately when a manual retry is already pending;
+2. records the current visible error presentation;
+3. sets `manualRetryPending = true`;
+4. awaits `query.refetch()`; and
+5. clears `manualRetryPending` in `finally`.
+
+The presentation inputs derive as follows:
+
+```ts
+retrying = manualRetryPending;
+refreshing = query.isFetching && query.data !== undefined && !manualRetryPending;
+```
+
+While a manual retry is pending, the previous blocking or cached error surface remains rendered with its Retry button disabled/loading. An automatic mount/focus refetch with cached data renders the normal count plus the subtle refreshing status.
+
+The selector must not derive both `retrying` and `refreshing` from `isFetching` alone.
 
 ### Home view selector
 
@@ -396,12 +571,15 @@ Rules:
 - no data plus initial fetch produces `loading`;
 - `due_today === 0` produces `zero`;
 - `due_today > 0` produces `positive`;
-- background fetch keeps zero/positive content with `refreshing: true`;
+- automatic background fetch keeps zero/positive content with `refreshing: true`;
 - visible failure without data produces `blocking_error`;
-- visible refetch failure with cached data produces `cached_error`;
+- visible refetch failure with cached data, including cached `0`, produces `cached_error`;
 - every non-auth visible failure offers manual Retry;
+- manual retry preserves the corresponding error kind with `retrying: true`;
 - cancellation and session-change outcomes produce no visible failure; and
 - unauthorized is never a Home view because auth state removes the content surface.
+
+A cached zero retains the stale-data notice after a failed refetch. Zero can become stale as review timestamps pass or progress changes through the web app or another client.
 
 ### Home presentation
 
@@ -439,14 +617,15 @@ Replace the M1 scaffold in `HomePage.vue` with a focused “Today’s review” 
 
 #### Cached refresh failure
 
-- Keep the last verified count visible.
+- Keep the last verified count visible, including `0`.
 - Non-blocking alert: “This count may be out of date.”
 - Retry button.
 
-#### Retrying
+#### Manual retry in progress
 
+- Keep the existing blocking or cached error surface visible.
 - Disable Retry.
-- Loading state and accessible label: “Retrying review count.”
+- Use loading state and accessible label: “Retrying review count.”
 
 #### Unauthorized
 
@@ -459,7 +638,7 @@ The page no longer displays app version, environment, or scaffold labels. Develo
 
 ### Network and server failures
 
-They do not mutate authentication state. They remain query errors and support manual retry. Cached verified data remains visible during a failed refetch.
+They do not mutate authentication state. They remain query errors and support automatic and manual retry according to the explicit predicate. Cached verified data remains visible during a failed refetch.
 
 ### Invalid API shape
 
@@ -467,11 +646,11 @@ Invalid stats are never cached. The client returns `invalid_response`, Home show
 
 ### Unauthorized session
 
-A final current-generation 401 is an auth concern. The coordinator owns recovery/cleanup, the query disables, the cache clears, and the gate removes protected content.
+A final current-generation 401 is an auth concern. The coordinator owns recovery/cleanup, returns the final response for client classification, the query disables, the cache clears, and the gate removes protected content.
 
 ### Sign-out during request
 
-Sign-out increments auth generation, marks the session unusable before cleanup, cancels query work, and clears cache. A late prior-generation response cannot repopulate data or invalidate the current session.
+Sign-out increments auth generation, marks the session unusable before cleanup, cancels query work, and clears cache. A late prior-generation response throws `session_changed` and cannot repopulate data or invalidate the current session.
 
 ### Identity replacement
 
@@ -486,36 +665,52 @@ A later sign-in receives a different user-scoped key and cannot select previous-
 - Reject accuracy outside 0–100.
 - Ignore unknown additional fields.
 - Produce distinct stats keys for distinct users and JLPT filters.
+- Confirm no production web caller is expected to change query behavior.
+- Confirm `packages/common/src/index.ts` package description covers contracts as well as query utilities.
 
 ### Auth coordinator
 
-- Attach the current ID token to an allowed path.
-- Prevent Authorization override.
-- Reject absolute, scheme-relative, root-relative, traversal, and outside-prefix paths.
-- Reject without a usable session.
+- Attach the current ID token to an allowed relative path.
+- Use the same URL builder for `auth/session` and `srs/stats`.
+- Reject absolute, scheme-relative, root-relative, backslash, traversal, and outside-prefix paths.
+- Reject `/api-evil/secret` when the configured base pathname is `/api/`.
+- Preserve the normalized trailing `/` in containment checks.
+- Reject `Authorization`, `authorization`, `AUTHORIZATION`, and mixed-case variants before network activity.
+- Reject without a usable session using the typed error.
 - Preserve caller abort behavior.
+- Propagate transport rejection for client classification.
 - Return non-401 responses without auth mutation.
 - Refresh and retry once when the token expires in flight.
 - Terminally clean up after a still-valid current token or refreshed retry is rejected.
-- Ignore an old-generation 401 for auth mutation.
+- Return the final 401 response after the auth transition.
+- Throw `session_changed` for an old-generation response without auth mutation.
 - Keep 403 feature-scoped.
 - Handle sign-out racing an in-flight request.
 - Keep token/header values out of logs and rendered errors.
 
 ### Mobile API and SRS services
 
+- Map each typed coordinator failure to the documented `MobileApiErrorCode`.
 - Successful JSON parsing and full stats validation.
-- Network, 403, non-2xx, and invalid-response classification.
+- Network, 401, 403, non-2xx, and invalid-response classification.
 - Cancellation and signal forwarding.
 - Exact `srs/stats` path.
-- Typed service provisioning from the coordinator.
+- Typed service provisioning from the coordinator without cross-boot `inject()`.
 
-### Query bootstrap and lifecycle
+### Query bootstrap and retry policy
 
-- QueryClient installation and boot ordering.
-- `focusManager` inactive/active updates.
-- Foreground refetch for an enabled query.
-- No foreground fetch while signed out.
+- QueryClient singleton creation and Vue plugin installation.
+- Boot ordering.
+- `retryDueCountQuery(0, network)` and `retryDueCountQuery(1, server)` return true.
+- `retryDueCountQuery(2, network)` returns false.
+- Unauthorized, forbidden, invalid-response, session-unavailable, and session-changed return false at every failure count.
+- Unknown/non-`MobileApiError` values return false.
+
+### Native lifecycle
+
+- `focusManager` receives inactive and active updates.
+- Foreground refetch occurs for an enabled query.
+- No foreground fetch occurs while signed out.
 - Existing lifecycle diagnostics remain intact.
 
 ### Cache isolation
@@ -524,18 +719,22 @@ A later sign-in receives a different user-scoped key and cannot select previous-
 - One initial query after restored authentication becomes usable.
 - User ID appears in the key.
 - Sign-out and terminal cleanup cancel and clear.
+- Cancellation precedes removal.
 - Soft refresh failure with a usable session retains cache.
 - Identity change cannot select previous-user data.
 - Failed durable cleanup still hides and clears due-count data.
 
-### Home component
+### Composable and Home component
 
+- Background fetch with cached data sets `refreshing` and not `retrying`.
+- Manual retry sets `retrying` and not `refreshing`.
+- The previous error surface remains visible while manual retry is pending.
 - Accessible loading state.
 - Zero, singular, and plural states.
 - Blocking network failure and manual retry.
 - Disabled/loading retry state.
 - Background refresh with cached count.
-- Cached refresh failure with alert and Retry.
+- Cached positive and cached-zero refresh failures show the stale-data alert and Retry.
 - No Start Review action.
 - No scaffold version/environment content.
 
@@ -581,6 +780,7 @@ Record account, build/environment, device, timestamp, comparison value, and resu
 - Modify: `apps/vela-mobile/src/boot/capacitor-lifecycle.ts`
 - Modify: `apps/vela-mobile/src/boot/capacitor-lifecycle.test.ts`
 - Modify: `apps/vela-mobile/src/boot/mobile-auth.ts`
+- Modify: `apps/vela-mobile/src/boot/mobile-auth.test.ts`
 
 ### Authenticated request boundary
 
@@ -617,18 +817,22 @@ Record account, build/environment, device, timestamp, comparison value, and resu
 | --- | --- |
 | Returning user reaches Home through restored auth | Existing HPA-206 gate plus enabled query after `sessionUsable` |
 | Home displays `/api/srs/stats` due count | Mobile SRS service and Home selector |
-| Expired/rejected token cannot expose another user’s data | Generation-aware recovery, user-scoped key, query disable, and cache cleanup |
-| Loading, empty, failure, and retry states are accessible | Exhaustive presentation union and required semantics |
-| Signing out clears user data | Auth-isolation service cancels and clears QueryClient |
+| Expired/rejected token cannot expose another user’s data | Generation-aware recovery, typed stale-session rejection, user-scoped key, query disable, and cache cleanup |
+| Loading, empty, failure, and retry states are accessible | Exhaustive presentation union, explicit manual-retry state, and required semantics |
+| Signing out clears user data | Auth-isolation service cancels then clears QueryClient |
 | Count agrees with web/API | Required manual verification matrix |
-| Tests cover states and auth/cache isolation | Shared, auth, service, query, cache, and component suites |
+| Tests cover states and auth/cache isolation | Shared, auth, service, retry, query, cache, and component suites |
 | Simulator and physical iPhone verification | Required matrix rows for both device classes |
 
 ## Risks and Mitigations
 
 ### Token leakage through an overly generic client
 
-Keep token application inside the coordinator, validate path containment, prohibit Authorization overrides, and extend secret-leak tests.
+Keep token application inside the coordinator, validate path containment, reject Authorization overrides case-insensitively, and extend secret-leak tests.
+
+### API-prefix boundary bypass
+
+Normalize the base pathname with a trailing `/`, resolve through parsed URLs, compare origin and pathname boundaries, and test `/api/` versus `/api-evil/` explicitly.
 
 ### Late 401 signs out a refreshed session
 
@@ -638,13 +842,21 @@ Capture and verify active owner plus auth generation before any 401-driven mutat
 
 Recheck expiry on 401, refresh through the existing durable credential path, and retry once before terminal cleanup.
 
+### Default retry repeats auth failures
+
+Use the explicit retry predicate and direct tests for all error codes rather than inheriting the shared numeric default.
+
 ### Previous-user cache flashes after sign-in
 
 Include user ID in the key and disable whenever no usable identity exists. Cache clearing remains defense in depth.
 
-### Shared query defaults prevent required refresh
+### Manual retry looks like background refresh
 
-Set due-count `refetchOnMount` and `refetchOnWindowFocus` to `always` while retaining shared stale/GC timing.
+Track `manualRetryPending` independently and retain the preceding error surface until the manual request settles.
+
+### Wiring relies on an unavailable cross-boot injection
+
+Pass the coordinator directly into service provisioning, import the QueryClient singleton only where infrastructure needs it, and reserve Vue injection for component/composable consumers.
 
 ### Native lifecycle does not produce browser focus events
 
@@ -658,13 +870,14 @@ Home presents count and status only. Review navigation and due-card retrieval re
 
 The implementation plan should preserve test-driven, independently reviewable boundaries in this order:
 
-1. shared SRS contract and user-scoped query key;
-2. coordinator-owned authenticated request capability and race handling;
-3. mobile API/SRS services and provisioning;
-4. TanStack Query boot and native focus bridge;
-5. auth-driven cache isolation;
-6. due-count composable and pure view selector;
-7. Home presentation and accessibility states; and
-8. Simulator and physical-device milestone evidence.
+1. shared SRS contract, package description, and user-scoped query key;
+2. shared API URL normalization and case-insensitive header ownership;
+3. coordinator authenticated-request failure contract and generation-aware 401 handling;
+4. mobile API/SRS services and direct coordinator provisioning;
+5. QueryClient boot, exact retry predicate, and native focus bridge;
+6. auth-driven cache isolation with explicit singleton/injection wiring;
+7. due-count composable with separate manual-retry state and pure view selector;
+8. Home presentation and accessibility states; and
+9. Simulator and physical-device milestone evidence.
 
-Each stage must leave existing web authentication, web SRS behavior, mobile OAuth restoration, and sign-out behavior unchanged except for the explicitly shared contract and query-key signature.
+Each stage must leave existing web authentication, web SRS loading behavior, mobile OAuth restoration, and sign-out behavior unchanged except for the explicitly shared contract, package description, and query-key signature.

--- a/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
+++ b/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
@@ -60,7 +60,7 @@ The mobile app does not yet install TanStack Query, and Home still renders the M
 | Query key | Change `srsKeys.stats()` to include authenticated user ID; mobile is its first production consumer |
 | Token ownership | ID tokens remain private to the mobile auth coordinator |
 | Feature request surface | Add a coordinator-owned authenticated request operation; do not add `getIdToken()` |
-| Coordinator failure contract | Throw a typed coordinator error for invalid paths, unavailable sessions, and stale-session responses; return HTTP responses, including final 401 responses, to the mobile API client |
+| Coordinator failures | Use stable typed failures for invalid path, invalid Authorization header, unavailable session, and stale session |
 | URL safety | Use one trailing-slash-preserving API URL builder for `/auth/session` and feature paths; require relative paths contained beneath the configured API prefix |
 | Header ownership | Reject caller-supplied `Authorization` headers case-insensitively before applying the coordinator-owned bearer token |
 | Unauthorized response | A current-session 401 enters auth recovery or terminal cleanup; Home never renders an unauthorized-data state |
@@ -72,7 +72,7 @@ The mobile app does not yet install TanStack Query, and Home still renders the M
 | Home re-entry | Refetch whenever Home mounts, even if cached data is still fresh |
 | Manual retry | Track manual retry separately from background fetching so `retrying` and `refreshing` are never inferred from the same flag |
 | Cache isolation | Disable immediately when auth is unusable, user-scope keys, and clear mobile query state on sign-out or identity loss |
-| Cached zero | A cached zero remains eligible for the same stale-data warning as any other cached count because time or another client can make reviews due |
+| Cached zero | A cached zero keeps the stale-data warning because time or another client can make reviews due |
 | Review navigation | Do not add a Start Review action in HPA-207 |
 | Platform | Native iOS remains the authenticated runtime for this milestone |
 
@@ -175,6 +175,7 @@ export type MobileAuthenticatedApiRequest = {
 
 export type MobileAuthenticatedApiRequestErrorCode =
   | 'invalid_request_path'
+  | 'invalid_request_headers'
   | 'session_unavailable'
   | 'session_changed';
 
@@ -205,6 +206,7 @@ The request operation has these observable outcomes:
 | Outcome | Coordinator result |
 | --- | --- |
 | Path violates the mobile API containment contract | Throw `MobileAuthenticatedApiRequestError('invalid_request_path')` before network activity |
+| Caller supplies any case variant of `Authorization` | Throw `MobileAuthenticatedApiRequestError('invalid_request_headers')` before network activity |
 | No usable current session before dispatch | Throw `MobileAuthenticatedApiRequestError('session_unavailable')` before network activity |
 | Caller aborts | Preserve the platform `AbortError`; do not mutate auth state |
 | Fetch rejects for another reason | Propagate the transport error; the mobile API client classifies it as `network` |
@@ -248,7 +250,7 @@ https://vela.example/api///  -> https://vela.example/api/
 - a resolved pathname that does not begin with the normalized trailing-slash API pathname; and
 - URL fragments.
 
-The implementation must compare parsed URL origin and pathname boundaries rather than using a base string with its trailing slash removed. With a base pathname of `/api/`, `/api-evil/secret` is outside the boundary and must fail.
+The implementation compares parsed URL origin and pathname boundaries rather than using a base string with its trailing slash removed. With a base pathname of `/api/`, `/api-evil/secret` is outside the boundary and must fail.
 
 The existing `/auth/session` request becomes:
 
@@ -271,14 +273,12 @@ HTTP header names are case-insensitive. The coordinator converts caller headers 
 ```ts
 const headers = new Headers(request.init?.headers);
 if (headers.has('authorization')) {
-  throw new MobileAuthenticatedApiRequestError('invalid_request_path');
+  throw new MobileAuthenticatedApiRequestError('invalid_request_headers');
 }
 headers.set('Authorization', `Bearer ${idToken}`);
 ```
 
-The implementation may use a dedicated `invalid_request_headers` code instead of reusing `invalid_request_path` if that produces a clearer contract during implementation planning. The important design requirement is stable typed rejection before network activity.
-
-Tests must cover `Authorization`, `authorization`, `AUTHORIZATION`, and at least one mixed-case spelling.
+Tests cover `Authorization`, `authorization`, `AUTHORIZATION`, and at least one mixed-case spelling.
 
 ### Auth generation and 401 handling
 
@@ -392,14 +392,14 @@ The client:
 | Coordinator/HTTP outcome | Client classification |
 | --- | --- |
 | Caller abort | Preserve abort semantics; no visible error |
-| `MobileAuthenticatedApiRequestError('session_unavailable')` | `MobileApiError('session_unavailable')` |
-| `MobileAuthenticatedApiRequestError('session_changed')` | `MobileApiError('session_changed')` |
-| Invalid internal request path/header | Treat as `invalid_response`; this is a programmer/configuration defect and must be covered by tests |
-| Final 401 after coordinator recovery | `unauthorized` |
-| 403 | `forbidden` |
-| Fetch rejection without caller abort | `network` |
-| Non-2xx other than 401/403 | `server` |
-| Invalid JSON or stats shape | `invalid_response` |
+| `session_unavailable` coordinator error | `MobileApiError('session_unavailable')` |
+| `session_changed` coordinator error | `MobileApiError('session_changed')` |
+| `invalid_request_path` or `invalid_request_headers` coordinator error | `MobileApiError('invalid_response')`; these are programmer/configuration defects and must be covered by tests |
+| Final 401 after coordinator recovery | `MobileApiError('unauthorized')` |
+| 403 | `MobileApiError('forbidden')` |
+| Fetch rejection without caller abort | `MobileApiError('network')` |
+| Non-2xx other than 401/403 | `MobileApiError('server')` |
+| Invalid JSON or stats shape | `MobileApiError('invalid_response')` |
 
 `unauthorized` exists for tests and control flow, but Home does not render it because the coordinator disables authenticated content.
 
@@ -494,7 +494,7 @@ useQuery({
 
 TanStack Query invokes the retry predicate as `(failureCount, error)`. `failureCount < 2` permits two retries, matching the existing shared numeric default while preventing retries for auth, authorization, validation, cancellation, or stale-session failures.
 
-Tests must verify the predicate directly for every `MobileApiErrorCode`, including that a final 401-derived `unauthorized` error receives zero automatic retries.
+Tests verify the predicate directly for every `MobileApiErrorCode`, including that a final 401-derived `unauthorized` error receives zero automatic retries.
 
 The shared stale and garbage-collection defaults remain. `refetchOnMount: 'always'` and `refetchOnWindowFocus: 'always'` are required because Home activation and foreground resume must refresh even while data is nominally fresh.
 
@@ -551,7 +551,7 @@ refreshing = query.isFetching && query.data !== undefined && !manualRetryPending
 
 While a manual retry is pending, the previous blocking or cached error surface remains rendered with its Retry button disabled/loading. An automatic mount/focus refetch with cached data renders the normal count plus the subtle refreshing status.
 
-The selector must not derive both `retrying` and `refreshing` from `isFetching` alone.
+The selector does not derive both `retrying` and `refreshing` from `isFetching` alone.
 
 ### Home view selector
 
@@ -665,8 +665,7 @@ A later sign-in receives a different user-scoped key and cannot select previous-
 - Reject accuracy outside 0–100.
 - Ignore unknown additional fields.
 - Produce distinct stats keys for distinct users and JLPT filters.
-- Confirm no production web caller is expected to change query behavior.
-- Confirm `packages/common/src/index.ts` package description covers contracts as well as query utilities.
+- Confirm the package header covers contracts as well as query utilities.
 
 ### Auth coordinator
 
@@ -675,8 +674,8 @@ A later sign-in receives a different user-scoped key and cannot select previous-
 - Reject absolute, scheme-relative, root-relative, backslash, traversal, and outside-prefix paths.
 - Reject `/api-evil/secret` when the configured base pathname is `/api/`.
 - Preserve the normalized trailing `/` in containment checks.
-- Reject `Authorization`, `authorization`, `AUTHORIZATION`, and mixed-case variants before network activity.
-- Reject without a usable session using the typed error.
+- Reject `Authorization`, `authorization`, `AUTHORIZATION`, and mixed-case variants with `invalid_request_headers` before network activity.
+- Reject without a usable session using `session_unavailable`.
 - Preserve caller abort behavior.
 - Propagate transport rejection for client classification.
 - Return non-401 responses without auth mutation.

--- a/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
+++ b/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
@@ -72,7 +72,7 @@ The mobile app does not install TanStack Query, does not alias `@vela/common` to
 | Retry | Retry only `network` and `server`, at most twice |
 | Auth abstraction | Feature code consumes a stable session-capability selector, not raw auth operation/error fields |
 | Module resolution | Mobile Quasar and Vitest alias `@vela/common` to source while retaining the workspace dependency |
-| Cache isolation | User-scope keys; disable without a usable session; cancel then clear on sign-out/identity loss |
+| Cache isolation | User-scope keys; disable without a usable session; scoped cancel-then-remove of `srsKeys.stats(previousUserId)` on sign-out/identity loss; no cache mutation when there is no prior user |
 | Foreground/Home refresh | Refetch on native foreground and every Home mount |
 | Manual retry | Track manual retry independently from background fetch |
 | Cached zero | Keep stale-data warning because time or another client can make reviews due |
@@ -278,7 +278,7 @@ After transport settles:
 | 401 | No | `session_changed`; no auth mutation |
 | 401 | Yes | Shared recovery decision |
 
-Sign-out and data freshness are enforced by caller cancellation, TanStack cancellation, user-scoped keys, and cancel-then-clear—not by discarding every old-generation response.
+Sign-out and data freshness are enforced by caller cancellation, TanStack cancellation, user-scoped keys, and scoped cancel-then-remove of the previous user's `srsKeys.stats(previousUserId)` entry—not by discarding every old-generation response, and not by a global `queryClient.clear()`.
 
 ### Explicit refresh observation
 
@@ -576,12 +576,14 @@ Install auth/cache isolation once from `App.vue` using the injected coordinator 
 
 1. Enable authenticated queries only for `usable` or `recovering` with `sessionUsable: true`.
 2. Sign-out, terminal cleanup, unusable recovery, or identity change cancels in-flight queries.
-3. Await cancellation before cache removal for sign-out, terminal cleanup, or identity change.
-4. Failed durable cleanup still leaves cache cleared.
-5. Soft refresh failure retains cached data only while the prior session remains usable.
-6. Backgrounding does not clear.
+3. For sign-out, terminal cleanup, or identity change with a known prior user, await `cancelQueries({ queryKey: srsKeys.stats(previousUserId) })` and then `removeQueries({ queryKey: srsKeys.stats(previousUserId) })`—scoped to the previous user only. Never call `queryClient.clear()`.
+4. When sign-out or a cleanup retry occurs with no prior user (`previousUserId === null`), perform no cache mutation: there is no authenticated user key to remove, and any cache present belongs to a successor that may authenticate during the await.
+5. Unusable recovery cancels only the recovering user's `srsKeys.stats(userId)` queries without removing cache.
+6. Failed durable cleanup still leaves the previous user's cache removed (the scoped `removeQueries` ran before the await resolved).
+7. Soft refresh failure retains cached data only while the prior session remains usable.
+8. Backgrounding does not clear.
 
-A non-401 may return after generation promotion; canceled-query semantics and user-scoped keys prevent repopulation after identity loss.
+A non-401 may return after generation promotion; canceled-query semantics and user-scoped keys prevent repopulation after identity loss. The scoped cancel-then-remove (rather than a global `clear()`) is what prevents a stale sign-out or recovery callback, parked at its `await cancelQueries()` when a successor session starts, from aborting the successor's in-flight requests or erasing its freshly seeded cache after the await resolves.
 
 ### Manual retry, view selector, and Home
 
@@ -692,7 +694,10 @@ Home copy and semantics:
 - Same-user `recovering -> usable` refetches once.
 - Composable does not inspect raw auth operation/retry/error fields.
 - Native focus updates and enabled-only refetch.
-- Sign-out/terminal cleanup cancel before clear.
+- Sign-out/terminal cleanup/identity change with a prior user: scoped `cancelQueries` then `removeQueries` on `srsKeys.stats(previousUserId)`; `queryClient.clear()` is never called.
+- Sign-out or cleanup retry with no prior user performs no cache mutation.
+- Unusable recovery cancels only the recovering user's key without removing cache.
+- A stale sign-out/recovery callback parked at its `await` does not abort a successor's in-flight request or erase its cache after the await resolves.
 - Soft refresh failure retains cache only while session remains usable.
 - Identity change cannot select previous data.
 - Manual/background flags are distinct.
@@ -779,9 +784,9 @@ Automated checks and Simulator flow are merge gates. Physical-device evidence is
 | --- | --- |
 | Restored user reaches Home | HPA-206 gate plus enabled query |
 | Home displays stats count | Mobile SRS service plus selector |
-| Rejected/expired token cannot leak another user’s data | 401-only generation guard, explicit recovery outcome, user key, cancellation, cache clear |
+| Rejected/expired token cannot leak another user’s data | 401-only generation guard, explicit recovery outcome, user key, cancellation, scoped cache removal |
 | Accessible loading/empty/failure/retry | Exhaustive view including auth recovery and manual retry |
-| Signing out clears user data | Cancel then clear |
+| Signing out clears user data | Scoped cancel-then-remove of `srsKeys.stats(previousUserId)`; no global `clear()` |
 | Count agrees with web/API | Manual matrix |
 | Tests cover states/isolation | Concurrency, no-op refresh, timeout, service, query, cache, and UI suites |
 | Simulator/device verification | Merge gate plus closure gate |
@@ -797,7 +802,7 @@ Automated checks and Simulator flow are merge gates. Physical-device evidence is
 - **Transient refresh deletes credential:** settle as pending recovery and retain HPA-206 state.
 - **Stale common build in per-app workflow:** alias mobile build/tests to current common source.
 - **Auth state machine leaks into feature code:** expose a stable auth-owned session-capability selector.
-- **Previous-user cache flash:** user key, disable, cancel then clear.
+- **Previous-user cache flash:** user key, disable, scoped cancel-then-remove of `srsKeys.stats(previousUserId)`; no global `clear()` (a global clear would race a successor authenticating during the await).
 - **Token/path leakage:** coordinator-owned bearer, header rejection, parsed path boundaries, secret-leak tests.
 - **Scope expansion:** count and status only; review execution later.
 

--- a/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
+++ b/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
@@ -290,8 +290,8 @@ Feature 401 recovery uses a feature-specific observer:
 type FeatureRefreshObservation =
   | { kind: 'promoted'; owner: ActiveSession; generation: number }
   | { kind: 'terminal' }
-  | { kind: 'retryable_failure' }
-  | { kind: 'superseded' };
+  | { kind: 'superseded' }
+  | { kind: 'retryable_failure' };
 
 async function observeFeatureRefresh(
   owner: ActiveSession,
@@ -299,12 +299,16 @@ async function observeFeatureRefresh(
 ): Promise<FeatureRefreshObservation>;
 ```
 
-`observeFeatureRefresh()` calls or joins `queueRefresh({ requireDue: false, owner, generation })`, then derives outcome from coordinator postconditions—not from promise fulfillment:
+`observeFeatureRefresh()` calls or joins `queueRefresh({ requireDue: false, owner, generation })`, then derives outcome from coordinator postconditions—not from promise fulfillment.
 
-- `promoted`: a usable active session for the same user exists and `activeBundleGeneration > generation`;
-- `superseded`: owner/generation changed without a verified same-user promotion, including sign-out, disposal, or identity replacement;
-- `terminal`: terminal credential cleanup completed or entered its terminal cleanup-failure surface; and
-- `retryable_failure`: generation did not advance and no terminal result exists, including app inactive, pending candidate, no-op guard, transient refresh/persist/verify failure, or retryable auth state.
+Postconditions are evaluated in this normative order:
+
+1. `promoted`: a usable active session for the same user exists and `activeBundleGeneration > generation`;
+2. `terminal`: the terminal-cleanup path started by this recovery record settled, including its cleanup-failure surface;
+3. `superseded`: owner/generation changed for another reason without a verified same-user promotion, including user sign-out, disposal, or identity replacement; and
+4. `retryable_failure`: generation did not advance and no recovery-owned terminal result exists, including app inactive, pending candidate, no-op guard, transient refresh/persist/verify failure, or retryable auth state.
+
+The recovery record owns a boolean/enum indicating whether it initiated terminal cleanup, so ordinary sign-out or disposal cannot be misclassified as the recovery’s terminal result.
 
 This explicitly covers every silent `queueRefresh()` no-op path. A `superseded` outcome maps to `session_changed`; `retryable_failure` maps to `session_recovery_pending`.
 
@@ -316,8 +320,8 @@ Concurrent 401s for one active owner/generation share one decision:
 type FeatureUnauthorizedRecoveryResult =
   | { kind: 'refreshed' }
   | { kind: 'terminal' }
-  | { kind: 'retryable_failure' }
-  | { kind: 'superseded' };
+  | { kind: 'superseded' }
+  | { kind: 'retryable_failure' };
 
 type FeatureUnauthorizedRecovery = {
   owner: ActiveSession;
@@ -332,7 +336,7 @@ Rules:
 2. Peers for the same owner/generation await the same promise.
 3. Caller abort detaches only that caller.
 4. Refresh work still uses `refreshPromise` and `serialize()` internally.
-5. Terminal cleanup is enqueued once through `serialize()`.
+5. Terminal cleanup is enqueued once through `serialize()` and marked as recovery-owned.
 6. The recovery record clears only after settlement.
 7. After `refreshed`, each caller retries its own feature request once.
 8. A feature retry captures the promoted generation and cannot recursively recover again.
@@ -341,14 +345,14 @@ Decision:
 
 - join a refresh already in flight for the captured owner/generation;
 - otherwise use `observeFeatureRefresh()` when the captured token expired in flight;
-- otherwise treat rejection of a still-valid current token as terminal and enqueue one cleanup.
+- otherwise treat rejection of a still-valid current token as terminal and enqueue one recovery-owned cleanup.
 
 | Shared result | Per-request result |
 | --- | --- |
 | `refreshed` | Retry own feature request once |
 | `terminal` | Return own original/final 401 after cleanup |
-| `retryable_failure` | `session_recovery_pending`; preserve credentials and retry state |
 | `superseded` | `session_changed`; do not mutate replacement state |
+| `retryable_failure` | `session_recovery_pending`; preserve credentials and retry state |
 
 A feature waiter waits only for the current shared attempt, never a later automatic or user-initiated auth retry.
 
@@ -543,7 +547,7 @@ useQuery({
 
 For `session_changed` or a dispatch-time `session_unavailable` race:
 
-- if not aborted, the selector still reports the same user as usable, silently retry once;
+- if not aborted, the semantic selector still reports the same user and `queryEnabled` remains true, silently retry once;
 - otherwise rethrow and let query enablement/the gate resolve the state; and
 - never exceed one silent control-flow retry per query execution.
 
@@ -651,8 +655,9 @@ Home copy and semantics:
 - `queueRefresh()` no-op while app inactive yields `retryable_failure`, not `refreshed`.
 - Pending-candidate no-op yields `retryable_failure`.
 - Verified same-user generation advance yields `promoted`.
+- Recovery-owned terminal cleanup takes precedence over generic generation change.
 - Sign-out or identity replacement while waiting yields `superseded`.
-- Invalid grant/terminal cleanup yields `terminal`.
+- Invalid grant/recovery-owned terminal cleanup yields `terminal`.
 - Join an already-running refresh.
 - Concurrent expired-token 401s start one refresh and each retry at most once.
 - Concurrent valid-token 401s perform one cleanup.
@@ -783,7 +788,8 @@ Automated checks and Simulator flow are merge gates. Physical-device evidence is
 
 ## Risks and Mitigations
 
-- **Refresh promise resolves without promotion:** derive the result from owner/generation/state postconditions.
+- **Refresh promise resolves without promotion:** derive the result from ordered owner/generation/state postconditions.
+- **Terminal cleanup confused with sign-out:** track whether the recovery record initiated cleanup and apply normative outcome precedence.
 - **Feature request blocks or deadlocks auth:** keep feature I/O outside `operationTail`; serialize mutations only.
 - **Successful response discarded during refresh:** return non-401 before generation comparison.
 - **Duplicate refresh/cleanup:** one recovery record per owner/generation.

--- a/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
+++ b/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
@@ -8,28 +8,28 @@
 
 ## Goal
 
-Deliver the smallest production-shaped Vela Mobile product flow: a returning iOS user restores a secure Cognito session, reaches Home, and sees the current authenticated `due_today` value returned by `GET /api/srs/stats`.
+Deliver the smallest production-shaped Vela Mobile product flow: a returning iOS user restores a secure Cognito session, reaches Home, and sees the authenticated `due_today` value returned by `GET /api/srs/stats`.
 
 This slice establishes reusable mobile boundaries for authenticated feature requests and user-scoped server-state caching without importing the web Home page or exposing Cognito tokens to feature components.
 
-`due_today` is the API field name. Its current semantics are “due as of request time” (`next_review_date <= now`), not “scheduled within the current calendar day.” Home copy therefore says “caught up for now.”
+`due_today` is the API field name. Its current semantics are “due as of request time” (`next_review_date <= now`), not “scheduled within the current calendar day.” Home therefore says “caught up for now.”
 
 ## Current State
 
-HPA-204 established the absolute mobile API base URL and approved Capacitor CORS behavior.
+HPA-204 established the absolute mobile API base URL and Capacitor CORS behavior.
 
-HPA-206 established the single mobile Cognito session owner. The mobile auth coordinator now:
+HPA-206 established the single mobile Cognito session owner. The coordinator:
 
-- restores a Keychain-backed refresh credential during initialization;
+- restores a Keychain-backed refresh credential;
 - keeps ID and access tokens in process memory only;
-- refreshes the active token bundle proactively and on app resume;
-- verifies candidate sessions through `/api/auth/session` before exposing protected content;
-- marks protected content usable only while a verified active bundle remains valid; and
+- refreshes proactively and on app resume;
+- verifies candidates through `/api/auth/session` before exposing protected content;
+- marks protected content usable only while a verified bundle remains valid; and
 - clears local session material during sign-out or terminal credential failure.
 
-HPA-206 intentionally did not expose a general token accessor or authenticated feature client. HPA-207 introduces that feature-request boundary.
+HPA-206 intentionally did not expose a token accessor or general authenticated feature client. HPA-207 introduces that boundary.
 
-The API already exposes `GET /api/srs/stats`. It applies Cognito ID-token middleware and returns:
+The API already exposes `GET /api/srs/stats` through Cognito ID-token middleware and returns:
 
 ```ts
 interface SRSStats {
@@ -47,9 +47,11 @@ interface SRSStats {
 }
 ```
 
-The web application owns an equivalent interface and a web-specific SRS service. `@vela/common` already owns the `srsKeys` factory, but `srsKeys.stats()` has no production callers and is not user-scoped. HPA-207 makes mobile the first production consumer of that key; it does not migrate the web stats card to TanStack Query.
+The web app owns an equivalent interface and web-specific service. `@vela/common` owns `srsKeys`, but `srsKeys.stats()` has no production callers and is not user-scoped. Mobile becomes its first production consumer; this does not migrate the web stats card to TanStack Query.
 
-The mobile app does not yet install TanStack Query, and Home still renders the M1 scaffold.
+The API verifier already accepts both web and mobile Cognito client audiences. `CLAUDE.md` still lists that prerequisite as outstanding; the implementation change set updates that stale documentation.
+
+The mobile app does not install TanStack Query, does not alias `@vela/common` to source, and Home still renders the M1 scaffold.
 
 ## Approved Decisions
 
@@ -57,26 +59,25 @@ The mobile app does not yet install TanStack Query, and Home still renders the M
 | --- | --- |
 | Product scope | Display only the authenticated due-review count and required states |
 | Backend | Reuse `GET /api/srs/stats` unchanged |
-| Shared contract | Move the complete `SRSStats` response contract into `@vela/common` |
-| Shared package scope | Update the `@vela/common` module header to cover query utilities and domain contracts |
+| Shared contract | Move the complete `SRSStats` contract into `@vela/common` |
 | Query key | Include authenticated user ID in `srsKeys.stats()`; mobile is its first production consumer |
-| Token ownership | ID tokens remain private to the mobile auth coordinator |
-| Feature request surface | Add coordinator-owned authenticated requests; do not add `getIdToken()` |
-| URL/header safety | Share a trailing-slash-preserving API URL builder and reject Authorization overrides case-insensitively |
-| Response ordering | Return every non-401 response despite concurrent auth promotion; generation checks guard only 401-driven auth mutation |
-| Stale 401 | A 401 from a superseded generation becomes `session_changed` and cannot mutate the replacement session |
-| Current 401 | Share one refresh-or-cleanup decision per owner/generation across concurrent requests |
-| Refresh failure | A transient shared refresh failure settles callers as `session_recovery_pending`; it never deletes a potentially valid durable credential or hangs the feature request |
-| Timeout | Bound each feature transport attempt and final response-body read to 15 seconds; timeout is a retryable network failure |
-| Server state | Install TanStack Query in Vela Mobile |
-| Automatic retry | Retry only `network` and `server`, at most twice |
-| Control-flow recovery | Silently retry one same-user `session_changed`/recoverable `session_unavailable` race; wait for auth recovery when already pending |
-| Foreground/Home refresh | Refetch on native foreground and every Home mount, even when cached data is fresh |
-| Manual retry | Track manual retry separately from background fetching |
-| Cache isolation | Disable without usable identity, user-scope keys, and cancel then clear on sign-out/identity loss |
-| Cached zero | Keep the stale-data warning because time or another client can make reviews due |
+| Token ownership | ID tokens remain private to `MobileAuthCoordinator` |
+| Concurrency | Feature I/O runs outside `serialize()`/`operationTail`; only auth mutations enter the queue |
+| Refresh observation | Never infer promotion from `queueRefresh(): Promise<void>` settlement; inspect explicit postconditions |
+| Response ordering | Return every non-401 response despite concurrent session promotion |
+| Stale 401 | A superseded-generation 401 cannot mutate the replacement session |
+| Current 401 | Concurrent requests share one refresh-or-cleanup decision per owner/generation |
+| Refresh failure | Transient/no-op refresh settles as pending recovery without deleting credentials or hanging callers |
+| Timeout | One due-count query execution has an eight-second feature deadline |
+| Retry | Retry only `network` and `server`, at most twice |
+| Auth abstraction | Feature code consumes a stable session-capability selector, not raw auth operation/error fields |
+| Module resolution | Mobile Quasar and Vitest alias `@vela/common` to source while retaining the workspace dependency |
+| Cache isolation | User-scope keys; disable without usable identity; cancel then clear on sign-out/identity loss |
+| Foreground/Home refresh | Refetch on native foreground and every Home mount |
+| Manual retry | Track manual retry independently from background fetch |
+| Cached zero | Keep stale-data warning because time or another client can make reviews due |
+| Device verification | Automated/Simulator checks are merge gates; physical iPhone evidence is a closure gate |
 | Review navigation | Do not add Start Review |
-| Device verification | Simulator/automated checks are merge gates; physical-iPhone evidence is an HPA-207 closure gate |
 | Platform | Native iOS only for this milestone |
 
 ## Scope
@@ -86,15 +87,17 @@ HPA-207 includes:
 - a shared SRS statistics contract and parser;
 - a user-scoped stats query key;
 - a coordinator-owned authenticated request capability with typed failures;
-- boundary-safe URL/header handling;
-- generation-safe, single-flight 401 recovery;
-- bounded feature transport and body consumption;
+- boundary-safe URL and header handling;
+- feature I/O outside the auth mutation queue;
+- explicit refresh observation and single-flight 401 recovery;
+- bounded feature request and body consumption;
 - a mobile JSON API client and SRS service;
+- mobile source aliases for `@vela/common`;
 - TanStack Query bootstrap and native focus integration;
 - auth-driven query lifecycle and cache cleanup;
-- a minimal Home due-count presentation;
-- unit/component coverage for concurrency, timeout, retry, isolation, and view states; and
-- Simulator and physical-device verification evidence.
+- a minimal accessible Home due-count presentation;
+- tests for concurrency, timeouts, retries, isolation, and view states; and
+- Simulator and physical-device evidence.
 
 ## Non-goals
 
@@ -129,16 +132,16 @@ TanStack Query uses srsKeys.stats(userId)
 Mobile SRS service requests "srs/stats"
                     |
                     v
-Mobile API client manages cancellation/body timeout
+Mobile API client applies the feature deadline and consumes JSON
                     |
                     v
-Coordinator sends bounded request with current ID token
+Coordinator sends a bounded request with the current ID token
                     |
                     v
 GET {VITE_MOBILE_API_URL}srs/stats
 ```
 
-### One token owner and request contract
+### One token owner and public request contract
 
 `apps/vela-mobile/src/services/mobile-auth.ts` remains the only owner of active Cognito token material.
 
@@ -180,18 +183,20 @@ export type MobileAuthCoordinator = {
 
 Feature code never receives an ID token. The coordinator constructs the request, owns `Authorization`, and performs transport through its injected fetch.
 
-Observable non-HTTP outcomes:
+### Concurrency boundary: feature I/O is outside `operationTail`
 
-| Outcome | Coordinator result |
-| --- | --- |
-| Invalid path | `invalid_request_path` before network activity |
-| Caller supplies any Authorization case variant | `invalid_request_headers` before network activity |
-| No usable session before dispatch | `session_unavailable` before network activity |
-| One feature transport attempt exceeds 15 seconds | `request_timeout`; no auth mutation caused by the timeout itself |
-| Caller aborts | Preserve caller cancellation |
-| Other transport rejection | Propagate transport failure; no generation-based auth mutation |
-| Stale-generation 401 | `session_changed`; replacement session untouched |
-| Shared refresh attempt fails transiently | `session_recovery_pending`; HPA-206 retry state retained |
+`requestAuthenticatedApi()` is a public coordinator operation, but unlike `initialize()`, `startSignIn()`, callback completion, retry, sign-out, and disposal, it is **not** wrapped in `serialize()`.
+
+The method:
+
+1. synchronously validates the request and snapshots the active owner, generation, token, expiry, and user;
+2. starts feature transport outside `operationTail`;
+3. returns non-401 responses outside the auth queue; and
+4. enters `serialize()` only through existing refresh or cleanup helpers when a current-generation 401 requires an auth mutation.
+
+This prevents a slow feature request from head-of-line blocking auth operations. It also prevents the self-deadlock that would occur if a serialized feature request awaited `queueRefresh()`, whose work is itself chained onto `operationTail`.
+
+Tests prove that a pending feature fetch does not block proactive refresh, sign-out, retry, or disposal, and that 401 recovery does not wait behind its own request.
 
 ### Shared API URL normalization and Authorization ownership
 
@@ -205,7 +210,7 @@ function resolveMobileApiUrl(baseUrl: URL, relativePath: string): URL;
 The normalized base removes search/hash and has exactly one trailing pathname `/`. `resolveMobileApiUrl()` accepts non-empty relative paths such as `auth/session` and `srs/stats` and rejects:
 
 - absolute, scheme-relative, and every root-relative URL;
-- backslash-prefixed/separated escape attempts;
+- backslash-prefixed or backslash-separated escapes;
 - raw or encoded traversal outside the base;
 - different origins;
 - pathnames outside the trailing-slash base boundary; and
@@ -228,43 +233,80 @@ if (headers.has('authorization')) {
 headers.set('Authorization', `Bearer ${idToken}`);
 ```
 
-### Feature transport timeout
+Tests cover `Authorization`, lowercase, uppercase, and mixed-case variants.
 
-Each actual feature fetch attempt receives the same 15-second network bound as existing auth network calls.
+### Feature transport and overall latency budget
 
-The coordinator merges the caller signal with an attempt-local controller:
+The coordinator retains a 15-second safety cap for each physical feature fetch, matching existing auth network calls. The mobile API client additionally applies:
 
-- caller abort remains caller cancellation;
-- attempt timer abort becomes `request_timeout`;
-- timer/listener cleanup runs in `finally`;
-- the timer covers dispatch through response headers; and
-- retry after auth refresh gets a fresh attempt timer.
+```ts
+export const MOBILE_DUE_COUNT_EXECUTION_TIMEOUT_MS = 8_000;
+```
 
-The timeout does not wrap the whole refresh-and-verify sequence. Existing Cognito refresh and `/auth/session` verification already have their own bounded operations. A feature caller waiting on shared recovery races that wait with its caller signal, but one caller abort never cancels recovery needed by peers.
+This deadline spans one complete query-function execution:
+
+- initial feature transport;
+- waiting for the current shared 401 recovery decision;
+- the one permitted feature retry after verified promotion; and
+- final response-body consumption.
+
+The deadline is caller-local. If it expires while shared auth recovery is running, the feature caller detaches without cancelling recovery needed by peers and settles as `session_recovery_pending`. Otherwise expiry is `network`.
+
+Each TanStack automatic retry receives a fresh eight-second execution budget. With two retries and the shared one-second then two-second retry delays, initial loading on a persistently dead network is bounded to approximately 27 seconds before the blocking error appears. This is the accepted user-facing bound for M1.
+
+Caller cancellation remains cancellation, not timeout. Timer and abort-listener cleanup runs in `finally`.
 
 ### Response-arrival ordering
 
-Generation is an auth-mutation guard, not a general response-freshness rule. A normal proactive/resume refresh promotes a bundle and increments generation; that must not discard valid data or feature errors returned by the prior verified token.
+Generation is an auth-mutation guard, not a general response-freshness rule. A proactive or resume refresh promotes a new bundle and increments generation; that must not discard valid feature responses returned by the prior verified token.
 
 After transport settles:
 
-1. If caller-aborted, preserve cancellation.
-2. If transport rejected/timed out, propagate the corresponding failure without a generation-driven auth mutation.
-3. If status is not 401, return `Response` unchanged regardless of generation.
-4. Only for 401, compare captured owner/generation with current active session.
-5. Stale 401 returns `session_changed` without mutation.
-6. Current-generation 401 enters shared recovery.
+1. Preserve caller cancellation.
+2. Propagate raw transport rejection or timeout without generation-driven auth mutation.
+3. If status is not 401, return the `Response` regardless of generation.
+4. Only for 401, compare the captured owner/generation with the current active session.
+5. A stale 401 returns `session_changed` without mutation.
+6. A current-generation 401 enters shared recovery.
 
 | Response | Generation matches | Result |
 | --- | --- | --- |
 | 2xx | Yes or no | Return response |
 | 4xx except 401 | Yes or no | Return response |
 | 5xx | Yes or no | Return response |
-| Transport failure | Yes or no | Propagate; no auth mutation |
+| Transport rejection | Yes or no | Propagate; no auth mutation |
 | 401 | No | `session_changed`; no auth mutation |
-| 401 | Yes | Shared refresh-or-cleanup decision |
+| 401 | Yes | Shared recovery decision |
 
-Sign-out/data freshness is enforced by caller abort, TanStack cancellation, user-scoped keys, and cancel-then-clear isolation—not by discarding every old-generation HTTP response.
+Sign-out and data freshness are enforced by caller cancellation, TanStack cancellation, user-scoped keys, and cancel-then-clear—not by discarding every old-generation response.
+
+### Explicit refresh observation
+
+The existing `queueRefresh()` returns `Promise<void>` and may resolve without starting or completing a promotion. Its settlement is never interpreted as refresh success.
+
+Feature 401 recovery uses a feature-specific observer:
+
+```ts
+type FeatureRefreshObservation =
+  | { kind: 'promoted'; owner: ActiveSession; generation: number }
+  | { kind: 'terminal' }
+  | { kind: 'retryable_failure' }
+  | { kind: 'superseded' };
+
+async function observeFeatureRefresh(
+  owner: ActiveSession,
+  generation: number,
+): Promise<FeatureRefreshObservation>;
+```
+
+`observeFeatureRefresh()` calls or joins `queueRefresh({ requireDue: false, owner, generation })`, then derives outcome from coordinator postconditions—not from promise fulfillment:
+
+- `promoted`: a usable active session for the same user exists and `activeBundleGeneration > generation`;
+- `superseded`: owner/generation changed without a verified same-user promotion, including sign-out, disposal, or identity replacement;
+- `terminal`: terminal credential cleanup completed or entered its terminal cleanup-failure surface; and
+- `retryable_failure`: generation did not advance and no terminal result exists, including app inactive, pending candidate, no-op guard, transient refresh/persist/verify failure, or retryable auth state.
+
+This explicitly covers every silent `queueRefresh()` no-op path. A `superseded` outcome maps to `session_changed`; `retryable_failure` maps to `session_recovery_pending`.
 
 ### Single-flight current-generation 401 recovery
 
@@ -274,7 +316,8 @@ Concurrent 401s for one active owner/generation share one decision:
 type FeatureUnauthorizedRecoveryResult =
   | { kind: 'refreshed' }
   | { kind: 'terminal' }
-  | { kind: 'retryable_failure' };
+  | { kind: 'retryable_failure' }
+  | { kind: 'superseded' };
 
 type FeatureUnauthorizedRecovery = {
   owner: ActiveSession;
@@ -285,60 +328,70 @@ type FeatureUnauthorizedRecovery = {
 
 Rules:
 
-1. First current-generation 401 creates the recovery record.
-2. Peers for the same owner/generation await it.
+1. The first current-generation 401 creates the guarded record outside `operationTail`.
+2. Peers for the same owner/generation await the same promise.
 3. Caller abort detaches only that caller.
-4. Existing `refreshPromise`/serialization remains the refresh single-flight mechanism.
-5. At most one terminal cleanup runs for the generation.
-6. The guarded record clears only after settlement.
+4. Refresh work still uses `refreshPromise` and `serialize()` internally.
+5. Terminal cleanup is enqueued once through `serialize()`.
+6. The recovery record clears only after settlement.
 7. After `refreshed`, each caller retries its own feature request once.
-8. The feature retry captures the promoted generation and cannot recursively retry again.
+8. A feature retry captures the promoted generation and cannot recursively recover again.
 
 Decision:
 
-- join a refresh already in flight for the captured generation;
-- otherwise refresh when the captured token expired in flight;
-- otherwise treat rejection of a still-valid current token as terminal and clean up once.
+- join a refresh already in flight for the captured owner/generation;
+- otherwise use `observeFeatureRefresh()` when the captured token expired in flight;
+- otherwise treat rejection of a still-valid current token as terminal and enqueue one cleanup.
 
 | Shared result | Per-request result |
 | --- | --- |
 | `refreshed` | Retry own feature request once |
 | `terminal` | Return own original/final 401 after cleanup |
-| `retryable_failure` | Settle as `session_recovery_pending`; preserve credential and coordinator retry state |
+| `retryable_failure` | `session_recovery_pending`; preserve credentials and retry state |
+| `superseded` | `session_changed`; do not mutate replacement state |
 
-### Soft refresh failure interaction
+A feature waiter waits only for the current shared attempt, never a later automatic or user-initiated auth retry.
 
-A feature waiter waits only for the current shared refresh attempt, never a later five-second automatic retry or user retry.
+### Shared SRS contract and keys
 
-On transient refresh failure:
+Create `packages/common/src/contracts/srs.ts` with `SRSStats` and:
 
-- HPA-206 retains `session_refresh_failed` and `retryAction: 'refresh'`;
-- waiter settles as `session_recovery_pending`;
-- no terminal cleanup or credential deletion occurs;
-- if the prior session remains usable, content/cache remains and the existing auth-retry banner is visible;
-- if unusable, the gate replaces Home with blocking auth recovery; and
-- later successful auth retry triggers one due-count refetch.
-
-### Shared SRS contract
-
-Create `packages/common/src/contracts/srs.ts` with `SRSStats` and `parseSrsStats(value)`.
+```ts
+export function parseSrsStats(value: unknown): SRSStats;
+```
 
 The parser requires non-negative integer count fields, a finite non-negative ease factor, accuracy from 0 through 100, and all required nested fields. Unknown fields are ignored.
 
-The web SRS service imports/re-exports `SRSStats`, preserving its public type and direct loading behavior. Update `packages/common/src/index.ts` so its header describes query configuration, keys, domain contracts, and lightweight utilities.
+The web service imports and re-exports `SRSStats`, preserving its public type and direct loading behavior. Update the `@vela/common` header so the package describes query configuration, keys, domain contracts, and lightweight utilities.
 
-### User-scoped stats key
+Change only the stats key:
 
 ```ts
 srsKeys.stats(userId: string | null, jlpt?: number[])
 // ['srs', 'stats', userId, jlpt]
 ```
 
-The user ID is the cache correctness boundary; clearing is defense in depth. This slice changes only `stats`. Other SRS keys remain unscoped and must be revisited before mobile review uses them.
+Add a comment immediately above `srsKeys.due`, `progress`, and `allProgress` stating that these keys remain identity-unscoped and must not be used for mobile user data until their identity/cache-isolation contract is redesigned. This makes the hazard visible at future call sites rather than only in tests.
 
-### Mobile API client and body timeout
+### Mobile package resolution
 
-Create `mobile-api-client.ts`:
+Add `@vela/common` and `@tanstack/vue-query` as workspace dependencies of `@vela/mobile`.
+
+Also modify both mobile configuration files:
+
+```ts
+// apps/vela-mobile/quasar.config.ts
+'@vela/common': resolve(__dirname, '../../packages/common/src/index.ts')
+
+// apps/vela-mobile/vitest.config.ts
+'@vela/common': resolve(__dirname, '../../packages/common/src/index.ts')
+```
+
+The aliases ensure local `cd apps/vela-mobile && bun run test:unit`, Quasar development/build, and contract edits use current source instead of stale `packages/common/dist`. The workspace dependency remains authoritative for package ownership and Turbo dependency ordering.
+
+### Mobile API client classification
+
+Create `apps/vela-mobile/src/services/mobile-api-client.ts`:
 
 ```ts
 export type MobileApiErrorCode =
@@ -361,26 +414,21 @@ export class MobileApiError extends Error {
     this.name = 'MobileApiError';
   }
 }
-
-export const MOBILE_FEATURE_BODY_TIMEOUT_MS = MOBILE_AUTH_NETWORK_TIMEOUT_MS; // 15_000
 ```
-
-The client creates a caller-linked controller before invoking the coordinator. After the coordinator returns the final `Response`, it starts a fresh 15-second body-read timer and keeps it active until JSON consumption completes. Aborting that controller cancels a stalled/truncated body stream.
-
-Classification:
 
 | Outcome | Client code |
 | --- | --- |
 | Caller abort | Preserve cancellation |
-| Coordinator `request_timeout` or body timeout | `network` |
-| Invalid path/header | `invalid_request`; stable development diagnostic only, no path/header/token dump |
-| Session codes | Preserve `session_unavailable`, `session_changed`, or `session_recovery_pending` |
+| `request_timeout` or feature deadline | `network`, unless shared auth recovery is pending |
+| Raw non-abort fetch rejection, including `TypeError` | `network` |
+| Invalid path/header | `invalid_request`; stable development diagnostic without request/token data |
+| Session coordinator codes | Preserve `session_unavailable`, `session_changed`, or `session_recovery_pending` |
 | Final 401 | `unauthorized` |
 | 403 | `forbidden` |
 | Other non-2xx | `server` |
-| Invalid JSON/stats | `invalid_response` |
+| Invalid JSON/stats payload | `invalid_response` |
 
-Body timeout/caller cleanup removes timer and listeners. It does not cancel coordinator recovery already shared by peers.
+The client forwards one caller signal, enforces the eight-second execution deadline, reads JSON within the remaining deadline, and removes timers/listeners in `finally`.
 
 ### Mobile SRS service and provisioning
 
@@ -403,11 +451,11 @@ export function provideMobileServices(
 ): void;
 ```
 
-`mobile-auth` boot creates/provides the coordinator, passes it directly to `provideMobileServices()`, then initializes. No cross-boot `inject()` and no QueryClient import in service provisioning.
+`mobile-auth` boot creates/provides the coordinator, passes it directly to `provideMobileServices()`, then initializes. Service provisioning does not use cross-boot `inject()` and does not import the QueryClient.
 
-### QueryClient bootstrap and wiring
+### QueryClient bootstrap and boot order
 
-Add `@vela/common` and `@tanstack/vue-query` to mobile.
+Create:
 
 ```ts
 export const mobileQueryClient = createQueryClient();
@@ -417,7 +465,7 @@ export default defineBoot(({ app }) => {
 });
 ```
 
-Boot order:
+Boot order becomes:
 
 ```text
 main
@@ -428,12 +476,37 @@ diagnostic-cold-entry (development only)
 ```
 
 - auth isolation imports `mobileQueryClient`;
-- Vue Query composables receive that instance through the plugin;
+- Vue Query composables receive the same instance through the plugin;
 - lifecycle imports only `focusManager`;
-- coordinator/SRS service use typed Vue injection for consumers; and
+- coordinator and SRS service use typed Vue injection for consumers; and
 - service provisioning receives the coordinator directly.
 
-### Due-count query and automatic retry
+### Stable feature-session selector
+
+Feature code does not inspect raw `operation`, `retryAction`, or `errorCode` fields.
+
+Create an auth-owned pure selector:
+
+```ts
+export type MobileFeatureSessionStatus =
+  | { kind: 'usable'; userId: string }
+  | { kind: 'recovering'; userId: string; sessionUsable: boolean }
+  | { kind: 'unavailable' };
+
+export function selectMobileFeatureSessionStatus(
+  state: Readonly<MobileAuthState>,
+): MobileFeatureSessionStatus;
+```
+
+The selector alone understands the auth state machine:
+
+- ordinary verified idle state -> `usable`;
+- refresh/persist/verify operation or retry state for an authenticated user -> `recovering`;
+- restoration, sign-out, cleanup, terminal state, or missing user -> `unavailable` unless the authenticated recovery state explicitly retains a usable prior session.
+
+`useDueReviewCount()` watches this semantic status. A transition from same-user `recovering` to `usable` triggers one refetch. This keeps the dependency one-directional without introducing a feature-specific event API into the coordinator.
+
+### Due-count query and recovery behavior
 
 ```ts
 const DUE_COUNT_RETRY_LIMIT = 2;
@@ -450,7 +523,7 @@ export function retryDueCountQuery(failureCount: number, error: unknown): boolea
 ```ts
 useQuery({
   queryKey: computed(() => srsKeys.stats(userId.value)),
-  enabled: computed(() => sessionUsable.value && userId.value !== null),
+  enabled: computed(() => sessionStatus.value.kind !== 'unavailable'),
   queryFn: ({ signal }) => fetchStatsWithSessionRaceRecovery(signal),
   refetchOnMount: 'always',
   refetchOnWindowFocus: 'always',
@@ -458,30 +531,26 @@ useQuery({
 });
 ```
 
-Only network/server receive two automatic retries. Auth/control-flow, cancellation, authorization, invalid request, and invalid response do not.
-
-### Session-race and pending-recovery query behavior
-
 `fetchStatsWithSessionRaceRecovery()` captures user ID.
 
-For `session_changed` or `session_unavailable`:
+For `session_changed` or a dispatch-time `session_unavailable` race:
 
-- if not aborted, same user remains authenticated, and session is usable, silently retry once;
-- otherwise rethrow for gate/query enablement; and
+- if not aborted, the selector still reports the same user as usable, silently retry once;
+- otherwise rethrow and let query enablement/the gate resolve the state; and
 - never exceed one silent control-flow retry per query execution.
 
-If that retry also fails while Home remains usable, show generic blocking/cached failure with manual Retry. Never leave an empty, settled, invisible-error state.
+If the silent retry repeats while Home remains usable, show a generic manual-recovery error. Never leave an empty, settled, invisible-error state.
 
 For `session_recovery_pending`:
 
 - do not immediately retry;
-- with cache, select normal zero/positive content without a Home-specific error—the auth gate’s retry banner owns the recovery message;
+- with cache, keep normal zero/positive content and let the auth gate/banner own recovery messaging;
 - without cache, show accessible session-recovery loading;
-- watch `sessionUsable`, user ID, `retryAction`, `operation`, and `errorCode`;
-- after successful recovery for the same user (usable, idle, no retry/error), refetch once; and
-- if auth becomes unusable, let the gate replace Home.
+- watch only `MobileFeatureSessionStatus`;
+- after same-user `recovering -> usable`, refetch once; and
+- if status becomes unavailable, let the gate replace Home.
 
-### Native foreground integration
+### Native foreground integration and cache isolation
 
 Extend `capacitor-lifecycle`:
 
@@ -489,21 +558,18 @@ Extend `capacitor-lifecycle`:
 focusManager.setFocused(event.isActive);
 ```
 
-Keep resume diagnostics. No polling/background task.
+Keep existing resume diagnostics. Add no polling or background task.
 
-### Auth and cache isolation
+Install auth/cache isolation once from `App.vue` using the injected coordinator and imported `mobileQueryClient`:
 
-Install once from `App.vue` with injected coordinator and imported `mobileQueryClient`.
+1. Enable authenticated queries only for a usable/recovering identified user as defined above.
+2. Sign-out, terminal cleanup, or identity change cancels in-flight queries.
+3. Await cancellation before cache removal.
+4. Failed durable cleanup still leaves cache cleared.
+5. Soft refresh failure retains cached data while the prior session remains usable.
+6. Backgrounding does not clear.
 
-1. Enable queries only with usable auth/user ID.
-2. Usable-to-unusable stops data selection immediately.
-3. Sign-out, terminal cleanup, or identity change cancels queries.
-4. Remove cache only after cancellation settles.
-5. Failed durable cleanup still leaves cache cleared.
-6. Soft refresh failure retains cache while prior session is usable.
-7. Backgrounding does not clear.
-
-A non-401 may return after generation change; cancellation and canceled-query semantics prevent repopulation after identity loss.
+A non-401 may return after generation promotion; canceled-query semantics and user-scoped keys prevent repopulation after identity loss.
 
 ### Manual retry, view selector, and Home
 
@@ -527,96 +593,90 @@ Rules:
 
 - initial no-data fetch -> loading;
 - no data plus pending auth recovery -> recovery loading;
-- pending auth recovery with cache -> zero/positive, no Home error;
+- pending recovery with cache -> zero/positive, no Home-specific error;
 - zero/positive remains during background fetch;
 - retryable failure without/with cache -> blocking/cached error;
 - `invalid_request` -> generic non-retryable defect;
 - `invalid_response` -> generic manually retryable failure;
-- repeated control-race failure while still usable -> generic manually retryable failure;
-- cancellation -> no visible error;
+- repeated control race while usable -> generic manually retryable failure;
+- caller cancellation -> no visible error; and
 - unauthorized -> gate removes Home.
 
-Home copy/semantics:
+Home copy and semantics:
 
-- loading: “Loading your review count…” (`role=status`, polite live region);
+- loading: “Loading your review count…” with `role="status"` and polite live region;
 - auth recovery: “Refreshing your session…”;
 - zero: prominent `0`, “You’re caught up for now.”;
 - positive: prominent count with singular/plural copy;
 - background refresh: keep count, “Refreshing review count…”;
-- blocking network failure: alert + Retry;
-- cached failure, including cached `0`: keep count, “This count may be out of date.” + Retry;
-- manual retry: preserve error surface and disable/loading Retry;
+- blocking network failure: alert plus Retry;
+- cached failure, including cached `0`: keep count, “This count may be out of date.” plus Retry;
+- manual retry: preserve the error surface and disable/load Retry;
 - invalid request defect: generic alert without misleading Retry;
-- unauthorized: no Home message;
+- unauthorized: no Home-specific message; and
 - no Start Review or scaffold version/environment content.
-
-## Error Handling Summary
-
-- **Non-401 during promotion:** return normally.
-- **Stale 401:** `session_changed`, no cleanup; silent same-user retry once.
-- **Concurrent current 401s:** one recovery decision; each request retries once or returns own final 401.
-- **Transient refresh failure:** `session_recovery_pending`; preserve credential and retry state; settle promptly.
-- **Transport/body timeout:** `network`; caller abort remains cancellation.
-- **Invalid request:** dedicated feature code, stable dev diagnostic, non-retryable UI.
-- **Invalid API payload:** `invalid_response`, not cached, safe generic copy.
-- **Sign-out race:** cancel then clear; late non-401 cannot mutate auth, late 401 cannot clean replacement session.
 
 ## Testing Strategy
 
-### Shared package
+### Shared package and configuration
 
 - Parse complete production response and reject invalid fields.
 - Ignore unknown fields.
-- Distinguish users/JLPT filters in stats key.
-- Confirm package header covers contracts.
-- Document that non-stats SRS keys remain unscoped.
+- Distinguish users and JLPT filters in the stats key.
+- Assert the identity-warning comment remains adjacent to unscoped sibling SRS keys.
+- Confirm `@vela/common` source aliases in mobile Quasar and Vitest config.
+- Run mobile tests from `apps/vela-mobile` without a prebuilt `packages/common/dist`.
+- Confirm the common package header covers domain contracts.
 
-### Auth coordinator
+### Auth coordinator and concurrency
 
 - Apply ID token to allowed path.
-- Share URL builder across session/stats.
-- Reject all path escape classes and `/api-evil/` boundary bypass.
+- Share URL builder across session and stats.
+- Reject all escape classes and `/api-evil/` boundary bypass.
 - Reject every Authorization case variant.
 - Reject without usable session.
-- Caller abort versus attempt timeout are distinguishable.
-- Transport failure does not trigger generation mutation.
-- **In-flight 200 survives soft-refresh promotion.**
-- **In-flight 500 survives soft-refresh promotion.**
-- **In-flight 401 after promotion returns `session_changed` and does not clean new session.**
+- Caller abort and timeout are distinguishable.
+- Raw transport rejection does not trigger generation mutation.
+- In-flight 200 survives soft-refresh promotion.
+- In-flight 500 survives soft-refresh promotion.
+- In-flight 401 after promotion returns `session_changed` without cleaning the new session.
+- `queueRefresh()` no-op while app inactive yields `retryable_failure`, not `refreshed`.
+- Pending-candidate no-op yields `retryable_failure`.
+- Verified same-user generation advance yields `promoted`.
+- Sign-out or identity replacement while waiting yields `superseded`.
+- Invalid grant/terminal cleanup yields `terminal`.
 - Join an already-running refresh.
 - Concurrent expired-token 401s start one refresh and each retry at most once.
 - Concurrent valid-token 401s perform one cleanup.
 - One caller abort does not cancel peer recovery.
-- Transient shared refresh failure settles all waiters as `session_recovery_pending` without cleanup.
-- Terminal result returns each final 401.
-- Keep 403 feature-scoped and secrets out of errors/logs.
+- A pending feature fetch does not block auth operations through `operationTail`.
+- 401 recovery cannot self-deadlock behind the feature request.
+- Keep 403 feature-scoped and secrets out of logs/errors.
 
-### Mobile API/SRS services
+### API/SRS service and latency
 
-- Map every coordinator code, including `invalid_request` and timeout.
-- Transport stall -> network.
-- Body stall -> network.
+- Map every coordinator code.
+- Raw fetch `TypeError` -> `network`.
+- Feature deadline without auth recovery -> `network`.
+- Feature deadline during shared auth recovery -> `session_recovery_pending`.
 - Caller abort -> cancellation.
 - Timer/listener cleanup.
-- Body timeout does not cancel peer auth recovery.
-- Parse/validate JSON and classify HTTP/errors.
-- Forward exact path/signal.
+- Deadline does not cancel peer auth recovery.
+- Parse/validate JSON and classify HTTP errors.
+- Forward exact path and signal.
+- Verify three failed network attempts plus retry delays remain within the documented approximately 27-second bound under fake timers.
 - Provision without cross-boot injection.
 
-### Query/recovery/retry
+### Query, lifecycle, cache, and UI
 
 - QueryClient singleton/plugin identity and boot order.
 - Exact two-retry network/server predicate; all other codes false.
-- First same-user `session_changed` silently retries once.
-- Repeated control race produces visible manual recovery, never blank UI.
-- Recoverable `session_unavailable` retries once.
-- Pending recovery with cache retains count and uses auth banner.
+- First same-user session race silently retries once.
+- Repeated race produces visible manual recovery, never blank UI.
+- Pending recovery with cache retains count.
 - Pending recovery without cache shows recovery loading.
-- Successful later auth retry refetches once.
-- Unusable auth removes Home.
-
-### Lifecycle/cache/UI
-
+- Same-user `recovering -> usable` refetches once.
+- Composable does not inspect raw auth operation/retry/error fields.
 - Native focus updates and enabled-only refetch.
 - Sign-out/terminal cleanup cancel before clear.
 - Soft refresh failure retains usable cache.
@@ -624,7 +684,7 @@ Home copy/semantics:
 - Manual/background flags are distinct.
 - All loading, zero, positive, error, retry, stale, recovery, and defect states are accessible.
 - Cached positive and zero both show stale warning after failed refetch.
-- No Start Review/scaffold content.
+- No Start Review or scaffold content.
 
 ## Manual Verification Matrix and Gates
 
@@ -633,11 +693,11 @@ Home copy/semantics:
 | Fresh sign-in | Home fetches authenticated count |
 | Relaunch restoration | Restores without another Google prompt |
 | Positive/zero | Mobile agrees with web/API and renders correct copy |
-| Network failure/retry | Safe retryable failure then successful Retry |
+| Network failure/retry | Blocking failure appears within the documented bound; Retry succeeds after restoration |
 | Background/resume | Active transition refetches |
-| Soft auth-refresh failure | Cached count remains if session usable; auth recovery can refetch |
+| Soft auth-refresh failure | Cached count remains if usable; later auth recovery refetches |
 | Rejected token | Home disappears and authentication is shown |
-| Sign-out/account isolation | Data clears immediately; later account never sees it |
+| Sign-out/account isolation | Data clears immediately; a later account never sees it |
 | iOS Simulator | Complete flow passes before implementation PR merge |
 | Physical iPhone | Complete flow passes before HPA-207 closes |
 
@@ -645,7 +705,7 @@ Automated checks and Simulator flow are merge gates. Physical-device evidence is
 
 ## Expected File Boundaries
 
-### Shared
+### Shared and repository documentation
 
 - Create: `packages/common/src/contracts/srs.ts`
 - Create: `packages/common/src/contracts/srs.test.ts`
@@ -654,11 +714,14 @@ Automated checks and Simulator flow are merge gates. Physical-device evidence is
 - Modify: `packages/common/src/index.ts`
 - Modify: `apps/vela/src/services/srsService.ts`
 - Modify: `apps/vela/src/services/srsService.test.ts`
+- Modify: `CLAUDE.md`
 
-### Mobile boot/dependencies
+### Mobile dependencies, configuration, and boot
 
 - Modify: `apps/vela-mobile/package.json`
 - Modify: `bun.lock`
+- Modify: `apps/vela-mobile/quasar.config.ts`
+- Modify: `apps/vela-mobile/vitest.config.ts`
 - Create: `apps/vela-mobile/src/boot/query.ts`
 - Create: `apps/vela-mobile/src/boot/query.test.ts`
 - Modify: `apps/vela-mobile/src/boot/boot-files.ts`
@@ -668,9 +731,11 @@ Automated checks and Simulator flow are merge gates. Physical-device evidence is
 - Modify: `apps/vela-mobile/src/boot/mobile-auth.ts`
 - Modify: `apps/vela-mobile/src/boot/mobile-auth.test.ts`
 
-### Auth/services
+### Auth and services
 
 - Modify: `apps/vela-mobile/src/auth/mobile-auth-contract.ts`
+- Create: `apps/vela-mobile/src/auth/mobile-feature-session-status.ts`
+- Create: `apps/vela-mobile/src/auth/mobile-feature-session-status.test.ts`
 - Modify: `apps/vela-mobile/src/services/mobile-auth.ts`
 - Modify: `apps/vela-mobile/src/services/mobile-auth.test.ts`
 - Modify: `apps/vela-mobile/src/test/secret-leak-helpers.ts`
@@ -681,7 +746,7 @@ Automated checks and Simulator flow are merge gates. Physical-device evidence is
 - Create: `apps/vela-mobile/src/services/mobile-services.ts`
 - Create: `apps/vela-mobile/src/services/mobile-services.test.ts`
 
-### Query/presentation
+### Query and presentation
 
 - Create: `apps/vela-mobile/src/services/mobile-query-auth-isolation.ts`
 - Create: `apps/vela-mobile/src/services/mobile-query-auth-isolation.test.ts`
@@ -698,35 +763,39 @@ Automated checks and Simulator flow are merge gates. Physical-device evidence is
 
 | Criterion | Coverage |
 | --- | --- |
-| Restored user reaches Home | HPA-206 gate + enabled query |
-| Home displays stats count | Mobile SRS service + selector |
-| Rejected/expired token cannot leak another user’s data | 401-only generation guard, shared recovery, user key, cancellation, cache clear |
+| Restored user reaches Home | HPA-206 gate plus enabled query |
+| Home displays stats count | Mobile SRS service plus selector |
+| Rejected/expired token cannot leak another user’s data | 401-only generation guard, explicit recovery outcome, user key, cancellation, cache clear |
 | Accessible loading/empty/failure/retry | Exhaustive view including auth recovery and manual retry |
-| Sign-out clears user data | Cancel then clear |
+| Signing out clears user data | Cancel then clear |
 | Count agrees with web/API | Manual matrix |
-| Tests cover states/isolation | Concurrency, timeout, service, query, cache, UI suites |
-| Simulator/device verification | Merge gate + closure gate |
+| Tests cover states/isolation | Concurrency, no-op refresh, timeout, service, query, cache, and UI suites |
+| Simulator/device verification | Merge gate plus closure gate |
 
 ## Risks and Mitigations
 
+- **Refresh promise resolves without promotion:** derive the result from owner/generation/state postconditions.
+- **Feature request blocks or deadlocks auth:** keep feature I/O outside `operationTail`; serialize mutations only.
 - **Successful response discarded during refresh:** return non-401 before generation comparison.
-- **Duplicate refresh/cleanup:** one recovery promise per owner/generation.
-- **Hanging feature request/body:** bounded transport attempts, bounded body read, bounded existing auth operations.
-- **Transient refresh deletes credential:** settle as pending recovery; retain HPA-206 state/credential.
+- **Duplicate refresh/cleanup:** one recovery record per owner/generation.
+- **Long invisible loading:** eight-second execution budgets and an approximately 27-second total retry bound.
+- **Transient refresh deletes credential:** settle as pending recovery and retain HPA-206 state.
+- **Stale common build in per-app workflow:** alias mobile build/tests to current common source.
+- **Auth state machine leaks into feature code:** expose a stable auth-owned session-capability selector.
 - **Previous-user cache flash:** user key, disable, cancel then clear.
 - **Token/path leakage:** coordinator-owned bearer, header rejection, parsed path boundaries, secret-leak tests.
-- **Scope expansion:** count/status only; review execution later.
+- **Scope expansion:** count and status only; review execution later.
 
 ## Implementation Sequence
 
-1. Shared contract, package description, and user-scoped stats key.
-2. URL/header boundary and bounded feature transport.
-3. Non-401 ordering plus single-flight current-401 recovery.
-4. API body timeout/error normalization and SRS service provisioning.
-5. QueryClient boot, retry predicate, and native focus bridge.
-6. Cache isolation and pending-auth-recovery refetch.
-7. Composable control-race/manual-retry behavior and pure selector.
-8. Home presentation/accessibility.
+1. Shared contract, package description, stats key, sibling-key warning, and stale repository documentation.
+2. Mobile common-source aliases and QueryClient dependency/bootstrap.
+3. URL/header boundary and feature transport outside `operationTail`.
+4. Explicit refresh observation, non-401 ordering, and single-flight current-401 recovery.
+5. API execution deadline, raw transport classification, body parsing, and SRS provisioning.
+6. Stable feature-session selector, retry policy, native focus, and cache isolation.
+7. Composable control-race, pending-recovery, and manual-retry behavior.
+8. Pure view selector and Home accessibility states.
 9. Simulator merge-gate and physical-device closure evidence.
 
-Each stage must leave existing web authentication, web SRS loading, mobile OAuth restoration, and sign-out behavior unchanged except for the shared contract, package description, and stats-key signature.
+Each stage must leave existing web authentication, web SRS loading, mobile OAuth restoration, and sign-out behavior unchanged except for the shared contract, package description, stats-key signature, and corrected repository documentation.

--- a/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
+++ b/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
@@ -459,8 +459,9 @@ diagnostic-cold-entry (development only)
 
 The wiring mechanisms are intentionally distinct:
 
-- `mobileQueryClient` is a module singleton imported by lifecycle/auth-isolation infrastructure.
+- `mobileQueryClient` is a module singleton imported by auth-isolation infrastructure.
 - `VueQueryPlugin` provides that same instance to TanStack Query composables.
+- `capacitor-lifecycle` imports TanStack Query's `focusManager` directly and does not import the QueryClient singleton.
 - `MobileAuthCoordinator` and `MobileSrsService` use typed Vue application injection.
 - `mobile-auth` boot passes the coordinator directly to `provideMobileServices()`; no boot file tries to recover another boot file's provided value through component injection.
 - `App.vue` injects the coordinator and imports `mobileQueryClient` to install auth/cache isolation once.
@@ -855,7 +856,7 @@ Track `manualRetryPending` independently and retain the preceding error surface 
 
 ### Wiring relies on an unavailable cross-boot injection
 
-Pass the coordinator directly into service provisioning, import the QueryClient singleton only where infrastructure needs it, and reserve Vue injection for component/composable consumers.
+Pass the coordinator directly into service provisioning, import the QueryClient singleton only where auth-isolation needs it, drive native focus through `focusManager`, and reserve Vue injection for component/composable consumers.
 
 ### Native lifecycle does not produce browser focus events
 

--- a/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
+++ b/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
@@ -1,0 +1,734 @@
+# HPA-207: Authenticated Mobile Due-Review Count Vertical Slice
+
+**Date:** 2026-07-30
+
+**Linear:** [HPA-207](https://linear.app/cwchanap/issue/HPA-207/mobile-mvpm1-deliver-the-authenticated-due-review-count-vertical-slice)
+
+**Parent:** HPA-194 — Mobile MVP M1
+
+## Goal
+
+Deliver the smallest production-shaped Vela Mobile product flow: a returning iOS user restores a secure Cognito session, reaches Home, and sees the current authenticated `due_today` value returned by `GET /api/srs/stats`.
+
+This slice establishes the reusable mobile boundaries for authenticated feature requests and user-scoped server-state caching without importing the web Home page or exposing Cognito tokens to feature components.
+
+## Current State
+
+HPA-204 established the native API environment contract, absolute mobile API base URL, and approved Capacitor CORS behavior.
+
+HPA-206 established the single mobile Cognito session owner. The mobile auth coordinator now:
+
+- restores a Keychain-backed refresh credential during app initialization;
+- keeps ID and access tokens in process memory only;
+- refreshes the active token bundle proactively and when the app resumes;
+- verifies candidate sessions through `/api/auth/session` before exposing protected content;
+- marks protected content usable only while a verified active bundle remains valid; and
+- clears local session material during sign-out or terminal credential failure.
+
+HPA-206 intentionally did not expose a general token accessor or authenticated feature client. Its only authenticated API call is the coordinator-owned `/api/auth/session` verification request. HPA-207 introduces that feature-request boundary.
+
+The API already exposes `GET /api/srs/stats`. It applies the shared Cognito ID-token middleware and returns:
+
+```ts
+interface SRSStats {
+  total_items: number;
+  due_today: number;
+  mastery_breakdown: {
+    new: number;
+    learning: number;
+    reviewing: number;
+    mastered: number;
+  };
+  average_ease_factor: number;
+  total_reviews: number;
+  accuracy_rate: number;
+}
+```
+
+The web application owns an equivalent TypeScript interface and a web-specific SRS service. `@vela/common` already owns the shared `srsKeys` query-key factory, but its stats key is not currently scoped by authenticated user.
+
+The mobile Home route currently renders only the M1 scaffold identity and version. The mobile app does not yet install TanStack Query.
+
+## Approved Decisions
+
+| Area | Decision |
+| --- | --- |
+| Product scope | Display only the authenticated due-review count and its required states |
+| Backend | Reuse the existing `GET /api/srs/stats` endpoint unchanged |
+| Shared contract | Move the complete `SRSStats` response contract into `@vela/common` |
+| Contract validation | Parse the complete stats payload at the mobile service boundary before caching it |
+| Token ownership | ID tokens remain private to the mobile auth coordinator |
+| Feature request surface | Add a coordinator-owned authenticated API request operation; do not add `getIdToken()` |
+| URL safety | Authenticated requests accept only paths beneath the configured Vela API base URL |
+| Unauthorized response | A current-session 401 enters auth recovery or terminal cleanup; Home never renders an unauthorized data error |
+| Expiry race | If the request token expires in flight, refresh and retry once before treating the session as unusable |
+| Stale request race | A response from an older auth generation cannot invalidate a replacement session |
+| Server state | Install TanStack Query in the mobile application |
+| Query key | Include the authenticated user ID in the stats key |
+| Foreground refresh | Bridge native app active state to TanStack Query focus state |
+| Home re-entry refresh | Refetch whenever Home mounts, even if cached data is still fresh |
+| Cache isolation | Disable queries immediately when the session is unusable, user-scope every key, and clear mobile query state on sign-out or identity loss |
+| Cached refetch failure | Keep the last verified count visible with a non-blocking retry message |
+| Review navigation | Do not add a Start Review action in HPA-207 |
+| Platform | Native iOS remains the supported authenticated runtime for this milestone |
+
+## Scope
+
+HPA-207 includes:
+
+- a shared SRS statistics contract;
+- a user-scoped SRS stats query key;
+- a coordinator-owned authenticated mobile request capability;
+- a mobile JSON API client with normalized failures;
+- a mobile SRS stats service;
+- TanStack Query bootstrap for Vela Mobile;
+- native foreground-to-query-focus integration;
+- authenticated query lifecycle and cache cleanup;
+- a minimal mobile Home due-count presentation;
+- unit and component coverage for service, query, auth isolation, and view states; and
+- Simulator and physical-device verification evidence.
+
+## Non-goals
+
+- starting, resuming, or completing a review session;
+- fetching individual due cards;
+- dashboard parity with the web application;
+- daily goals, streaks, mastery summaries, or learning shortcuts;
+- persistent offline query storage;
+- offline due-deck generation;
+- connectivity monitoring through a new native plugin;
+- background polling;
+- Android support;
+- remote Cognito global sign-out;
+- refactoring the web page into a shared presentation component; and
+- final mobile navigation or visual polish.
+
+## Architecture
+
+### End-to-end flow
+
+```text
+MobileAuthCoordinator restores and verifies session
+                    |
+                    v
+MobileAuthGate exposes authenticated routes
+                    |
+                    v
+HomePage mounts useDueReviewCount()
+                    |
+                    v
+TanStack Query uses srsKeys.stats(userId)
+                    |
+                    v
+Mobile SRS service requests "srs/stats"
+                    |
+                    v
+Mobile API client asks coordinator to send authenticated request
+                    |
+                    v
+Coordinator attaches current in-memory Cognito ID token
+                    |
+                    v
+GET {VITE_MOBILE_API_URL}srs/stats
+```
+
+The reverse auth-failure path is:
+
+```text
+Current authenticated request returns 401
+                    |
+                    v
+Coordinator validates request generation and token expiry
+                    |
+          +---------+---------+
+          |                   |
+  Token expired in flight   Still-valid token rejected
+          |                   |
+Refresh and retry once      Terminal session cleanup
+          |                   |
+          +---------+---------+
+                    |
+                    v
+sessionUsable becomes false if recovery cannot continue
+                    |
+                    v
+MobileAuthGate hides Home and query cache is cleared
+```
+
+### One token owner
+
+`apps/vela-mobile/src/services/mobile-auth.ts` remains the only owner of active Cognito token material.
+
+The public coordinator contract gains a request operation rather than a token accessor:
+
+```ts
+export type MobileAuthenticatedApiRequest = {
+  path: string;
+  init?: Omit<RequestInit, 'headers'> & {
+    headers?: Record<string, string>;
+  };
+};
+
+export type MobileAuthCoordinator = {
+  state: Readonly<MobileAuthState>;
+  initialize(): Promise<void>;
+  startSignIn(): Promise<void>;
+  completeCallback(url: string): Promise<void>;
+  retryCurrentOperation(): Promise<void>;
+  requestAuthenticatedApi(request: MobileAuthenticatedApiRequest): Promise<Response>;
+  signOut(): Promise<void>;
+  dispose(): Promise<void>;
+};
+```
+
+Feature code never receives an ID token. The coordinator constructs the final request, applies `Authorization: Bearer <id-token>`, and performs the fetch through its injected transport.
+
+The request method rejects without network activity unless all of these are true:
+
+- the coordinator is initialized and not disposing;
+- `state.phase === 'authenticated'`;
+- `state.sessionUsable === true`;
+- an active verified bundle exists;
+- an authenticated user exists; and
+- the request path resolves beneath the configured API base URL.
+
+Callers cannot override `Authorization`. The coordinator owns that header even when other headers are supplied.
+
+### URL containment
+
+The mobile API base URL is expected to end at the Vela API prefix, for example `https://vela.example/api/`.
+
+`requestAuthenticatedApi()` accepts a relative feature path such as `srs/stats`. It rejects:
+
+- absolute URLs;
+- scheme-relative URLs;
+- paths beginning with `/` that could escape the configured `/api/` prefix;
+- `.` or `..` path segments; and
+- any URL whose resolved origin or base-path prefix differs from `config.api.url`.
+
+This validation prevents a future feature service from accidentally sending an ID token to an unrelated host or to a non-API route on the same host.
+
+### Auth generation and 401 handling
+
+Every request captures the active session owner and `activeBundleGeneration` before dispatch.
+
+When the response arrives:
+
+1. If the coordinator has been disposed, the request is treated as cancelled.
+2. If the active owner or generation changed, the response belongs to a stale session. It is rejected without mutating current auth state.
+3. Any non-401 response is returned to the feature client.
+4. For a current-generation 401, the coordinator rechecks token expiry.
+5. If the captured ID token expired while the request was in flight, the coordinator queues the existing refresh path and retries the feature request once after successful verified promotion.
+6. If the token was still valid when rejected, or the single retry also returns 401, the coordinator performs terminal session cleanup.
+7. If refresh fails transiently, existing HPA-206 retry state is retained; protected content remains available only while an older verified token is still usable.
+8. If refresh proves the durable credential unusable, the existing terminal cleanup path returns the user to authentication.
+
+The request method does not treat 403 as proof that the Cognito credential is invalid. A 403 remains an API authorization failure handled by the mobile API client.
+
+### Shared SRS contract
+
+Create `packages/common/src/contracts/srs.ts` and export:
+
+```ts
+export interface SRSStats {
+  total_items: number;
+  due_today: number;
+  mastery_breakdown: {
+    new: number;
+    learning: number;
+    reviewing: number;
+    mastered: number;
+  };
+  average_ease_factor: number;
+  total_reviews: number;
+  accuracy_rate: number;
+}
+
+export function parseSrsStats(value: unknown): SRSStats;
+```
+
+The parser enforces:
+
+- all count fields are non-negative integers;
+- `average_ease_factor` is a finite non-negative number;
+- `accuracy_rate` is a finite number from 0 through 100; and
+- no required nested field is missing.
+
+Unknown additional fields are ignored so the API can add backward-compatible metadata later.
+
+The web SRS service imports and re-exports `SRSStats` from `@vela/common`, preserving the current service API while removing its duplicate contract.
+
+### User-scoped query key
+
+Change the shared stats key to:
+
+```ts
+srsKeys.stats(userId: string | null, jlpt?: number[])
+```
+
+It produces:
+
+```ts
+['srs', 'stats', userId, jlpt]
+```
+
+HPA-207 calls it with the authenticated `MobileAuthUser.userId` and no JLPT filter.
+
+The explicit user ID ensures that cached data for one identity cannot be selected by a component rendering another identity. This remains required even though sign-out also clears the cache: key isolation is the correctness boundary, while clearing is memory and defense-in-depth cleanup.
+
+### Mobile API client
+
+Create a Vela-owned client in `apps/vela-mobile/src/services/mobile-api-client.ts`.
+
+Its responsibilities are:
+
+- accept a relative API path and request options;
+- delegate authenticated transport to the coordinator;
+- request JSON through an explicit `Accept: application/json` header;
+- parse successful JSON bodies;
+- preserve the TanStack Query abort signal;
+- classify failures without UI copy; and
+- avoid logging request headers, token-bearing objects, or raw identity responses.
+
+Use a stable error union:
+
+```ts
+export type MobileApiErrorCode =
+  | 'session_unavailable'
+  | 'session_changed'
+  | 'unauthorized'
+  | 'forbidden'
+  | 'network'
+  | 'server'
+  | 'invalid_response';
+```
+
+`unauthorized` is observable for unit tests and non-visual control flow, but Home does not render it. The coordinator auth transition disables the query and the gate replaces Home.
+
+HTTP behavior:
+
+| Outcome | Client classification |
+| --- | --- |
+| Request aborted | Preserve abort semantics; do not show an error |
+| No usable session before dispatch | `session_unavailable` |
+| Session generation changes during request | `session_changed` |
+| Final 401 after coordinator recovery rules | `unauthorized` |
+| 403 | `forbidden` |
+| Fetch rejects without caller abort | `network` |
+| 5xx | `server` |
+| Other non-2xx | `server` for this read-only slice |
+| Invalid JSON or invalid stats shape | `invalid_response` |
+
+### Mobile SRS service
+
+Create `apps/vela-mobile/src/services/mobile-srs.ts`:
+
+```ts
+export type MobileSrsService = {
+  getStats(options?: { signal?: AbortSignal }): Promise<SRSStats>;
+};
+```
+
+`getStats()` calls `srs/stats`, forwards the abort signal, and runs `parseSrsStats()` before returning. No page component builds URLs, headers, or response shapes.
+
+The service is created from the authenticated API client during mobile boot and provided through a typed Vue injection key. Tests can provide a deterministic fake service without mocking global fetch.
+
+### TanStack Query bootstrap
+
+Add workspace dependencies on `@vela/common` and `@tanstack/vue-query` to `@vela/mobile`.
+
+Create `apps/vela-mobile/src/boot/query.ts` to:
+
+- create a mobile QueryClient through the existing `createQueryClient()` factory;
+- install `VueQueryPlugin`; and
+- export the mobile query client for lifecycle and auth-isolation wiring.
+
+Add `query` before `mobile-auth` in `getMobileBootFiles()` so application components and later boot files can rely on the plugin.
+
+The due-count query overrides only the behavior specific to this product slice:
+
+```ts
+useQuery({
+  queryKey: computed(() => srsKeys.stats(userId.value)),
+  enabled: computed(() => sessionUsable.value && userId.value !== null),
+  queryFn: ({ signal }) => srsService.getStats({ signal }),
+  refetchOnMount: 'always',
+  refetchOnWindowFocus: 'always',
+  retry: retryDueCountQuery,
+});
+```
+
+The shared five-minute stale and ten-minute garbage-collection defaults remain. `always` is intentional: the issue requires refresh on Home activation and foreground resume, even when the last result is younger than the shared stale window.
+
+`retryDueCountQuery` retries network and server failures up to the shared query retry limit. It does not retry:
+
+- `session_unavailable`;
+- `session_changed`;
+- `unauthorized`;
+- `forbidden`;
+- `invalid_response`; or
+- caller cancellation.
+
+### Native foreground integration
+
+The existing Capacitor lifecycle boot remains the single product-level bridge for native application activation.
+
+Extend it to subscribe to `appStateChange` and call:
+
+```ts
+focusManager.setFocused(event.isActive);
+```
+
+The existing resume diagnostics behavior remains available. The lifecycle adapter and tests cover both inactive and active transitions.
+
+TanStack Query then refetches the active due-count query when iOS returns Vela to the foreground. No polling or background task is added.
+
+### Auth and cache isolation
+
+Create `apps/vela-mobile/src/services/mobile-query-auth-isolation.ts` and install it once from `App.vue` after both the auth coordinator and QueryClient are available.
+
+It watches the public auth tuple, especially:
+
+- `state.sessionUsable`;
+- `state.user?.userId`;
+- `state.operation`; and
+- `state.phase`.
+
+Its rules are:
+
+1. Queries are enabled only while a usable session and user ID are present.
+2. A transition from usable to unusable immediately makes Home stop selecting authenticated query data.
+3. When sign-out starts, terminal cleanup starts, or identity changes, cancel all in-flight mobile queries.
+4. Clear the mobile QueryClient after cancellation.
+5. Never retain previous-user data for a later sign-in, including when durable sign-out cleanup fails.
+6. Do not clear the cache during a soft in-session refresh failure while `sessionUsable` remains true.
+7. Do not clear on ordinary backgrounding.
+
+Clearing the complete mobile QueryClient is acceptable in M1 because every current mobile server-state query is authenticated and user-specific. Later public or durable server-state slices can narrow the cleanup filters if necessary.
+
+### Due-count composable
+
+Create `apps/vela-mobile/src/composables/useDueReviewCount.ts`.
+
+It injects the coordinator and mobile SRS service, derives the current user ID, and owns the TanStack query configuration. It returns query state and an explicit `retry()` action to the page.
+
+The composable does not contain display copy and does not navigate. Unauthorized navigation remains the responsibility of `MobileAuthGate` through coordinator state.
+
+### Home view model
+
+Create a pure selector in `apps/vela-mobile/src/components/home/due-review-view.ts`.
+
+It converts query state into an exhaustive presentation union:
+
+```ts
+type DueReviewView =
+  | { kind: 'loading' }
+  | { kind: 'zero'; refreshing: boolean }
+  | { kind: 'positive'; count: number; refreshing: boolean }
+  | { kind: 'blocking_error'; message: string; retrying: boolean }
+  | { kind: 'cached_error'; count: number; message: string; retrying: boolean };
+```
+
+The selector never receives or returns `unauthorized`; those states remove the authenticated content surface.
+
+View rules:
+
+- no data plus pending fetch produces `loading`;
+- `due_today === 0` produces `zero`;
+- `due_today > 0` produces `positive`;
+- a background refetch retains zero or positive content with `refreshing: true`;
+- a retryable failure with no data produces `blocking_error`;
+- a retryable refetch failure with cached data produces `cached_error`;
+- invalid-response and forbidden failures use a generic safe failure message and remain manually retryable only when the query policy permits a manual request; and
+- abort and session-change outcomes do not produce visible failures.
+
+### Home presentation
+
+Replace the M1 scaffold content in `HomePage.vue` with a focused “Today’s review” surface.
+
+Required states:
+
+#### Initial loading
+
+- Show a spinner or skeleton.
+- Use `role="status"` and `aria-live="polite"`.
+- Copy: “Loading your review count…”
+
+#### Zero due
+
+- Display `0` prominently.
+- Copy: “You’re caught up for now.”
+- Do not show a disabled or misleading review action.
+
+#### Positive due
+
+- Display the integer prominently.
+- Use singular copy for one item and plural copy for all other counts.
+- Example: “1 word is due for review” / “12 words are due for review.”
+
+#### Background refresh
+
+- Keep the last verified count visible.
+- Add a subtle `role="status"` indication: “Refreshing review count…”
+- Do not replace verified content with a blocking spinner.
+
+#### Blocking failure
+
+- Use `role="alert"` for the message.
+- Network copy: “Vela couldn’t load your review count. Check your connection and try again.”
+- Other safe copy: “Vela couldn’t load your review count. Please try again.”
+- Show a Retry button.
+
+#### Cached refresh failure
+
+- Keep the last verified count visible.
+- Show a non-blocking alert: “This count may be out of date.”
+- Show Retry.
+
+#### Retrying
+
+- Disable the Retry button.
+- Set its loading state and accessible label to “Retrying review count.”
+
+#### Unauthorized
+
+- Render no Home-specific unauthorized message.
+- The coordinator makes the session unusable and `MobileAuthGate` returns the user to authentication.
+
+The page does not expose app version, environment, or scaffold labels after this change. Development diagnostics remain accessible from More.
+
+## Error Handling
+
+### Network and server failures
+
+Network and 5xx failures do not mutate authentication state. They remain query errors and support manual retry. A cached value remains visible during a failed refetch.
+
+### Invalid API shape
+
+An invalid stats payload is never cached. It becomes `invalid_response`, shows safe generic copy, and emits no raw response body to logs.
+
+### Unauthorized session
+
+A final current-generation 401 is an auth concern, not a Home concern. The coordinator owns recovery and cleanup, the query becomes disabled, the cache is cleared, and the gate removes protected content.
+
+### Sign-out during request
+
+Sign-out increments the auth generation, marks the session unusable before cleanup, cancels query work, and clears cache state. A late response from the prior generation cannot repopulate or invalidate the current session.
+
+### Identity replacement
+
+Although multi-account switching is outside the MVP, a later sign-in after sign-out receives a different user-scoped key. It cannot select previous-user data even if asynchronous cache cleanup has not completed.
+
+## Testing Strategy
+
+### Shared package tests
+
+Cover:
+
+- parsing a complete production-shaped stats response;
+- rejecting missing `due_today`;
+- rejecting negative and fractional count fields;
+- rejecting non-finite metrics;
+- rejecting accuracy outside 0–100;
+- ignoring unknown additional fields;
+- producing distinct stats keys for distinct users; and
+- preserving JLPT filter identity in the key.
+
+### Auth coordinator tests
+
+Cover:
+
+- adding the current ID token to an allowed relative API request;
+- preventing callers from overriding `Authorization`;
+- rejecting absolute, scheme-relative, root-relative, traversal, and outside-prefix paths;
+- rejecting requests without a usable session;
+- preserving caller abort behavior;
+- returning non-401 responses without auth mutation;
+- refreshing and retrying once when a request token expires in flight;
+- terminal cleanup after a still-valid current token is rejected;
+- terminal cleanup after a refreshed retry is rejected;
+- retaining current auth state when an old-generation request returns 401;
+- not treating 403 as terminal Cognito failure;
+- sign-out racing an in-flight request; and
+- token and header values not appearing in logs or rendered errors.
+
+### Mobile API and SRS service tests
+
+Cover:
+
+- successful JSON parsing;
+- full stats contract validation;
+- network classification;
+- 403, 5xx, and invalid-response classification;
+- caller cancellation;
+- signal forwarding; and
+- exact request path `srs/stats`.
+
+### Query bootstrap and lifecycle tests
+
+Cover:
+
+- mobile QueryClient installation;
+- boot-file ordering;
+- `focusManager` receiving inactive and active native states;
+- active transition refetching an enabled due-count query;
+- no foreground refetch when signed out; and
+- existing lifecycle diagnostics remaining intact.
+
+### Cache isolation tests
+
+Cover:
+
+- no query while authentication is restoring;
+- one initial query after restored authentication becomes usable;
+- query key includes the restored user ID;
+- sign-out cancels in-flight work and clears cached stats;
+- terminal auth cleanup clears cached stats;
+- soft refresh failure with a still-usable session retains cache;
+- identity change cannot select previous-user data; and
+- failed durable sign-out cleanup still hides and clears due-count data.
+
+### Home component tests
+
+Cover:
+
+- loading copy and live-region semantics;
+- zero-due state;
+- singular positive copy;
+- plural positive copy;
+- blocking network failure;
+- manual retry;
+- disabled/loading retry state;
+- background refreshing with visible cached count;
+- failed background refresh with visible cached count and alert;
+- no Start Review action; and
+- no scaffold version/environment content.
+
+## Manual Verification Matrix
+
+Record the account, build/environment, device, timestamp, API or web comparison value, and result for every row.
+
+| Scenario | Expected result |
+| --- | --- |
+| Fresh sign-in | Successful Google sign-in opens Home and fetches the authenticated count |
+| Relaunch restoration | Force-close and reopen restores the user without another Google prompt and loads Home |
+| Positive due count | Mobile count matches web/API for the same account at the recorded verification time |
+| Zero due count | Home displays `0` and the caught-up message |
+| Network failure | Home remains authenticated and shows a retryable failure without exposing stale foreign data |
+| Retry | Restoring connectivity and tapping Retry loads the count |
+| Background and resume | Returning Vela to active state refetches the count |
+| Rejected token | Protected Home content disappears and the user returns safely to authentication |
+| Sign-out | Home data is removed immediately; relaunch remains signed out |
+| Account isolation | A later sign-in cannot display the prior account’s cached count |
+| iOS Simulator | Complete product flow passes in a configured Simulator build |
+| Physical development iPhone | Complete product flow passes on a configured development device |
+
+## Expected File Boundaries
+
+### Shared contract and key
+
+- Create: `packages/common/src/contracts/srs.ts`
+- Create: `packages/common/src/contracts/srs.test.ts`
+- Modify: `packages/common/src/keys.ts`
+- Modify: `packages/common/src/keys.test.ts`
+- Modify: `packages/common/src/index.ts`
+- Modify: `apps/vela/src/services/srsService.ts`
+- Modify: `apps/vela/src/services/srsService.test.ts`
+
+### Mobile dependencies and boot
+
+- Modify: `apps/vela-mobile/package.json`
+- Modify: `bun.lock`
+- Create: `apps/vela-mobile/src/boot/query.ts`
+- Create: `apps/vela-mobile/src/boot/query.test.ts`
+- Modify: `apps/vela-mobile/src/boot/boot-files.ts`
+- Modify: `apps/vela-mobile/src/boot/boot-files.test.ts`
+- Modify: `apps/vela-mobile/src/boot/capacitor-lifecycle.ts`
+- Modify: `apps/vela-mobile/src/boot/capacitor-lifecycle.test.ts`
+
+### Authenticated request boundary
+
+- Modify: `apps/vela-mobile/src/auth/mobile-auth-contract.ts`
+- Modify: `apps/vela-mobile/src/services/mobile-auth.ts`
+- Modify: `apps/vela-mobile/src/services/mobile-auth.test.ts`
+- Modify: `apps/vela-mobile/src/test/secret-leak-helpers.ts`
+
+### Mobile server-state services
+
+- Create: `apps/vela-mobile/src/services/mobile-api-client.ts`
+- Create: `apps/vela-mobile/src/services/mobile-api-client.test.ts`
+- Create: `apps/vela-mobile/src/services/mobile-srs.ts`
+- Create: `apps/vela-mobile/src/services/mobile-srs.test.ts`
+- Create: `apps/vela-mobile/src/boot/mobile-services.ts`
+- Create: `apps/vela-mobile/src/boot/mobile-services.test.ts`
+
+### Query and presentation
+
+- Create: `apps/vela-mobile/src/services/mobile-query-auth-isolation.ts`
+- Create: `apps/vela-mobile/src/services/mobile-query-auth-isolation.test.ts`
+- Modify: `apps/vela-mobile/src/App.vue`
+- Modify: `apps/vela-mobile/src/App.test.ts`
+- Create: `apps/vela-mobile/src/composables/useDueReviewCount.ts`
+- Create: `apps/vela-mobile/src/composables/useDueReviewCount.test.ts`
+- Create: `apps/vela-mobile/src/components/home/due-review-view.ts`
+- Create: `apps/vela-mobile/src/components/home/due-review-view.test.ts`
+- Modify: `apps/vela-mobile/src/pages/HomePage.vue`
+- Modify: `apps/vela-mobile/src/pages/HomePage.test.ts`
+
+## Acceptance-Criteria Mapping
+
+| Acceptance criterion | Design coverage |
+| --- | --- |
+| Returning user reaches Home through restored authentication | Existing HPA-206 gate plus enabled query after `sessionUsable` |
+| Home displays `/api/srs/stats` due count | Mobile SRS service and Home view model |
+| Expired or rejected token cannot expose another user’s data | Generation-aware auth recovery, user-scoped key, disabled query, and cache cleanup |
+| Loading, empty, failure, and retry states are understandable and accessible | Exhaustive Home presentation union and accessibility requirements |
+| Signing out clears user-specific due-count data | Auth-isolation service cancels and clears QueryClient state |
+| Count agrees with web/API | Required manual verification matrix |
+| Tests cover primary states and auth/cache isolation | Shared, auth, service, query, cache, and component test sections |
+| Simulator and physical iPhone verification | Required matrix rows for both device classes |
+
+## Risks and Mitigations
+
+### Token leakage through an overly generic client
+
+Mitigation: keep token application inside the coordinator, validate API path containment, prohibit Authorization overrides, and extend secret-leak tests.
+
+### Late 401 signs out a refreshed session
+
+Mitigation: capture and verify active owner plus auth generation before any 401-driven mutation.
+
+### In-flight expiry destroys a valid refresh credential
+
+Mitigation: recheck token expiry on 401, refresh through the existing durable credential path, and retry once before terminal cleanup.
+
+### Previous-user cache flashes after sign-in
+
+Mitigation: include user ID in the query key and disable queries whenever no usable authenticated identity exists. Cache clearing remains defense in depth.
+
+### Shared query defaults prevent required refresh
+
+Mitigation: set due-count `refetchOnMount` and `refetchOnWindowFocus` to `always` while retaining shared stale and garbage-collection timing.
+
+### Mobile lifecycle refetch is not triggered by browser focus semantics
+
+Mitigation: explicitly drive TanStack Query `focusManager` from Capacitor app active state.
+
+### Scope grows into the review flow
+
+Mitigation: Home presents count and status only. Review navigation and due-card retrieval remain in the next milestone.
+
+## Implementation Sequence
+
+The implementation plan should preserve test-driven, independently reviewable boundaries in this order:
+
+1. shared SRS contract and user-scoped query key;
+2. coordinator-owned authenticated request capability and race handling;
+3. mobile API and SRS services;
+4. TanStack Query boot and native focus bridge;
+5. auth-driven cache isolation;
+6. due-count composable and pure view selector;
+7. Home presentation and accessibility states; and
+8. Simulator and physical-device milestone evidence.
+
+Each stage must leave existing web authentication, web SRS behavior, mobile OAuth restoration, and sign-out behavior unchanged except for the explicitly shared contract and query-key signature.

--- a/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
+++ b/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
@@ -12,6 +12,8 @@ Deliver the smallest production-shaped Vela Mobile product flow: a returning iOS
 
 This slice establishes reusable mobile boundaries for authenticated feature requests and user-scoped server-state caching without importing the web Home page or exposing Cognito tokens to feature components.
 
+`due_today` is the API field name. Its current semantics are “due as of request time” (`next_review_date <= now`), not “scheduled within the current calendar day.” Home copy therefore says “caught up for now.”
+
 ## Current State
 
 HPA-204 established the absolute mobile API base URL and approved Capacitor CORS behavior.
@@ -60,20 +62,25 @@ The mobile app does not yet install TanStack Query, and Home still renders the M
 | Query key | Change `srsKeys.stats()` to include authenticated user ID; mobile is its first production consumer |
 | Token ownership | ID tokens remain private to the mobile auth coordinator |
 | Feature request surface | Add a coordinator-owned authenticated request operation; do not add `getIdToken()` |
-| Coordinator failures | Use stable typed failures for invalid path, invalid Authorization header, unavailable session, and stale session |
-| URL safety | Use one trailing-slash-preserving API URL builder for `/auth/session` and feature paths; require relative paths contained beneath the configured API prefix |
-| Header ownership | Reject caller-supplied `Authorization` headers case-insensitively before applying the coordinator-owned bearer token |
-| Unauthorized response | A current-session 401 enters auth recovery or terminal cleanup; Home never renders an unauthorized-data state |
-| Expiry race | If the request token expires in flight, refresh and retry once before declaring the session unusable |
-| Stale request race | A response from an older auth generation cannot invalidate a replacement session |
+| Coordinator failures | Use stable typed failures for invalid path, invalid Authorization header, unavailable session, changed session, and pending session recovery |
+| URL safety | Use one trailing-slash-preserving API URL builder for `/auth/session` and feature paths |
+| Header ownership | Reject caller-supplied `Authorization` headers case-insensitively |
+| Response ordering | Return every non-401 response regardless of a concurrent auth-generation change; generation checks guard only 401-driven auth mutation |
+| Stale 401 | A 401 from a superseded generation returns `session_changed` and cannot mutate the replacement session |
+| Current 401 | Share one refresh-or-cleanup decision per auth generation across concurrent requests |
+| Expiry race | If the request token expires in flight, refresh and retry that feature request once |
+| Refresh failure | A transient shared refresh failure returns promptly as `session_recovery_pending`; it never deletes a potentially valid durable credential or leaves callers hanging |
+| Feature timeout | Apply a 15-second timeout to the complete JSON request, including body consumption; timeout is a retryable network failure |
 | Server state | Install TanStack Query in Vela Mobile |
-| Automatic retry | Use an explicit `(failureCount, error) => boolean` predicate; retry only `network` and `server` errors, at most twice |
+| Automatic retry | Retry only `network` and `server` errors, at most twice |
+| Control-flow recovery | Silently retry one `session_changed`/recoverable `session_unavailable` race for the same usable user; wait for auth recovery when it is already pending |
 | Foreground refresh | Bridge native app active state to TanStack Query focus state |
 | Home re-entry | Refetch whenever Home mounts, even if cached data is still fresh |
-| Manual retry | Track manual retry separately from background fetching so `retrying` and `refreshing` are never inferred from the same flag |
-| Cache isolation | Disable immediately when auth is unusable, user-scope keys, and clear mobile query state on sign-out or identity loss |
+| Manual retry | Track manual retry separately from background fetching |
+| Cache isolation | Disable immediately when auth is unusable, user-scope keys, and clear query state on sign-out or identity loss |
 | Cached zero | A cached zero keeps the stale-data warning because time or another client can make reviews due |
 | Review navigation | Do not add a Start Review action in HPA-207 |
+| Device verification | Simulator/automated checks are merge gates; physical-iPhone verification is an HPA-207 closure gate before the Linear issue moves to Done |
 | Platform | Native iOS remains the authenticated runtime for this milestone |
 
 ## Scope
@@ -83,20 +90,22 @@ HPA-207 includes:
 - a shared SRS statistics contract and parser;
 - a user-scoped stats query key;
 - a coordinator-owned authenticated request capability with an explicit failure contract;
-- a shared, boundary-safe mobile API URL builder;
-- a mobile JSON API client with normalized failures;
+- a boundary-safe mobile API URL builder;
+- generation-safe, single-flight 401 recovery;
+- a mobile JSON API client with full-request timeout and normalized failures;
 - a mobile SRS stats service;
 - TanStack Query bootstrap;
 - native foreground-to-query-focus integration;
 - auth-driven query lifecycle and cache cleanup;
 - a minimal Home due-count presentation;
-- unit/component tests for services, retry policy, query behavior, auth isolation, and view states; and
+- unit/component tests for services, concurrency, timeout, retry policy, query behavior, auth isolation, and view states; and
 - Simulator and physical-device verification evidence.
 
 ## Non-goals
 
 - starting, resuming, or completing a review session;
 - fetching individual due cards;
+- user-scoping `srsKeys.due()`, `srsKeys.progress()`, or `srsKeys.allProgress()` in this slice;
 - dashboard parity with the web application;
 - migrating the web SRS stats card to TanStack Query;
 - daily goals, streaks, mastery summaries, or learning shortcuts;
@@ -127,36 +136,13 @@ TanStack Query uses srsKeys.stats(userId)
 Mobile SRS service requests "srs/stats"
                     |
                     v
-Mobile API client delegates authenticated transport
+Mobile API client applies full-request timeout
                     |
                     v
-Coordinator applies current in-memory Cognito ID token
+Coordinator sends request with current in-memory ID token
                     |
                     v
 GET {VITE_MOBILE_API_URL}srs/stats
-```
-
-The auth-failure path is:
-
-```text
-Current authenticated request returns 401
-                    |
-                    v
-Coordinator checks request generation and token expiry
-                    |
-          +---------+---------+
-          |                   |
-  Token expired in flight   Still-valid token rejected
-          |                   |
-Refresh and retry once      Terminal session cleanup
-          |                   |
-          +---------+---------+
-                    |
-                    v
-sessionUsable becomes false if recovery cannot continue
-                    |
-                    v
-MobileAuthGate hides Home and query state is cleared
 ```
 
 ### One token owner and explicit request failures
@@ -177,7 +163,8 @@ export type MobileAuthenticatedApiRequestErrorCode =
   | 'invalid_request_path'
   | 'invalid_request_headers'
   | 'session_unavailable'
-  | 'session_changed';
+  | 'session_changed'
+  | 'session_recovery_pending';
 
 export class MobileAuthenticatedApiRequestError extends Error {
   constructor(
@@ -201,20 +188,19 @@ export type MobileAuthCoordinator = {
 };
 ```
 
-The request operation has these observable outcomes:
+Feature code never receives an ID token. The coordinator constructs the request, owns `Authorization`, and performs the fetch through its injected transport.
+
+The request operation has these observable non-HTTP outcomes:
 
 | Outcome | Coordinator result |
 | --- | --- |
-| Path violates the mobile API containment contract | Throw `MobileAuthenticatedApiRequestError('invalid_request_path')` before network activity |
-| Caller supplies any case variant of `Authorization` | Throw `MobileAuthenticatedApiRequestError('invalid_request_headers')` before network activity |
-| No usable current session before dispatch | Throw `MobileAuthenticatedApiRequestError('session_unavailable')` before network activity |
-| Caller aborts | Preserve the platform `AbortError`; do not mutate auth state |
-| Fetch rejects for another reason | Propagate the transport error; the mobile API client classifies it as `network` |
-| Active owner or generation changes before response handling | Throw `MobileAuthenticatedApiRequestError('session_changed')`; do not mutate the replacement session |
-| Non-401 HTTP response | Return the `Response` unchanged |
-| Final current-generation 401 after recovery rules | Complete the required auth transition, then return the final 401 `Response` for client classification |
-
-Feature code never receives an ID token. The coordinator constructs the request, owns `Authorization`, and performs the fetch through its injected transport.
+| Invalid API path | Throw `invalid_request_path` before network activity |
+| Caller supplies any case variant of `Authorization` | Throw `invalid_request_headers` before network activity |
+| No usable current session before dispatch | Throw `session_unavailable` before network activity |
+| Caller aborts | Preserve platform abort semantics; do not mutate auth state |
+| Transport rejects | Propagate the transport failure; do not perform generation-based auth mutation |
+| A stale-generation 401 arrives | Throw `session_changed`; do not mutate the replacement session |
+| Shared auth refresh fails transiently | Throw `session_recovery_pending` after the refresh attempt settles; do not wait for later automatic/manual auth retry |
 
 ### Shared API URL normalization and containment
 
@@ -232,43 +218,29 @@ function resolveMobileApiUrl(baseUrl: URL, relativePath: string): URL;
 - normalizes the API pathname to exactly one trailing `/`; and
 - preserves that trailing separator for boundary comparisons.
 
-For example:
-
-```text
-https://vela.example/api     -> https://vela.example/api/
-https://vela.example/api///  -> https://vela.example/api/
-```
-
 `resolveMobileApiUrl()` accepts a non-empty relative path such as `auth/session` or `srs/stats`. It rejects:
 
 - absolute URLs;
 - scheme-relative URLs;
 - every root-relative path, including `/api/srs/stats`;
 - backslash-prefixed or backslash-separated escape attempts;
-- raw or percent-encoded traversal that normalizes outside the API base pathname;
-- a resolved origin different from the configured API origin;
-- a resolved pathname that does not begin with the normalized trailing-slash API pathname; and
+- raw or percent-encoded traversal outside the API base pathname;
+- a different resolved origin;
+- a pathname outside the normalized trailing-slash API pathname; and
 - URL fragments.
 
-The implementation compares parsed URL origin and pathname boundaries rather than using a base string with its trailing slash removed. With a base pathname of `/api/`, `/api-evil/secret` is outside the boundary and must fail.
+The comparison is parsed-origin and pathname-boundary aware. With base `/api/`, `/api-evil/secret` must fail.
 
-The existing `/auth/session` request becomes:
+Both requests use the same helper:
 
 ```ts
 resolveMobileApiUrl(apiBaseUrl, 'auth/session');
-```
-
-The due-count request becomes:
-
-```ts
 resolveMobileApiUrl(apiBaseUrl, 'srs/stats');
 ```
 
-This avoids two normalization conventions inside the coordinator and prevents accidental bearer-token delivery to another host or same-origin non-API route.
-
 ### Case-insensitive Authorization ownership
 
-HTTP header names are case-insensitive. The coordinator converts caller headers through the platform `Headers` implementation before inspection:
+HTTP header names are case-insensitive. The coordinator normalizes caller headers through `Headers` before inspection:
 
 ```ts
 const headers = new Headers(request.init?.headers);
@@ -278,26 +250,93 @@ if (headers.has('authorization')) {
 headers.set('Authorization', `Bearer ${idToken}`);
 ```
 
-Tests cover `Authorization`, `authorization`, `AUTHORIZATION`, and at least one mixed-case spelling.
+Tests cover lower-, upper-, canonical-, and mixed-case variants.
 
-### Auth generation and 401 handling
+### Response-arrival ordering
 
-Every request captures the active session owner, ID-token expiry, and `activeBundleGeneration` before dispatch.
+Generation is an auth-mutation guard, not a general response-freshness rule. A proactive or resume refresh normally promotes a new bundle and increments `activeBundleGeneration`; that must not discard a valid response produced by the prior verified token.
 
-When the response arrives:
+After the feature transport settles:
 
-1. Caller abort terminates without auth mutation.
-2. If the active owner or generation changed, throw `session_changed` without mutating current auth state.
-3. Return every non-401 response to the feature client.
-4. For a current-generation 401, recheck the captured token expiry.
-5. If the token expired in flight, queue the existing refresh path and retry the feature request once after verified promotion.
-6. The retried request captures the promoted owner and generation and may not recursively retry again.
-7. If the token was still valid when rejected, or the one retry also returns 401, perform terminal session cleanup.
-8. After cleanup begins or completes, return the final 401 response so the API client can classify `unauthorized` while the gate removes protected content.
-9. If refresh fails transiently, retain the existing HPA-206 retry state. Protected content remains usable only while the prior verified token remains valid.
-10. If refresh proves the durable credential unusable, use the existing terminal cleanup path.
+1. If the caller signal is aborted, preserve abort semantics and stop.
+2. If the transport rejected, propagate the rejection without inspecting generation or mutating auth.
+3. If the HTTP status is not 401, return the `Response` unchanged, even when owner/generation changed while it was in flight.
+4. Only for HTTP 401, compare captured owner/generation with the current active session.
+5. If the 401 belongs to a superseded owner/generation, throw `session_changed` without auth mutation.
+6. If the 401 belongs to the current generation, enter the single-flight recovery contract below.
 
-A 403 is not proof that the Cognito credential is invalid and remains a feature-level API error.
+Decision table:
+
+| Response | Generation matches | Result |
+| --- | --- | --- |
+| 2xx | Yes or no | Return response |
+| 4xx other than 401 | Yes or no | Return response |
+| 5xx | Yes or no | Return response |
+| Transport rejection | Yes or no | Propagate; no auth mutation |
+| 401 | No | Throw `session_changed`; no auth mutation |
+| 401 | Yes | Shared refresh-or-cleanup decision |
+
+Data freshness after sign-out or identity loss is enforced by caller abort, TanStack cancellation, user-scoped keys, and cancel-then-clear cache isolation—not by discarding every old-generation HTTP response.
+
+### Single-flight current-generation 401 recovery
+
+Concurrent requests can receive 401 from the same generation. They must share one auth decision.
+
+The coordinator keeps one in-flight recovery record keyed by active session owner and generation:
+
+```ts
+type FeatureUnauthorizedRecoveryResult =
+  | { kind: 'refreshed' }
+  | { kind: 'terminal' }
+  | { kind: 'retryable_failure' };
+
+type FeatureUnauthorizedRecovery = {
+  owner: ActiveSession;
+  generation: number;
+  promise: Promise<FeatureUnauthorizedRecoveryResult>;
+};
+```
+
+Rules:
+
+1. The first current-generation 401 creates the recovery promise.
+2. Peer 401s for the same owner/generation await that promise.
+3. A caller abort detaches only that caller; it does not cancel the shared auth refresh/cleanup needed by peers.
+4. At most one refresh grant starts for the generation. The existing `refreshPromise`/serialized refresh path remains the refresh single-flight mechanism.
+5. At most one terminal cleanup starts for the generation.
+6. The recovery entry is cleared only when its guarded promise settles.
+7. Every caller retries its own feature HTTP request at most once after a `refreshed` result.
+8. A feature retry captures the promoted owner/generation and cannot recursively initiate another feature retry.
+
+The recovery decision is:
+
+- If a refresh for the captured generation is already in flight, join it even if the captured token had not yet crossed local expiry.
+- Otherwise, if the captured ID token expired in flight, start/join the existing refresh path.
+- Otherwise, a still-valid current token was rejected without an active refresh explanation; perform terminal cleanup once.
+
+Recovery outcomes:
+
+| Shared result | Per-request behavior |
+| --- | --- |
+| `refreshed` | Retry that feature request once with the promoted verified session |
+| `terminal` | Return that request’s original/final 401 after cleanup for `unauthorized` classification |
+| `retryable_failure` | Throw `session_recovery_pending` promptly; preserve the coordinator’s HPA-206 retry state and durable credential |
+
+### Interaction with soft refresh failure
+
+A feature request waits only for the current shared refresh attempt to settle. It never remains pending until a later five-second automatic retry or user-triggered auth retry.
+
+When the shared refresh fails transiently:
+
+- HPA-206 retains `session_refresh_failed` and `retryAction: 'refresh'`;
+- the feature waiter throws `session_recovery_pending`;
+- no terminal cleanup runs;
+- no refresh token is deleted;
+- if the prior verified token remains usable, `MobileAuthGate` keeps content visible with its existing auth-retry banner;
+- if the prior token is no longer usable, the gate replaces Home with blocking auth recovery; and
+- a later successful auth retry causes the due-count composable to refetch once.
+
+This preserves HPA-206’s fail-safe credential semantics while guaranteeing the feature request settles.
 
 ### Shared SRS contract
 
@@ -321,18 +360,11 @@ export interface SRSStats {
 export function parseSrsStats(value: unknown): SRSStats;
 ```
 
-The parser requires:
+The parser requires non-negative integer count fields, a finite non-negative ease factor, accuracy from 0 through 100, and every required nested field. Unknown fields are ignored.
 
-- all count fields to be non-negative integers;
-- `average_ease_factor` to be finite and non-negative;
-- `accuracy_rate` to be finite and between 0 and 100; and
-- every required nested field to exist.
+The web SRS service imports and re-exports `SRSStats`, preserving its public type while removing the duplicate contract. The web card continues direct-service loading.
 
-Unknown additional fields are ignored so the API can add backward-compatible metadata later.
-
-The web SRS service imports and re-exports `SRSStats`, preserving its public service type while removing the duplicate contract. The web card continues its current direct-service loading behavior.
-
-Update the top-level comment in `packages/common/src/index.ts` so the package describes shared query configuration, query keys, domain contracts, and lightweight utilities rather than identifying itself as `@vela/query` only.
+Update the `packages/common/src/index.ts` header so it describes query configuration, query keys, domain contracts, and lightweight utilities rather than `@vela/query` only.
 
 ### User-scoped stats key
 
@@ -348,20 +380,19 @@ It produces:
 ['srs', 'stats', userId, jlpt]
 ```
 
-HPA-207 supplies `MobileAuthUser.userId` and no JLPT filter.
+HPA-207 supplies the authenticated `MobileAuthUser.userId` and no JLPT filter. User identity in the key is the cache correctness boundary; cache clearing is defense in depth.
 
-The user ID is the cache correctness boundary. Explicit cache clearing remains defense-in-depth cleanup. This signature change does not imply that the web app now caches SRS stats; mobile is the first production caller.
+This slice scopes only `stats`. `srsKeys.due()`, `srsKeys.progress()`, and `srsKeys.allProgress()` remain unchanged and must be revisited before the mobile review flow uses them.
 
-### Mobile API client
+### Mobile API client and full-request timeout
 
 Create `apps/vela-mobile/src/services/mobile-api-client.ts`.
-
-Use a stable feature-facing error type:
 
 ```ts
 export type MobileApiErrorCode =
   | 'session_unavailable'
   | 'session_changed'
+  | 'session_recovery_pending'
   | 'unauthorized'
   | 'forbidden'
   | 'network'
@@ -377,31 +408,38 @@ export class MobileApiError extends Error {
     this.name = 'MobileApiError';
   }
 }
+
+export const MOBILE_FEATURE_REQUEST_TIMEOUT_MS = MOBILE_AUTH_NETWORK_TIMEOUT_MS; // 15_000
 ```
 
-The client:
+The client owns the timeout because it also consumes the JSON body. A coordinator timer cleared when headers arrive would not protect against a stalled or truncated response body.
 
-- accepts a relative path and request options;
-- delegates authenticated transport to the coordinator;
-- sends `Accept: application/json`;
-- parses successful JSON;
-- preserves the TanStack Query abort signal;
-- classifies failures without UI copy; and
-- never logs authorization headers, token-bearing objects, or raw identity responses.
+For each JSON request, the client:
 
-| Coordinator/HTTP outcome | Client classification |
+1. creates an internal `AbortController`;
+2. forwards caller abort to it;
+3. starts the 15-second timeout;
+4. delegates transport to the coordinator with the internal signal;
+5. reads the complete response body;
+6. parses/validates the result; and
+7. clears the timer and abort listener in `finally`.
+
+Classification:
+
+| Outcome | Client classification |
 | --- | --- |
-| Caller abort | Preserve abort semantics; no visible error |
-| `session_unavailable` coordinator error | `MobileApiError('session_unavailable')` |
-| `session_changed` coordinator error | `MobileApiError('session_changed')` |
-| `invalid_request_path` or `invalid_request_headers` coordinator error | `MobileApiError('invalid_response')`; these are programmer/configuration defects and must be covered by tests |
-| Final 401 after coordinator recovery | `MobileApiError('unauthorized')` |
-| 403 | `MobileApiError('forbidden')` |
-| Fetch rejection without caller abort | `MobileApiError('network')` |
-| Non-2xx other than 401/403 | `MobileApiError('server')` |
-| Invalid JSON or stats shape | `MobileApiError('invalid_response')` |
+| Caller abort | Preserve cancellation; no visible error |
+| Timeout during transport or body read | `network` |
+| `session_unavailable` | Same code |
+| `session_changed` | Same code |
+| `session_recovery_pending` | Same code |
+| Invalid path/header | `invalid_response`; in development log only a stable defect code, never headers/tokens/raw response |
+| Final 401 | `unauthorized` |
+| 403 | `forbidden` |
+| Other non-2xx | `server` |
+| Invalid JSON/stats shape | `invalid_response` |
 
-`unauthorized` exists for tests and control flow, but Home does not render it because the coordinator disables authenticated content.
+Timeout abort must not cancel a shared coordinator auth-recovery promise; it only stops that feature caller from waiting and prevents its feature retry/body read.
 
 ### Mobile SRS service and provisioning
 
@@ -413,9 +451,9 @@ export type MobileSrsService = {
 };
 ```
 
-`getStats()` calls `srs/stats`, forwards the abort signal, and runs `parseSrsStats()` before returning.
+`getStats()` calls `srs/stats`, forwards the signal, and runs `parseSrsStats()`.
 
-Create `apps/vela-mobile/src/services/mobile-services.ts` with typed injection keys and a provider function:
+Create `mobile-services.ts` with typed injection keys and:
 
 ```ts
 export function provideMobileServices(
@@ -424,20 +462,13 @@ export function provideMobileServices(
 ): void;
 ```
 
-The existing `mobile-auth` boot:
-
-1. creates the coordinator;
-2. provides `MOBILE_AUTH_KEY`;
-3. calls `provideMobileServices(app, coordinator)` with the coordinator directly; and
-4. starts coordinator initialization.
-
-`mobile-services.ts` does not use `inject()` and does not import the QueryClient. Tests can provide deterministic fake services without mocking global fetch.
+The existing `mobile-auth` boot creates/provides the coordinator, calls `provideMobileServices(app, coordinator)` directly, then starts initialization. `mobile-services.ts` does not use `inject()` and does not import the QueryClient.
 
 ### QueryClient bootstrap and wiring
 
-Add workspace dependencies on `@vela/common` and `@tanstack/vue-query` to `@vela/mobile`.
+Add `@vela/common` and `@tanstack/vue-query` to `@vela/mobile`.
 
-Create `apps/vela-mobile/src/boot/query.ts`:
+Create `src/boot/query.ts`:
 
 ```ts
 export const mobileQueryClient = createQueryClient();
@@ -447,7 +478,7 @@ export default defineBoot(({ app }) => {
 });
 ```
 
-The boot order becomes:
+Boot order:
 
 ```text
 main
@@ -457,20 +488,17 @@ capacitor-lifecycle (Capacitor only)
 diagnostic-cold-entry (development only)
 ```
 
-The wiring mechanisms are intentionally distinct:
+Wiring is explicit:
 
-- `mobileQueryClient` is a module singleton imported by auth-isolation infrastructure.
-- `VueQueryPlugin` provides that same instance to TanStack Query composables.
-- `capacitor-lifecycle` imports TanStack Query's `focusManager` directly and does not import the QueryClient singleton.
-- `MobileAuthCoordinator` and `MobileSrsService` use typed Vue application injection.
-- `mobile-auth` boot passes the coordinator directly to `provideMobileServices()`; no boot file tries to recover another boot file's provided value through component injection.
-- `App.vue` injects the coordinator and imports `mobileQueryClient` to install auth/cache isolation once.
+- auth isolation imports the `mobileQueryClient` singleton;
+- Vue Query composables receive the same instance through `VueQueryPlugin`;
+- native lifecycle imports only `focusManager`;
+- coordinator and SRS service use typed Vue injection for components/composables; and
+- service provisioning receives the coordinator directly rather than attempting cross-boot `inject()`.
 
-### Due-count query and exact automatic retry policy
+### Due-count query and automatic retry policy
 
-Create `apps/vela-mobile/src/composables/useDueReviewCount.ts`.
-
-The query configuration is:
+Create `useDueReviewCount.ts`.
 
 ```ts
 const DUE_COUNT_RETRY_LIMIT = 2;
@@ -482,280 +510,252 @@ export function retryDueCountQuery(failureCount: number, error: unknown): boolea
     failureCount < DUE_COUNT_RETRY_LIMIT
   );
 }
+```
 
+The query uses:
+
+```ts
 useQuery({
   queryKey: computed(() => srsKeys.stats(userId.value)),
   enabled: computed(() => sessionUsable.value && userId.value !== null),
-  queryFn: ({ signal }) => srsService.getStats({ signal }),
+  queryFn: ({ signal }) => fetchStatsWithSessionRaceRecovery(signal),
   refetchOnMount: 'always',
   refetchOnWindowFocus: 'always',
   retry: retryDueCountQuery,
 });
 ```
 
-TanStack Query invokes the retry predicate as `(failureCount, error)`. `failureCount < 2` permits two retries, matching the existing shared numeric default while preventing retries for auth, authorization, validation, cancellation, or stale-session failures.
+Only network/server failures receive up to two TanStack retries. Auth/control-flow, authorization, cancellation, and validation failures do not.
 
-Tests verify the predicate directly for every `MobileApiErrorCode`, including that a final 401-derived `unauthorized` error receives zero automatic retries.
+### Session-race and pending-recovery query behavior
 
-The shared stale and garbage-collection defaults remain. `refetchOnMount: 'always'` and `refetchOnWindowFocus: 'always'` are required because Home activation and foreground resume must refresh even while data is nominally fresh.
+`fetchStatsWithSessionRaceRecovery(signal)` captures the current user ID and performs one service call.
+
+For `session_changed` or `session_unavailable`:
+
+- if the caller is not aborted, the same user is still authenticated, and `sessionUsable` is true, silently retry once;
+- otherwise rethrow and allow the auth gate/query enablement to remove the content path; and
+- never perform more than one silent control-flow retry per query execution.
+
+If the one silent retry also returns a control-flow error while Home remains usable, it escapes to the selector as a safe generic blocking/cached failure with manual Retry. The view must never settle into an empty, non-fetching, non-error state.
+
+For `session_recovery_pending`:
+
+- do not immediately retry the feature request;
+- retain cached count data if present;
+- with no cached data, remain in an accessible loading/recovery state;
+- watch the coordinator’s retry tuple (`sessionUsable`, user ID, `retryAction`, `operation`, and `errorCode`);
+- when auth recovery later succeeds for the same user (`sessionUsable`, idle operation, no retry action/error), refetch once; and
+- if auth becomes unusable, let `MobileAuthGate` replace Home.
+
+This distinguishes a settled feature request from an auth recovery that continues independently.
 
 ### Native foreground integration
 
-Extend the existing Capacitor lifecycle boot to subscribe to `appStateChange` and call:
+Extend `capacitor-lifecycle` to subscribe to `appStateChange`:
 
 ```ts
 focusManager.setFocused(event.isActive);
 ```
 
-Keep existing resume diagnostics behavior. Tests cover inactive and active transitions. No polling or background task is added.
+Keep existing resume diagnostics. No polling or background task is added.
 
 ### Auth and cache isolation
 
-Create `apps/vela-mobile/src/services/mobile-query-auth-isolation.ts` and install it once from `App.vue`.
+Install `mobile-query-auth-isolation.ts` once from `App.vue` with the injected coordinator and imported `mobileQueryClient`.
 
-`App.vue`:
+Rules:
 
-- injects `MOBILE_AUTH_KEY`;
-- imports the `mobileQueryClient` module singleton; and
-- calls the installer with both explicit dependencies.
+1. Queries enable only with usable auth and user ID.
+2. Usable-to-unusable immediately stops authenticated data selection.
+3. Sign-out start, terminal cleanup start, or identity change cancels in-flight queries.
+4. Cache removal runs after cancellation settles.
+5. Failed durable cleanup still leaves query data cleared.
+6. Soft refresh failure does not clear while the prior verified session remains usable.
+7. Ordinary backgrounding does not clear.
 
-The isolation rules are:
-
-1. Queries are enabled only with a usable session and user ID.
-2. A usable-to-unusable transition immediately stops Home from selecting authenticated data.
-3. Sign-out start, terminal cleanup start, or identity change cancels in-flight queries and clears the mobile QueryClient.
-4. Failed durable sign-out cleanup still leaves query data cleared.
-5. A soft in-session refresh failure does not clear while `sessionUsable` remains true.
-6. Ordinary backgrounding does not clear.
-7. Cancellation completes before cache removal so an older response cannot repopulate the cache afterward.
-
-Clearing the complete QueryClient is acceptable in M1 because all current mobile server state is authenticated and user-specific.
+A non-401 response may legally return after a generation change; cancellation, abort propagation, and TanStack’s canceled-query semantics prevent it from repopulating removed cache state.
 
 ### Manual retry versus background refresh
 
-The composable owns a local `manualRetryPending` ref in addition to TanStack Query state.
+The composable owns `manualRetryPending`.
 
-Its `retry()` operation:
-
-1. returns immediately when a manual retry is already pending;
-2. records the current visible error presentation;
-3. sets `manualRetryPending = true`;
-4. awaits `query.refetch()`; and
-5. clears `manualRetryPending` in `finally`.
-
-The presentation inputs derive as follows:
+`retry()` prevents concurrent manual retries, preserves the current error surface, sets `manualRetryPending`, awaits `query.refetch()`, and clears the flag in `finally`.
 
 ```ts
 retrying = manualRetryPending;
 refreshing = query.isFetching && query.data !== undefined && !manualRetryPending;
 ```
 
-While a manual retry is pending, the previous blocking or cached error surface remains rendered with its Retry button disabled/loading. An automatic mount/focus refetch with cached data renders the normal count plus the subtle refreshing status.
-
-The selector does not derive both `retrying` and `refreshing` from `isFetching` alone.
+Automatic mount/focus refetch keeps cached content visible with a subtle refresh status. Manual retry keeps the prior error surface visible with a disabled/loading Retry button.
 
 ### Home view selector
 
-Create `apps/vela-mobile/src/components/home/due-review-view.ts`:
+Create a pure exhaustive selector:
 
 ```ts
 type DueReviewView =
-  | { kind: 'loading' }
+  | { kind: 'loading'; recoveringSession: boolean }
   | { kind: 'zero'; refreshing: boolean }
   | { kind: 'positive'; count: number; refreshing: boolean }
-  | { kind: 'blocking_error'; message: string; retrying: boolean }
-  | { kind: 'cached_error'; count: number; message: string; retrying: boolean };
+  | { kind: 'blocking_error'; message: string; retrying: boolean; canRetry: boolean }
+  | { kind: 'cached_error'; count: number; message: string; retrying: boolean; canRetry: boolean };
 ```
 
 Rules:
 
 - no data plus initial fetch produces `loading`;
-- `due_today === 0` produces `zero`;
-- `due_today > 0` produces `positive`;
-- automatic background fetch keeps zero/positive content with `refreshing: true`;
-- visible failure without data produces `blocking_error`;
-- visible refetch failure with cached data, including cached `0`, produces `cached_error`;
-- every non-auth visible failure offers manual Retry;
+- no data plus `session_recovery_pending` produces `loading` with `recoveringSession: true`;
+- zero/positive data remain visible during background fetch;
+- network/server/control-race failure with no data produces `blocking_error`;
+- failed refetch with cached data, including `0`, produces `cached_error`;
+- invalid request defects are generic and non-retryable;
 - manual retry preserves the corresponding error kind with `retrying: true`;
-- cancellation and session-change outcomes produce no visible failure; and
-- unauthorized is never a Home view because auth state removes the content surface.
+- caller cancellation produces no visible error; and
+- unauthorized is never a Home view because the gate removes authenticated content.
 
-A cached zero retains the stale-data notice after a failed refetch. Zero can become stale as review timestamps pass or progress changes through the web app or another client.
+A cached zero retains the stale-data warning because due state changes with time and cross-client progress.
 
 ### Home presentation
 
-Replace the M1 scaffold in `HomePage.vue` with a focused “Today’s review” surface.
+Replace the scaffold with a focused “Today’s review” surface.
 
-#### Initial loading
+- **Loading:** “Loading your review count…” with `role="status"` and `aria-live="polite"`.
+- **Session recovery without data:** “Refreshing your session…” with the same status semantics.
+- **Zero:** prominent `0`; “You’re caught up for now.”
+- **Positive:** prominent count with singular/plural copy.
+- **Background refresh:** keep count visible; “Refreshing review count…” status.
+- **Blocking network failure:** alert, connection-aware copy, Retry.
+- **Cached failure:** keep count visible; “This count may be out of date.”; Retry.
+- **Manual retry:** preserve error surface; disable/loading Retry; accessible label “Retrying review count.”
+- **Non-retryable defect:** generic safe alert without a misleading Retry action.
+- **Unauthorized:** no Home-specific message; auth gate replaces Home.
 
-- Spinner or skeleton.
-- `role="status"` and `aria-live="polite"`.
-- Copy: “Loading your review count…”
-
-#### Zero due
-
-- Prominent `0`.
-- Copy: “You’re caught up for now.”
-- No disabled or misleading review action.
-
-#### Positive due
-
-- Prominent integer.
-- Singular/plural copy: “1 word is due for review” or “12 words are due for review.”
-
-#### Background refresh
-
-- Keep the last verified count visible.
-- Add `role="status"`: “Refreshing review count…”
-- Do not replace verified content with a blocking spinner.
-
-#### Blocking failure
-
-- `role="alert"`.
-- Network copy: “Vela couldn’t load your review count. Check your connection and try again.”
-- Other safe copy: “Vela couldn’t load your review count. Please try again.”
-- Retry button.
-
-#### Cached refresh failure
-
-- Keep the last verified count visible, including `0`.
-- Non-blocking alert: “This count may be out of date.”
-- Retry button.
-
-#### Manual retry in progress
-
-- Keep the existing blocking or cached error surface visible.
-- Disable Retry.
-- Use loading state and accessible label: “Retrying review count.”
-
-#### Unauthorized
-
-- No Home-specific message.
-- The coordinator makes the session unusable and `MobileAuthGate` returns to authentication.
-
-The page no longer displays app version, environment, or scaffold labels. Development diagnostics remain under More.
+Do not add Start Review.
 
 ## Error Handling
 
-### Network and server failures
+### Non-401 response during refresh promotion
 
-They do not mutate authentication state. They remain query errors and support automatic and manual retry according to the explicit predicate. Cached verified data remains visible during a failed refetch.
+Return it normally. A generation change alone does not invalidate a successful or feature-level error response.
 
-### Invalid API shape
+### Stale-generation 401
 
-Invalid stats are never cached. The client returns `invalid_response`, Home shows safe generic copy, and raw response content is not logged.
+Return `session_changed` without cleanup. The composable silently retries once for the same usable user; if the race repeats, it presents a recoverable generic state rather than going blank.
 
-### Unauthorized session
+### Concurrent current-generation 401
 
-A final current-generation 401 is an auth concern. The coordinator owns recovery/cleanup, returns the final response for client classification, the query disables, the cache clears, and the gate removes protected content.
+Share one refresh/cleanup decision. Peer requests wait on it, then each retries once after refresh or returns its own final 401 after terminal cleanup.
+
+### Transient refresh failure
+
+Return `session_recovery_pending` when the current refresh attempt settles. Preserve durable credentials and the coordinator retry state. Do not wait indefinitely for a later auth retry.
+
+### Network timeout
+
+The mobile API client aborts after 15 seconds across transport and body reading and classifies the timeout as `network`. Caller abort remains cancellation.
+
+### Invalid request or API shape
+
+Invalid caller path/header is a programmer defect: preserve a dedicated coordinator code, emit only a stable development diagnostic, show generic non-retryable copy, and never log token-bearing data. Invalid server JSON/stats is `invalid_response` and may be manually retried.
 
 ### Sign-out during request
 
-Sign-out increments auth generation, marks the session unusable before cleanup, cancels query work, and clears cache. A late prior-generation response throws `session_changed` and cannot repopulate data or invalidate the current session.
-
-### Identity replacement
-
-A later sign-in receives a different user-scoped key and cannot select previous-user data even if asynchronous cleanup has not completed.
+Sign-out makes auth unusable, cancels query work, then clears cache. A late non-401 response does not mutate auth; cancellation prevents it from repopulating the canceled query. A late 401 cannot clean up a replacement generation.
 
 ## Testing Strategy
 
 ### Shared package
 
-- Parse a complete production-shaped response.
-- Reject missing, negative, fractional, or non-finite required values.
+- Parse complete production response.
+- Reject missing, negative, fractional, and non-finite required fields.
 - Reject accuracy outside 0–100.
-- Ignore unknown additional fields.
-- Produce distinct stats keys for distinct users and JLPT filters.
-- Confirm the package header covers contracts as well as query utilities.
+- Ignore unknown fields.
+- Produce distinct stats keys for users/JLPT filters.
+- Confirm package header includes contracts.
+- Document that non-stats SRS keys remain unscoped.
 
 ### Auth coordinator
 
-- Attach the current ID token to an allowed relative path.
-- Use the same URL builder for `auth/session` and `srs/stats`.
-- Reject absolute, scheme-relative, root-relative, backslash, traversal, and outside-prefix paths.
-- Reject `/api-evil/secret` when the configured base pathname is `/api/`.
-- Preserve the normalized trailing `/` in containment checks.
-- Reject `Authorization`, `authorization`, `AUTHORIZATION`, and mixed-case variants with `invalid_request_headers` before network activity.
-- Reject without a usable session using `session_unavailable`.
-- Preserve caller abort behavior.
-- Propagate transport rejection for client classification.
-- Return non-401 responses without auth mutation.
-- Refresh and retry once when the token expires in flight.
-- Terminally clean up after a still-valid current token or refreshed retry is rejected.
-- Return the final 401 response after the auth transition.
-- Throw `session_changed` for an old-generation response without auth mutation.
+- Apply ID token to allowed relative path.
+- Share URL builder between `auth/session` and `srs/stats`.
+- Reject absolute, scheme-relative, root-relative, backslash, traversal, outside-prefix, and `/api-evil/` paths.
+- Reject every case variant of Authorization before network activity.
+- Reject dispatch without usable session.
+- Preserve caller abort.
+- Propagate transport rejection without generation mutation.
+- **Return an in-flight 200 after concurrent soft-refresh promotion.**
+- **Return an in-flight 500 after concurrent soft-refresh promotion.**
+- **Return `session_changed` for an in-flight 401 after promotion without cleaning the new session.**
+- Join an already-running refresh before deciding a current 401 is terminal.
+- Concurrent expired-token 401s start one refresh and each feature request retries at most once.
+- Concurrent still-valid-token 401s perform one terminal cleanup.
+- One caller abort does not cancel shared recovery for peers.
+- A transient shared refresh failure settles all waiters as `session_recovery_pending` without cleanup.
+- A terminal shared result returns each request’s final 401.
 - Keep 403 feature-scoped.
-- Handle sign-out racing an in-flight request.
-- Keep token/header values out of logs and rendered errors.
+- Keep secrets out of logs/errors.
 
 ### Mobile API and SRS services
 
-- Map each typed coordinator failure to the documented `MobileApiErrorCode`.
-- Successful JSON parsing and full stats validation.
-- Network, 401, 403, non-2xx, and invalid-response classification.
-- Cancellation and signal forwarding.
-- Exact `srs/stats` path.
-- Typed service provisioning from the coordinator without cross-boot `inject()`.
+- Map every coordinator code.
+- Transport stall times out as network.
+- Response-body stall times out as network.
+- Caller abort before timeout remains cancellation.
+- Timeout/caller cleanup removes timer and signal listeners.
+- Timeout of one caller does not cancel shared auth recovery.
+- Parse successful JSON and validate full stats.
+- Classify 401, 403, other non-2xx, invalid JSON, and invalid stats.
+- Forward exact `srs/stats` path and signal.
+- Provision services without cross-boot injection.
 
-### Query bootstrap and retry policy
+### Query, auth recovery, and retry policy
 
-- QueryClient singleton creation and Vue plugin installation.
-- Boot ordering.
-- `retryDueCountQuery(0, network)` and `retryDueCountQuery(1, server)` return true.
-- `retryDueCountQuery(2, network)` returns false.
-- Unauthorized, forbidden, invalid-response, session-unavailable, and session-changed return false at every failure count.
-- Unknown/non-`MobileApiError` values return false.
+- QueryClient singleton and plugin use the same instance.
+- Boot order is `main`, `query`, `mobile-auth`, then conditional boots.
+- Retry predicate permits exactly two network/server retries and rejects all other codes.
+- First `session_changed` for same usable user silently retries once.
+- Repeated `session_changed` never leaves a blank state.
+- Recoverable `session_unavailable` silently retries once after the same user becomes usable.
+- `session_recovery_pending` with cache retains data and waits for auth recovery.
+- `session_recovery_pending` without cache renders accessible recovery loading.
+- Successful later auth retry triggers one due-count refetch.
+- Auth becoming unusable removes Home instead of surfacing a feature error.
 
-### Native lifecycle
+### Lifecycle, cache, and UI
 
-- `focusManager` receives inactive and active updates.
-- Foreground refetch occurs for an enabled query.
-- No foreground fetch occurs while signed out.
-- Existing lifecycle diagnostics remain intact.
-
-### Cache isolation
-
-- No query during restoration.
-- One initial query after restored authentication becomes usable.
-- User ID appears in the key.
-- Sign-out and terminal cleanup cancel and clear.
-- Cancellation precedes removal.
-- Soft refresh failure with a usable session retains cache.
+- `focusManager` receives inactive/active transitions.
+- Foreground refetch occurs only for enabled query.
+- Sign-out/terminal cleanup cancel before clear.
+- Failed durable cleanup still clears data.
+- Soft refresh failure with usable session retains cache.
 - Identity change cannot select previous-user data.
-- Failed durable cleanup still hides and clears due-count data.
-
-### Composable and Home component
-
-- Background fetch with cached data sets `refreshing` and not `retrying`.
-- Manual retry sets `retrying` and not `refreshing`.
-- The previous error surface remains visible while manual retry is pending.
-- Accessible loading state.
-- Zero, singular, and plural states.
-- Blocking network failure and manual retry.
-- Disabled/loading retry state.
-- Background refresh with cached count.
-- Cached positive and cached-zero refresh failures show the stale-data alert and Retry.
-- No Start Review action.
-- No scaffold version/environment content.
+- Manual retry and background refresh use distinct flags.
+- Loading, recovery loading, zero, singular, plural, blocking error, cached error, retrying, and non-retryable defect states are accessible.
+- Cached positive and cached zero show stale warning after failed refetch.
+- No Start Review or scaffold content.
 
 ## Manual Verification Matrix
 
-Record account, build/environment, device, timestamp, comparison value, and result for every row.
+Record account, build/environment, device, timestamp, comparison value, and result.
 
 | Scenario | Expected result |
 | --- | --- |
-| Fresh sign-in | Google sign-in opens Home and fetches the authenticated count |
-| Relaunch restoration | Force-close/reopen restores without another Google prompt and loads Home |
-| Positive due count | Mobile matches web/API for the same account at the recorded time |
-| Zero due count | Home displays `0` and the caught-up message |
-| Network failure | Home remains authenticated and shows a retryable failure |
-| Retry | Restoring connectivity and tapping Retry loads the count |
-| Background/resume | Returning Vela to active state refetches the count |
+| Fresh sign-in | Google sign-in opens Home and fetches authenticated count |
+| Relaunch restoration | Force-close/reopen restores without another Google prompt |
+| Positive due count | Mobile matches web/API for same account and timestamp |
+| Zero due count | Home shows `0` and caught-up copy |
+| Network failure | Auth remains safe; retryable Home failure appears |
+| Retry | Connectivity restoration plus Retry loads count |
+| Background/resume | Returning active refetches count |
+| Soft auth-refresh failure | Existing count remains when prior session is usable; auth retry can recover |
 | Rejected token | Protected Home disappears and authentication is shown |
 | Sign-out | Home data is removed immediately; relaunch remains signed out |
-| Account isolation | A later sign-in never displays the prior account’s count |
-| iOS Simulator | Complete flow passes in a configured Simulator build |
-| Physical development iPhone | Complete flow passes on a configured device |
+| Account isolation | Later sign-in never displays prior account count |
+| iOS Simulator | Complete flow passes before implementation PR merge |
+| Physical development iPhone | Complete flow passes before HPA-207 is closed |
+
+Automated checks and the configured Simulator flow are merge gates. The physical-iPhone run is a closure gate: implementation may merge after the merge gates pass, but HPA-207 must remain open until device evidence is recorded.
 
 ## Expected File Boundaries
 
@@ -815,69 +815,55 @@ Record account, build/environment, device, timestamp, comparison value, and resu
 
 | Acceptance criterion | Design coverage |
 | --- | --- |
-| Returning user reaches Home through restored auth | Existing HPA-206 gate plus enabled query after `sessionUsable` |
+| Returning user reaches Home through restored auth | HPA-206 gate plus enabled query after usable session |
 | Home displays `/api/srs/stats` due count | Mobile SRS service and Home selector |
-| Expired/rejected token cannot expose another user’s data | Generation-aware recovery, typed stale-session rejection, user-scoped key, query disable, and cache cleanup |
-| Loading, empty, failure, and retry states are accessible | Exhaustive presentation union, explicit manual-retry state, and required semantics |
-| Signing out clears user data | Auth-isolation service cancels then clears QueryClient |
-| Count agrees with web/API | Required manual verification matrix |
-| Tests cover states and auth/cache isolation | Shared, auth, service, retry, query, cache, and component suites |
-| Simulator and physical iPhone verification | Required matrix rows for both device classes |
+| Expired/rejected token cannot expose another user’s data | 401-only generation guards, shared recovery, user-scoped key, cancellation, and cache cleanup |
+| Loading, empty, failure, and retry states are accessible | Exhaustive view union including auth-recovery loading and manual retry |
+| Signing out clears user data | Cancel then clear QueryClient |
+| Count agrees with web/API | Manual matrix |
+| Tests cover primary states and auth/cache isolation | Shared, concurrency, timeout, query, cache, and component suites |
+| Simulator and physical iPhone verification | Simulator merge gate plus device closure gate |
 
 ## Risks and Mitigations
 
-### Token leakage through an overly generic client
+### Successful response discarded by soft refresh
 
-Keep token application inside the coordinator, validate path containment, reject Authorization overrides case-insensitively, and extend secret-leak tests.
+Return non-401 responses before generation comparison. Generation guards only auth-mutating 401 paths.
 
-### API-prefix boundary bypass
+### Concurrent 401s duplicate cleanup or refresh
 
-Normalize the base pathname with a trailing `/`, resolve through parsed URLs, compare origin and pathname boundaries, and test `/api/` versus `/api-evil/` explicitly.
+Use one recovery promise per owner/generation, reuse `refreshPromise`, and permit one terminal cleanup.
 
-### Late 401 signs out a refreshed session
+### Feature request hangs
 
-Capture and verify active owner plus auth generation before any 401-driven mutation.
+Keep the client timeout active through body consumption. Shared auth-recovery waiters settle on the current attempt rather than waiting for later retries.
 
-### In-flight expiry destroys a valid refresh credential
+### Transient refresh failure destroys credential
 
-Recheck expiry on 401, refresh through the existing durable credential path, and retry once before terminal cleanup.
-
-### Default retry repeats auth failures
-
-Use the explicit retry predicate and direct tests for all error codes rather than inheriting the shared numeric default.
+Return `session_recovery_pending`, preserve HPA-206 retry state, and never terminally clean up due solely to transport/server refresh failure.
 
 ### Previous-user cache flashes after sign-in
 
-Include user ID in the key and disable whenever no usable identity exists. Cache clearing remains defense in depth.
+User-scope the key, disable without usable identity, and cancel then clear on identity loss.
 
-### Manual retry looks like background refresh
+### Token leakage or API-prefix escape
 
-Track `manualRetryPending` independently and retain the preceding error surface until the manual request settles.
-
-### Wiring relies on an unavailable cross-boot injection
-
-Pass the coordinator directly into service provisioning, import the QueryClient singleton only where auth-isolation needs it, drive native focus through `focusManager`, and reserve Vue injection for component/composable consumers.
-
-### Native lifecycle does not produce browser focus events
-
-Drive TanStack Query `focusManager` explicitly from Capacitor app state.
+Keep bearer application inside the coordinator, reject Authorization overrides case-insensitively, use parsed pathname boundaries, and extend secret-leak tests.
 
 ### Scope grows into review execution
 
-Home presents count and status only. Review navigation and due-card retrieval remain in the next milestone.
+Home presents count/status only. Due-card retrieval and review navigation remain later work.
 
 ## Implementation Sequence
 
-The implementation plan should preserve test-driven, independently reviewable boundaries in this order:
+1. Shared SRS contract, package description, and user-scoped stats key.
+2. Shared API URL normalization and case-insensitive header ownership.
+3. Coordinator request contract, non-401 ordering, and single-flight 401 recovery.
+4. Mobile API timeout/error normalization and SRS service provisioning.
+5. QueryClient boot, exact retry predicate, and native focus bridge.
+6. Auth-driven cache isolation and pending-recovery refetch behavior.
+7. Due-count composable with silent race recovery and separate manual-retry state.
+8. Home selector/presentation and accessibility states.
+9. Simulator merge-gate evidence and physical-device closure evidence.
 
-1. shared SRS contract, package description, and user-scoped query key;
-2. shared API URL normalization and case-insensitive header ownership;
-3. coordinator authenticated-request failure contract and generation-aware 401 handling;
-4. mobile API/SRS services and direct coordinator provisioning;
-5. QueryClient boot, exact retry predicate, and native focus bridge;
-6. auth-driven cache isolation with explicit singleton/injection wiring;
-7. due-count composable with separate manual-retry state and pure view selector;
-8. Home presentation and accessibility states; and
-9. Simulator and physical-device milestone evidence.
-
-Each stage must leave existing web authentication, web SRS loading behavior, mobile OAuth restoration, and sign-out behavior unchanged except for the explicitly shared contract, package description, and query-key signature.
+Each stage must leave existing web authentication, web SRS loading behavior, mobile OAuth restoration, and sign-out behavior unchanged except for the explicitly shared contract, package description, and stats-key signature.

--- a/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
+++ b/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
@@ -58,30 +58,26 @@ The mobile app does not yet install TanStack Query, and Home still renders the M
 | Product scope | Display only the authenticated due-review count and required states |
 | Backend | Reuse `GET /api/srs/stats` unchanged |
 | Shared contract | Move the complete `SRSStats` response contract into `@vela/common` |
-| Shared package scope | Update the `@vela/common` module header so it describes shared query utilities and contracts rather than `@vela/query` only |
-| Query key | Change `srsKeys.stats()` to include authenticated user ID; mobile is its first production consumer |
+| Shared package scope | Update the `@vela/common` module header to cover query utilities and domain contracts |
+| Query key | Include authenticated user ID in `srsKeys.stats()`; mobile is its first production consumer |
 | Token ownership | ID tokens remain private to the mobile auth coordinator |
-| Feature request surface | Add a coordinator-owned authenticated request operation; do not add `getIdToken()` |
-| Coordinator failures | Use stable typed failures for invalid path, invalid Authorization header, unavailable session, changed session, and pending session recovery |
-| URL safety | Use one trailing-slash-preserving API URL builder for `/auth/session` and feature paths |
-| Header ownership | Reject caller-supplied `Authorization` headers case-insensitively |
-| Response ordering | Return every non-401 response regardless of a concurrent auth-generation change; generation checks guard only 401-driven auth mutation |
-| Stale 401 | A 401 from a superseded generation returns `session_changed` and cannot mutate the replacement session |
-| Current 401 | Share one refresh-or-cleanup decision per auth generation across concurrent requests |
-| Expiry race | If the request token expires in flight, refresh and retry that feature request once |
-| Refresh failure | A transient shared refresh failure returns promptly as `session_recovery_pending`; it never deletes a potentially valid durable credential or leaves callers hanging |
-| Feature timeout | Apply a 15-second timeout to the complete JSON request, including body consumption; timeout is a retryable network failure |
+| Feature request surface | Add coordinator-owned authenticated requests; do not add `getIdToken()` |
+| URL/header safety | Share a trailing-slash-preserving API URL builder and reject Authorization overrides case-insensitively |
+| Response ordering | Return every non-401 response despite concurrent auth promotion; generation checks guard only 401-driven auth mutation |
+| Stale 401 | A 401 from a superseded generation becomes `session_changed` and cannot mutate the replacement session |
+| Current 401 | Share one refresh-or-cleanup decision per owner/generation across concurrent requests |
+| Refresh failure | A transient shared refresh failure settles callers as `session_recovery_pending`; it never deletes a potentially valid durable credential or hangs the feature request |
+| Timeout | Bound each feature transport attempt and final response-body read to 15 seconds; timeout is a retryable network failure |
 | Server state | Install TanStack Query in Vela Mobile |
-| Automatic retry | Retry only `network` and `server` errors, at most twice |
-| Control-flow recovery | Silently retry one `session_changed`/recoverable `session_unavailable` race for the same usable user; wait for auth recovery when it is already pending |
-| Foreground refresh | Bridge native app active state to TanStack Query focus state |
-| Home re-entry | Refetch whenever Home mounts, even if cached data is still fresh |
+| Automatic retry | Retry only `network` and `server`, at most twice |
+| Control-flow recovery | Silently retry one same-user `session_changed`/recoverable `session_unavailable` race; wait for auth recovery when already pending |
+| Foreground/Home refresh | Refetch on native foreground and every Home mount, even when cached data is fresh |
 | Manual retry | Track manual retry separately from background fetching |
-| Cache isolation | Disable immediately when auth is unusable, user-scope keys, and clear query state on sign-out or identity loss |
-| Cached zero | A cached zero keeps the stale-data warning because time or another client can make reviews due |
-| Review navigation | Do not add a Start Review action in HPA-207 |
-| Device verification | Simulator/automated checks are merge gates; physical-iPhone verification is an HPA-207 closure gate before the Linear issue moves to Done |
-| Platform | Native iOS remains the authenticated runtime for this milestone |
+| Cache isolation | Disable without usable identity, user-scope keys, and cancel then clear on sign-out/identity loss |
+| Cached zero | Keep the stale-data warning because time or another client can make reviews due |
+| Review navigation | Do not add Start Review |
+| Device verification | Simulator/automated checks are merge gates; physical-iPhone evidence is an HPA-207 closure gate |
+| Platform | Native iOS only for this milestone |
 
 ## Scope
 
@@ -89,16 +85,15 @@ HPA-207 includes:
 
 - a shared SRS statistics contract and parser;
 - a user-scoped stats query key;
-- a coordinator-owned authenticated request capability with an explicit failure contract;
-- a boundary-safe mobile API URL builder;
+- a coordinator-owned authenticated request capability with typed failures;
+- boundary-safe URL/header handling;
 - generation-safe, single-flight 401 recovery;
-- a mobile JSON API client with full-request timeout and normalized failures;
-- a mobile SRS stats service;
-- TanStack Query bootstrap;
-- native foreground-to-query-focus integration;
+- bounded feature transport and body consumption;
+- a mobile JSON API client and SRS service;
+- TanStack Query bootstrap and native focus integration;
 - auth-driven query lifecycle and cache cleanup;
 - a minimal Home due-count presentation;
-- unit/component tests for services, concurrency, timeout, retry policy, query behavior, auth isolation, and view states; and
+- unit/component coverage for concurrency, timeout, retry, isolation, and view states; and
 - Simulator and physical-device verification evidence.
 
 ## Non-goals
@@ -106,11 +101,9 @@ HPA-207 includes:
 - starting, resuming, or completing a review session;
 - fetching individual due cards;
 - user-scoping `srsKeys.due()`, `srsKeys.progress()`, or `srsKeys.allProgress()` in this slice;
-- dashboard parity with the web application;
-- migrating the web SRS stats card to TanStack Query;
+- dashboard parity or web stats-card query migration;
 - daily goals, streaks, mastery summaries, or learning shortcuts;
-- persistent offline query storage or offline due-deck generation;
-- a new connectivity plugin, background polling, or background tasks;
+- persistent offline query storage, offline due-deck generation, connectivity plugins, polling, or background tasks;
 - Android support;
 - remote Cognito global sign-out;
 - sharing the web Home presentation; and
@@ -136,32 +129,29 @@ TanStack Query uses srsKeys.stats(userId)
 Mobile SRS service requests "srs/stats"
                     |
                     v
-Mobile API client applies full-request timeout
+Mobile API client manages cancellation/body timeout
                     |
                     v
-Coordinator sends request with current in-memory ID token
+Coordinator sends bounded request with current ID token
                     |
                     v
 GET {VITE_MOBILE_API_URL}srs/stats
 ```
 
-### One token owner and explicit request failures
+### One token owner and request contract
 
 `apps/vela-mobile/src/services/mobile-auth.ts` remains the only owner of active Cognito token material.
-
-The coordinator contract gains a request operation instead of a token accessor:
 
 ```ts
 export type MobileAuthenticatedApiRequest = {
   path: string;
-  init?: Omit<RequestInit, 'headers'> & {
-    headers?: HeadersInit;
-  };
+  init?: Omit<RequestInit, 'headers'> & { headers?: HeadersInit };
 };
 
 export type MobileAuthenticatedApiRequestErrorCode =
   | 'invalid_request_path'
   | 'invalid_request_headers'
+  | 'request_timeout'
   | 'session_unavailable'
   | 'session_changed'
   | 'session_recovery_pending';
@@ -188,59 +178,47 @@ export type MobileAuthCoordinator = {
 };
 ```
 
-Feature code never receives an ID token. The coordinator constructs the request, owns `Authorization`, and performs the fetch through its injected transport.
+Feature code never receives an ID token. The coordinator constructs the request, owns `Authorization`, and performs transport through its injected fetch.
 
-The request operation has these observable non-HTTP outcomes:
+Observable non-HTTP outcomes:
 
 | Outcome | Coordinator result |
 | --- | --- |
-| Invalid API path | Throw `invalid_request_path` before network activity |
-| Caller supplies any case variant of `Authorization` | Throw `invalid_request_headers` before network activity |
-| No usable current session before dispatch | Throw `session_unavailable` before network activity |
-| Caller aborts | Preserve platform abort semantics; do not mutate auth state |
-| Transport rejects | Propagate the transport failure; do not perform generation-based auth mutation |
-| A stale-generation 401 arrives | Throw `session_changed`; do not mutate the replacement session |
-| Shared auth refresh fails transiently | Throw `session_recovery_pending` after the refresh attempt settles; do not wait for later automatic/manual auth retry |
+| Invalid path | `invalid_request_path` before network activity |
+| Caller supplies any Authorization case variant | `invalid_request_headers` before network activity |
+| No usable session before dispatch | `session_unavailable` before network activity |
+| One feature transport attempt exceeds 15 seconds | `request_timeout`; no auth mutation caused by the timeout itself |
+| Caller aborts | Preserve caller cancellation |
+| Other transport rejection | Propagate transport failure; no generation-based auth mutation |
+| Stale-generation 401 | `session_changed`; replacement session untouched |
+| Shared refresh attempt fails transiently | `session_recovery_pending`; HPA-206 retry state retained |
 
-### Shared API URL normalization and containment
+### Shared API URL normalization and Authorization ownership
 
-Replace the narrow `sessionUrl()` string helper with one coordinator-local URL boundary used by both session verification and feature requests:
+Replace `sessionUrl()` with one coordinator-local boundary:
 
 ```ts
 function normalizeMobileApiBaseUrl(apiUrl: string): URL;
 function resolveMobileApiUrl(baseUrl: URL, relativePath: string): URL;
 ```
 
-`normalizeMobileApiBaseUrl()`:
+The normalized base removes search/hash and has exactly one trailing pathname `/`. `resolveMobileApiUrl()` accepts non-empty relative paths such as `auth/session` and `srs/stats` and rejects:
 
-- parses the configured absolute API URL;
-- removes search and hash components;
-- normalizes the API pathname to exactly one trailing `/`; and
-- preserves that trailing separator for boundary comparisons.
+- absolute, scheme-relative, and every root-relative URL;
+- backslash-prefixed/separated escape attempts;
+- raw or encoded traversal outside the base;
+- different origins;
+- pathnames outside the trailing-slash base boundary; and
+- fragments.
 
-`resolveMobileApiUrl()` accepts a non-empty relative path such as `auth/session` or `srs/stats`. It rejects:
-
-- absolute URLs;
-- scheme-relative URLs;
-- every root-relative path, including `/api/srs/stats`;
-- backslash-prefixed or backslash-separated escape attempts;
-- raw or percent-encoded traversal outside the API base pathname;
-- a different resolved origin;
-- a pathname outside the normalized trailing-slash API pathname; and
-- URL fragments.
-
-The comparison is parsed-origin and pathname-boundary aware. With base `/api/`, `/api-evil/secret` must fail.
-
-Both requests use the same helper:
+With base `/api/`, `/api-evil/secret` is outside the boundary.
 
 ```ts
 resolveMobileApiUrl(apiBaseUrl, 'auth/session');
 resolveMobileApiUrl(apiBaseUrl, 'srs/stats');
 ```
 
-### Case-insensitive Authorization ownership
-
-HTTP header names are case-insensitive. The coordinator normalizes caller headers through `Headers` before inspection:
+Caller headers are normalized through `Headers`:
 
 ```ts
 const headers = new Headers(request.init?.headers);
@@ -250,39 +228,47 @@ if (headers.has('authorization')) {
 headers.set('Authorization', `Bearer ${idToken}`);
 ```
 
-Tests cover lower-, upper-, canonical-, and mixed-case variants.
+### Feature transport timeout
+
+Each actual feature fetch attempt receives the same 15-second network bound as existing auth network calls.
+
+The coordinator merges the caller signal with an attempt-local controller:
+
+- caller abort remains caller cancellation;
+- attempt timer abort becomes `request_timeout`;
+- timer/listener cleanup runs in `finally`;
+- the timer covers dispatch through response headers; and
+- retry after auth refresh gets a fresh attempt timer.
+
+The timeout does not wrap the whole refresh-and-verify sequence. Existing Cognito refresh and `/auth/session` verification already have their own bounded operations. A feature caller waiting on shared recovery races that wait with its caller signal, but one caller abort never cancels recovery needed by peers.
 
 ### Response-arrival ordering
 
-Generation is an auth-mutation guard, not a general response-freshness rule. A proactive or resume refresh normally promotes a new bundle and increments `activeBundleGeneration`; that must not discard a valid response produced by the prior verified token.
+Generation is an auth-mutation guard, not a general response-freshness rule. A normal proactive/resume refresh promotes a bundle and increments generation; that must not discard valid data or feature errors returned by the prior verified token.
 
-After the feature transport settles:
+After transport settles:
 
-1. If the caller signal is aborted, preserve abort semantics and stop.
-2. If the transport rejected, propagate the rejection without inspecting generation or mutating auth.
-3. If the HTTP status is not 401, return the `Response` unchanged, even when owner/generation changed while it was in flight.
-4. Only for HTTP 401, compare captured owner/generation with the current active session.
-5. If the 401 belongs to a superseded owner/generation, throw `session_changed` without auth mutation.
-6. If the 401 belongs to the current generation, enter the single-flight recovery contract below.
-
-Decision table:
+1. If caller-aborted, preserve cancellation.
+2. If transport rejected/timed out, propagate the corresponding failure without a generation-driven auth mutation.
+3. If status is not 401, return `Response` unchanged regardless of generation.
+4. Only for 401, compare captured owner/generation with current active session.
+5. Stale 401 returns `session_changed` without mutation.
+6. Current-generation 401 enters shared recovery.
 
 | Response | Generation matches | Result |
 | --- | --- | --- |
 | 2xx | Yes or no | Return response |
-| 4xx other than 401 | Yes or no | Return response |
+| 4xx except 401 | Yes or no | Return response |
 | 5xx | Yes or no | Return response |
-| Transport rejection | Yes or no | Propagate; no auth mutation |
-| 401 | No | Throw `session_changed`; no auth mutation |
+| Transport failure | Yes or no | Propagate; no auth mutation |
+| 401 | No | `session_changed`; no auth mutation |
 | 401 | Yes | Shared refresh-or-cleanup decision |
 
-Data freshness after sign-out or identity loss is enforced by caller abort, TanStack cancellation, user-scoped keys, and cancel-then-clear cache isolation—not by discarding every old-generation HTTP response.
+Sign-out/data freshness is enforced by caller abort, TanStack cancellation, user-scoped keys, and cancel-then-clear isolation—not by discarding every old-generation HTTP response.
 
 ### Single-flight current-generation 401 recovery
 
-Concurrent requests can receive 401 from the same generation. They must share one auth decision.
-
-The coordinator keeps one in-flight recovery record keyed by active session owner and generation:
+Concurrent 401s for one active owner/generation share one decision:
 
 ```ts
 type FeatureUnauthorizedRecoveryResult =
@@ -299,97 +285,64 @@ type FeatureUnauthorizedRecovery = {
 
 Rules:
 
-1. The first current-generation 401 creates the recovery promise.
-2. Peer 401s for the same owner/generation await that promise.
-3. A caller abort detaches only that caller; it does not cancel the shared auth refresh/cleanup needed by peers.
-4. At most one refresh grant starts for the generation. The existing `refreshPromise`/serialized refresh path remains the refresh single-flight mechanism.
-5. At most one terminal cleanup starts for the generation.
-6. The recovery entry is cleared only when its guarded promise settles.
-7. Every caller retries its own feature HTTP request at most once after a `refreshed` result.
-8. A feature retry captures the promoted owner/generation and cannot recursively initiate another feature retry.
+1. First current-generation 401 creates the recovery record.
+2. Peers for the same owner/generation await it.
+3. Caller abort detaches only that caller.
+4. Existing `refreshPromise`/serialization remains the refresh single-flight mechanism.
+5. At most one terminal cleanup runs for the generation.
+6. The guarded record clears only after settlement.
+7. After `refreshed`, each caller retries its own feature request once.
+8. The feature retry captures the promoted generation and cannot recursively retry again.
 
-The recovery decision is:
+Decision:
 
-- If a refresh for the captured generation is already in flight, join it even if the captured token had not yet crossed local expiry.
-- Otherwise, if the captured ID token expired in flight, start/join the existing refresh path.
-- Otherwise, a still-valid current token was rejected without an active refresh explanation; perform terminal cleanup once.
+- join a refresh already in flight for the captured generation;
+- otherwise refresh when the captured token expired in flight;
+- otherwise treat rejection of a still-valid current token as terminal and clean up once.
 
-Recovery outcomes:
-
-| Shared result | Per-request behavior |
+| Shared result | Per-request result |
 | --- | --- |
-| `refreshed` | Retry that feature request once with the promoted verified session |
-| `terminal` | Return that request’s original/final 401 after cleanup for `unauthorized` classification |
-| `retryable_failure` | Throw `session_recovery_pending` promptly; preserve the coordinator’s HPA-206 retry state and durable credential |
+| `refreshed` | Retry own feature request once |
+| `terminal` | Return own original/final 401 after cleanup |
+| `retryable_failure` | Settle as `session_recovery_pending`; preserve credential and coordinator retry state |
 
-### Interaction with soft refresh failure
+### Soft refresh failure interaction
 
-A feature request waits only for the current shared refresh attempt to settle. It never remains pending until a later five-second automatic retry or user-triggered auth retry.
+A feature waiter waits only for the current shared refresh attempt, never a later five-second automatic retry or user retry.
 
-When the shared refresh fails transiently:
+On transient refresh failure:
 
 - HPA-206 retains `session_refresh_failed` and `retryAction: 'refresh'`;
-- the feature waiter throws `session_recovery_pending`;
-- no terminal cleanup runs;
-- no refresh token is deleted;
-- if the prior verified token remains usable, `MobileAuthGate` keeps content visible with its existing auth-retry banner;
-- if the prior token is no longer usable, the gate replaces Home with blocking auth recovery; and
-- a later successful auth retry causes the due-count composable to refetch once.
-
-This preserves HPA-206’s fail-safe credential semantics while guaranteeing the feature request settles.
+- waiter settles as `session_recovery_pending`;
+- no terminal cleanup or credential deletion occurs;
+- if the prior session remains usable, content/cache remains and the existing auth-retry banner is visible;
+- if unusable, the gate replaces Home with blocking auth recovery; and
+- later successful auth retry triggers one due-count refetch.
 
 ### Shared SRS contract
 
-Create `packages/common/src/contracts/srs.ts`:
+Create `packages/common/src/contracts/srs.ts` with `SRSStats` and `parseSrsStats(value)`.
 
-```ts
-export interface SRSStats {
-  total_items: number;
-  due_today: number;
-  mastery_breakdown: {
-    new: number;
-    learning: number;
-    reviewing: number;
-    mastered: number;
-  };
-  average_ease_factor: number;
-  total_reviews: number;
-  accuracy_rate: number;
-}
+The parser requires non-negative integer count fields, a finite non-negative ease factor, accuracy from 0 through 100, and all required nested fields. Unknown fields are ignored.
 
-export function parseSrsStats(value: unknown): SRSStats;
-```
-
-The parser requires non-negative integer count fields, a finite non-negative ease factor, accuracy from 0 through 100, and every required nested field. Unknown fields are ignored.
-
-The web SRS service imports and re-exports `SRSStats`, preserving its public type while removing the duplicate contract. The web card continues direct-service loading.
-
-Update the `packages/common/src/index.ts` header so it describes query configuration, query keys, domain contracts, and lightweight utilities rather than `@vela/query` only.
+The web SRS service imports/re-exports `SRSStats`, preserving its public type and direct loading behavior. Update `packages/common/src/index.ts` so its header describes query configuration, keys, domain contracts, and lightweight utilities.
 
 ### User-scoped stats key
 
-Change the shared factory to:
-
 ```ts
 srsKeys.stats(userId: string | null, jlpt?: number[])
+// ['srs', 'stats', userId, jlpt]
 ```
 
-It produces:
+The user ID is the cache correctness boundary; clearing is defense in depth. This slice changes only `stats`. Other SRS keys remain unscoped and must be revisited before mobile review uses them.
 
-```ts
-['srs', 'stats', userId, jlpt]
-```
+### Mobile API client and body timeout
 
-HPA-207 supplies the authenticated `MobileAuthUser.userId` and no JLPT filter. User identity in the key is the cache correctness boundary; cache clearing is defense in depth.
-
-This slice scopes only `stats`. `srsKeys.due()`, `srsKeys.progress()`, and `srsKeys.allProgress()` remain unchanged and must be revisited before the mobile review flow uses them.
-
-### Mobile API client and full-request timeout
-
-Create `apps/vela-mobile/src/services/mobile-api-client.ts`.
+Create `mobile-api-client.ts`:
 
 ```ts
 export type MobileApiErrorCode =
+  | 'invalid_request'
   | 'session_unavailable'
   | 'session_changed'
   | 'session_recovery_pending'
@@ -409,41 +362,29 @@ export class MobileApiError extends Error {
   }
 }
 
-export const MOBILE_FEATURE_REQUEST_TIMEOUT_MS = MOBILE_AUTH_NETWORK_TIMEOUT_MS; // 15_000
+export const MOBILE_FEATURE_BODY_TIMEOUT_MS = MOBILE_AUTH_NETWORK_TIMEOUT_MS; // 15_000
 ```
 
-The client owns the timeout because it also consumes the JSON body. A coordinator timer cleared when headers arrive would not protect against a stalled or truncated response body.
-
-For each JSON request, the client:
-
-1. creates an internal `AbortController`;
-2. forwards caller abort to it;
-3. starts the 15-second timeout;
-4. delegates transport to the coordinator with the internal signal;
-5. reads the complete response body;
-6. parses/validates the result; and
-7. clears the timer and abort listener in `finally`.
+The client creates a caller-linked controller before invoking the coordinator. After the coordinator returns the final `Response`, it starts a fresh 15-second body-read timer and keeps it active until JSON consumption completes. Aborting that controller cancels a stalled/truncated body stream.
 
 Classification:
 
-| Outcome | Client classification |
+| Outcome | Client code |
 | --- | --- |
-| Caller abort | Preserve cancellation; no visible error |
-| Timeout during transport or body read | `network` |
-| `session_unavailable` | Same code |
-| `session_changed` | Same code |
-| `session_recovery_pending` | Same code |
-| Invalid path/header | `invalid_response`; in development log only a stable defect code, never headers/tokens/raw response |
+| Caller abort | Preserve cancellation |
+| Coordinator `request_timeout` or body timeout | `network` |
+| Invalid path/header | `invalid_request`; stable development diagnostic only, no path/header/token dump |
+| Session codes | Preserve `session_unavailable`, `session_changed`, or `session_recovery_pending` |
 | Final 401 | `unauthorized` |
 | 403 | `forbidden` |
 | Other non-2xx | `server` |
-| Invalid JSON/stats shape | `invalid_response` |
+| Invalid JSON/stats | `invalid_response` |
 
-Timeout abort must not cancel a shared coordinator auth-recovery promise; it only stops that feature caller from waiting and prevents its feature retry/body read.
+Body timeout/caller cleanup removes timer and listeners. It does not cancel coordinator recovery already shared by peers.
 
 ### Mobile SRS service and provisioning
 
-Create `apps/vela-mobile/src/services/mobile-srs.ts`:
+Create `mobile-srs.ts`:
 
 ```ts
 export type MobileSrsService = {
@@ -451,7 +392,7 @@ export type MobileSrsService = {
 };
 ```
 
-`getStats()` calls `srs/stats`, forwards the signal, and runs `parseSrsStats()`.
+`getStats()` calls `srs/stats`, forwards the signal, and validates with `parseSrsStats()`.
 
 Create `mobile-services.ts` with typed injection keys and:
 
@@ -462,13 +403,11 @@ export function provideMobileServices(
 ): void;
 ```
 
-The existing `mobile-auth` boot creates/provides the coordinator, calls `provideMobileServices(app, coordinator)` directly, then starts initialization. `mobile-services.ts` does not use `inject()` and does not import the QueryClient.
+`mobile-auth` boot creates/provides the coordinator, passes it directly to `provideMobileServices()`, then initializes. No cross-boot `inject()` and no QueryClient import in service provisioning.
 
 ### QueryClient bootstrap and wiring
 
-Add `@vela/common` and `@tanstack/vue-query` to `@vela/mobile`.
-
-Create `src/boot/query.ts`:
+Add `@vela/common` and `@tanstack/vue-query` to mobile.
 
 ```ts
 export const mobileQueryClient = createQueryClient();
@@ -488,17 +427,13 @@ capacitor-lifecycle (Capacitor only)
 diagnostic-cold-entry (development only)
 ```
 
-Wiring is explicit:
+- auth isolation imports `mobileQueryClient`;
+- Vue Query composables receive that instance through the plugin;
+- lifecycle imports only `focusManager`;
+- coordinator/SRS service use typed Vue injection for consumers; and
+- service provisioning receives the coordinator directly.
 
-- auth isolation imports the `mobileQueryClient` singleton;
-- Vue Query composables receive the same instance through `VueQueryPlugin`;
-- native lifecycle imports only `focusManager`;
-- coordinator and SRS service use typed Vue injection for components/composables; and
-- service provisioning receives the coordinator directly rather than attempting cross-boot `inject()`.
-
-### Due-count query and automatic retry policy
-
-Create `useDueReviewCount.ts`.
+### Due-count query and automatic retry
 
 ```ts
 const DUE_COUNT_RETRY_LIMIT = 2;
@@ -512,8 +447,6 @@ export function retryDueCountQuery(failureCount: number, error: unknown): boolea
 }
 ```
 
-The query uses:
-
 ```ts
 useQuery({
   queryKey: computed(() => srsKeys.stats(userId.value)),
@@ -525,73 +458,61 @@ useQuery({
 });
 ```
 
-Only network/server failures receive up to two TanStack retries. Auth/control-flow, authorization, cancellation, and validation failures do not.
+Only network/server receive two automatic retries. Auth/control-flow, cancellation, authorization, invalid request, and invalid response do not.
 
 ### Session-race and pending-recovery query behavior
 
-`fetchStatsWithSessionRaceRecovery(signal)` captures the current user ID and performs one service call.
+`fetchStatsWithSessionRaceRecovery()` captures user ID.
 
 For `session_changed` or `session_unavailable`:
 
-- if the caller is not aborted, the same user is still authenticated, and `sessionUsable` is true, silently retry once;
-- otherwise rethrow and allow the auth gate/query enablement to remove the content path; and
-- never perform more than one silent control-flow retry per query execution.
+- if not aborted, same user remains authenticated, and session is usable, silently retry once;
+- otherwise rethrow for gate/query enablement; and
+- never exceed one silent control-flow retry per query execution.
 
-If the one silent retry also returns a control-flow error while Home remains usable, it escapes to the selector as a safe generic blocking/cached failure with manual Retry. The view must never settle into an empty, non-fetching, non-error state.
+If that retry also fails while Home remains usable, show generic blocking/cached failure with manual Retry. Never leave an empty, settled, invisible-error state.
 
 For `session_recovery_pending`:
 
-- do not immediately retry the feature request;
-- retain cached count data if present;
-- with no cached data, remain in an accessible loading/recovery state;
-- watch the coordinator’s retry tuple (`sessionUsable`, user ID, `retryAction`, `operation`, and `errorCode`);
-- when auth recovery later succeeds for the same user (`sessionUsable`, idle operation, no retry action/error), refetch once; and
-- if auth becomes unusable, let `MobileAuthGate` replace Home.
-
-This distinguishes a settled feature request from an auth recovery that continues independently.
+- do not immediately retry;
+- with cache, select normal zero/positive content without a Home-specific error—the auth gate’s retry banner owns the recovery message;
+- without cache, show accessible session-recovery loading;
+- watch `sessionUsable`, user ID, `retryAction`, `operation`, and `errorCode`;
+- after successful recovery for the same user (usable, idle, no retry/error), refetch once; and
+- if auth becomes unusable, let the gate replace Home.
 
 ### Native foreground integration
 
-Extend `capacitor-lifecycle` to subscribe to `appStateChange`:
+Extend `capacitor-lifecycle`:
 
 ```ts
 focusManager.setFocused(event.isActive);
 ```
 
-Keep existing resume diagnostics. No polling or background task is added.
+Keep resume diagnostics. No polling/background task.
 
 ### Auth and cache isolation
 
-Install `mobile-query-auth-isolation.ts` once from `App.vue` with the injected coordinator and imported `mobileQueryClient`.
+Install once from `App.vue` with injected coordinator and imported `mobileQueryClient`.
 
-Rules:
+1. Enable queries only with usable auth/user ID.
+2. Usable-to-unusable stops data selection immediately.
+3. Sign-out, terminal cleanup, or identity change cancels queries.
+4. Remove cache only after cancellation settles.
+5. Failed durable cleanup still leaves cache cleared.
+6. Soft refresh failure retains cache while prior session is usable.
+7. Backgrounding does not clear.
 
-1. Queries enable only with usable auth and user ID.
-2. Usable-to-unusable immediately stops authenticated data selection.
-3. Sign-out start, terminal cleanup start, or identity change cancels in-flight queries.
-4. Cache removal runs after cancellation settles.
-5. Failed durable cleanup still leaves query data cleared.
-6. Soft refresh failure does not clear while the prior verified session remains usable.
-7. Ordinary backgrounding does not clear.
+A non-401 may return after generation change; cancellation and canceled-query semantics prevent repopulation after identity loss.
 
-A non-401 response may legally return after a generation change; cancellation, abort propagation, and TanStack’s canceled-query semantics prevent it from repopulating removed cache state.
+### Manual retry, view selector, and Home
 
-### Manual retry versus background refresh
-
-The composable owns `manualRetryPending`.
-
-`retry()` prevents concurrent manual retries, preserves the current error surface, sets `manualRetryPending`, awaits `query.refetch()`, and clears the flag in `finally`.
+The composable owns `manualRetryPending`:
 
 ```ts
 retrying = manualRetryPending;
 refreshing = query.isFetching && query.data !== undefined && !manualRetryPending;
 ```
-
-Automatic mount/focus refetch keeps cached content visible with a subtle refresh status. Manual retry keeps the prior error surface visible with a disabled/loading Retry button.
-
-### Home view selector
-
-Create a pure exhaustive selector:
 
 ```ts
 type DueReviewView =
@@ -604,162 +525,127 @@ type DueReviewView =
 
 Rules:
 
-- no data plus initial fetch produces `loading`;
-- no data plus `session_recovery_pending` produces `loading` with `recoveringSession: true`;
-- zero/positive data remain visible during background fetch;
-- network/server/control-race failure with no data produces `blocking_error`;
-- failed refetch with cached data, including `0`, produces `cached_error`;
-- invalid request defects are generic and non-retryable;
-- manual retry preserves the corresponding error kind with `retrying: true`;
-- caller cancellation produces no visible error; and
-- unauthorized is never a Home view because the gate removes authenticated content.
+- initial no-data fetch -> loading;
+- no data plus pending auth recovery -> recovery loading;
+- pending auth recovery with cache -> zero/positive, no Home error;
+- zero/positive remains during background fetch;
+- retryable failure without/with cache -> blocking/cached error;
+- `invalid_request` -> generic non-retryable defect;
+- `invalid_response` -> generic manually retryable failure;
+- repeated control-race failure while still usable -> generic manually retryable failure;
+- cancellation -> no visible error;
+- unauthorized -> gate removes Home.
 
-A cached zero retains the stale-data warning because due state changes with time and cross-client progress.
+Home copy/semantics:
 
-### Home presentation
+- loading: “Loading your review count…” (`role=status`, polite live region);
+- auth recovery: “Refreshing your session…”;
+- zero: prominent `0`, “You’re caught up for now.”;
+- positive: prominent count with singular/plural copy;
+- background refresh: keep count, “Refreshing review count…”;
+- blocking network failure: alert + Retry;
+- cached failure, including cached `0`: keep count, “This count may be out of date.” + Retry;
+- manual retry: preserve error surface and disable/loading Retry;
+- invalid request defect: generic alert without misleading Retry;
+- unauthorized: no Home message;
+- no Start Review or scaffold version/environment content.
 
-Replace the scaffold with a focused “Today’s review” surface.
+## Error Handling Summary
 
-- **Loading:** “Loading your review count…” with `role="status"` and `aria-live="polite"`.
-- **Session recovery without data:** “Refreshing your session…” with the same status semantics.
-- **Zero:** prominent `0`; “You’re caught up for now.”
-- **Positive:** prominent count with singular/plural copy.
-- **Background refresh:** keep count visible; “Refreshing review count…” status.
-- **Blocking network failure:** alert, connection-aware copy, Retry.
-- **Cached failure:** keep count visible; “This count may be out of date.”; Retry.
-- **Manual retry:** preserve error surface; disable/loading Retry; accessible label “Retrying review count.”
-- **Non-retryable defect:** generic safe alert without a misleading Retry action.
-- **Unauthorized:** no Home-specific message; auth gate replaces Home.
-
-Do not add Start Review.
-
-## Error Handling
-
-### Non-401 response during refresh promotion
-
-Return it normally. A generation change alone does not invalidate a successful or feature-level error response.
-
-### Stale-generation 401
-
-Return `session_changed` without cleanup. The composable silently retries once for the same usable user; if the race repeats, it presents a recoverable generic state rather than going blank.
-
-### Concurrent current-generation 401
-
-Share one refresh/cleanup decision. Peer requests wait on it, then each retries once after refresh or returns its own final 401 after terminal cleanup.
-
-### Transient refresh failure
-
-Return `session_recovery_pending` when the current refresh attempt settles. Preserve durable credentials and the coordinator retry state. Do not wait indefinitely for a later auth retry.
-
-### Network timeout
-
-The mobile API client aborts after 15 seconds across transport and body reading and classifies the timeout as `network`. Caller abort remains cancellation.
-
-### Invalid request or API shape
-
-Invalid caller path/header is a programmer defect: preserve a dedicated coordinator code, emit only a stable development diagnostic, show generic non-retryable copy, and never log token-bearing data. Invalid server JSON/stats is `invalid_response` and may be manually retried.
-
-### Sign-out during request
-
-Sign-out makes auth unusable, cancels query work, then clears cache. A late non-401 response does not mutate auth; cancellation prevents it from repopulating the canceled query. A late 401 cannot clean up a replacement generation.
+- **Non-401 during promotion:** return normally.
+- **Stale 401:** `session_changed`, no cleanup; silent same-user retry once.
+- **Concurrent current 401s:** one recovery decision; each request retries once or returns own final 401.
+- **Transient refresh failure:** `session_recovery_pending`; preserve credential and retry state; settle promptly.
+- **Transport/body timeout:** `network`; caller abort remains cancellation.
+- **Invalid request:** dedicated feature code, stable dev diagnostic, non-retryable UI.
+- **Invalid API payload:** `invalid_response`, not cached, safe generic copy.
+- **Sign-out race:** cancel then clear; late non-401 cannot mutate auth, late 401 cannot clean replacement session.
 
 ## Testing Strategy
 
 ### Shared package
 
-- Parse complete production response.
-- Reject missing, negative, fractional, and non-finite required fields.
-- Reject accuracy outside 0–100.
+- Parse complete production response and reject invalid fields.
 - Ignore unknown fields.
-- Produce distinct stats keys for users/JLPT filters.
-- Confirm package header includes contracts.
+- Distinguish users/JLPT filters in stats key.
+- Confirm package header covers contracts.
 - Document that non-stats SRS keys remain unscoped.
 
 ### Auth coordinator
 
-- Apply ID token to allowed relative path.
-- Share URL builder between `auth/session` and `srs/stats`.
-- Reject absolute, scheme-relative, root-relative, backslash, traversal, outside-prefix, and `/api-evil/` paths.
-- Reject every case variant of Authorization before network activity.
-- Reject dispatch without usable session.
-- Preserve caller abort.
-- Propagate transport rejection without generation mutation.
-- **Return an in-flight 200 after concurrent soft-refresh promotion.**
-- **Return an in-flight 500 after concurrent soft-refresh promotion.**
-- **Return `session_changed` for an in-flight 401 after promotion without cleaning the new session.**
-- Join an already-running refresh before deciding a current 401 is terminal.
-- Concurrent expired-token 401s start one refresh and each feature request retries at most once.
-- Concurrent still-valid-token 401s perform one terminal cleanup.
-- One caller abort does not cancel shared recovery for peers.
-- A transient shared refresh failure settles all waiters as `session_recovery_pending` without cleanup.
-- A terminal shared result returns each request’s final 401.
-- Keep 403 feature-scoped.
-- Keep secrets out of logs/errors.
+- Apply ID token to allowed path.
+- Share URL builder across session/stats.
+- Reject all path escape classes and `/api-evil/` boundary bypass.
+- Reject every Authorization case variant.
+- Reject without usable session.
+- Caller abort versus attempt timeout are distinguishable.
+- Transport failure does not trigger generation mutation.
+- **In-flight 200 survives soft-refresh promotion.**
+- **In-flight 500 survives soft-refresh promotion.**
+- **In-flight 401 after promotion returns `session_changed` and does not clean new session.**
+- Join an already-running refresh.
+- Concurrent expired-token 401s start one refresh and each retry at most once.
+- Concurrent valid-token 401s perform one cleanup.
+- One caller abort does not cancel peer recovery.
+- Transient shared refresh failure settles all waiters as `session_recovery_pending` without cleanup.
+- Terminal result returns each final 401.
+- Keep 403 feature-scoped and secrets out of errors/logs.
 
-### Mobile API and SRS services
+### Mobile API/SRS services
 
-- Map every coordinator code.
-- Transport stall times out as network.
-- Response-body stall times out as network.
-- Caller abort before timeout remains cancellation.
-- Timeout/caller cleanup removes timer and signal listeners.
-- Timeout of one caller does not cancel shared auth recovery.
-- Parse successful JSON and validate full stats.
-- Classify 401, 403, other non-2xx, invalid JSON, and invalid stats.
-- Forward exact `srs/stats` path and signal.
-- Provision services without cross-boot injection.
+- Map every coordinator code, including `invalid_request` and timeout.
+- Transport stall -> network.
+- Body stall -> network.
+- Caller abort -> cancellation.
+- Timer/listener cleanup.
+- Body timeout does not cancel peer auth recovery.
+- Parse/validate JSON and classify HTTP/errors.
+- Forward exact path/signal.
+- Provision without cross-boot injection.
 
-### Query, auth recovery, and retry policy
+### Query/recovery/retry
 
-- QueryClient singleton and plugin use the same instance.
-- Boot order is `main`, `query`, `mobile-auth`, then conditional boots.
-- Retry predicate permits exactly two network/server retries and rejects all other codes.
-- First `session_changed` for same usable user silently retries once.
-- Repeated `session_changed` never leaves a blank state.
-- Recoverable `session_unavailable` silently retries once after the same user becomes usable.
-- `session_recovery_pending` with cache retains data and waits for auth recovery.
-- `session_recovery_pending` without cache renders accessible recovery loading.
-- Successful later auth retry triggers one due-count refetch.
-- Auth becoming unusable removes Home instead of surfacing a feature error.
+- QueryClient singleton/plugin identity and boot order.
+- Exact two-retry network/server predicate; all other codes false.
+- First same-user `session_changed` silently retries once.
+- Repeated control race produces visible manual recovery, never blank UI.
+- Recoverable `session_unavailable` retries once.
+- Pending recovery with cache retains count and uses auth banner.
+- Pending recovery without cache shows recovery loading.
+- Successful later auth retry refetches once.
+- Unusable auth removes Home.
 
-### Lifecycle, cache, and UI
+### Lifecycle/cache/UI
 
-- `focusManager` receives inactive/active transitions.
-- Foreground refetch occurs only for enabled query.
+- Native focus updates and enabled-only refetch.
 - Sign-out/terminal cleanup cancel before clear.
-- Failed durable cleanup still clears data.
-- Soft refresh failure with usable session retains cache.
-- Identity change cannot select previous-user data.
-- Manual retry and background refresh use distinct flags.
-- Loading, recovery loading, zero, singular, plural, blocking error, cached error, retrying, and non-retryable defect states are accessible.
-- Cached positive and cached zero show stale warning after failed refetch.
-- No Start Review or scaffold content.
+- Soft refresh failure retains usable cache.
+- Identity change cannot select previous data.
+- Manual/background flags are distinct.
+- All loading, zero, positive, error, retry, stale, recovery, and defect states are accessible.
+- Cached positive and zero both show stale warning after failed refetch.
+- No Start Review/scaffold content.
 
-## Manual Verification Matrix
-
-Record account, build/environment, device, timestamp, comparison value, and result.
+## Manual Verification Matrix and Gates
 
 | Scenario | Expected result |
 | --- | --- |
-| Fresh sign-in | Google sign-in opens Home and fetches authenticated count |
-| Relaunch restoration | Force-close/reopen restores without another Google prompt |
-| Positive due count | Mobile matches web/API for same account and timestamp |
-| Zero due count | Home shows `0` and caught-up copy |
-| Network failure | Auth remains safe; retryable Home failure appears |
-| Retry | Connectivity restoration plus Retry loads count |
-| Background/resume | Returning active refetches count |
-| Soft auth-refresh failure | Existing count remains when prior session is usable; auth retry can recover |
-| Rejected token | Protected Home disappears and authentication is shown |
-| Sign-out | Home data is removed immediately; relaunch remains signed out |
-| Account isolation | Later sign-in never displays prior account count |
+| Fresh sign-in | Home fetches authenticated count |
+| Relaunch restoration | Restores without another Google prompt |
+| Positive/zero | Mobile agrees with web/API and renders correct copy |
+| Network failure/retry | Safe retryable failure then successful Retry |
+| Background/resume | Active transition refetches |
+| Soft auth-refresh failure | Cached count remains if session usable; auth recovery can refetch |
+| Rejected token | Home disappears and authentication is shown |
+| Sign-out/account isolation | Data clears immediately; later account never sees it |
 | iOS Simulator | Complete flow passes before implementation PR merge |
-| Physical development iPhone | Complete flow passes before HPA-207 is closed |
+| Physical iPhone | Complete flow passes before HPA-207 closes |
 
-Automated checks and the configured Simulator flow are merge gates. The physical-iPhone run is a closure gate: implementation may merge after the merge gates pass, but HPA-207 must remain open until device evidence is recorded.
+Automated checks and Simulator flow are merge gates. Physical-device evidence is a closure gate: implementation may merge after merge gates pass, but HPA-207 remains open until device verification is recorded.
 
 ## Expected File Boundaries
 
-### Shared contract and key
+### Shared
 
 - Create: `packages/common/src/contracts/srs.ts`
 - Create: `packages/common/src/contracts/srs.test.ts`
@@ -769,7 +655,7 @@ Automated checks and the configured Simulator flow are merge gates. The physical
 - Modify: `apps/vela/src/services/srsService.ts`
 - Modify: `apps/vela/src/services/srsService.test.ts`
 
-### Mobile dependencies and boot
+### Mobile boot/dependencies
 
 - Modify: `apps/vela-mobile/package.json`
 - Modify: `bun.lock`
@@ -782,15 +668,12 @@ Automated checks and the configured Simulator flow are merge gates. The physical
 - Modify: `apps/vela-mobile/src/boot/mobile-auth.ts`
 - Modify: `apps/vela-mobile/src/boot/mobile-auth.test.ts`
 
-### Authenticated request boundary
+### Auth/services
 
 - Modify: `apps/vela-mobile/src/auth/mobile-auth-contract.ts`
 - Modify: `apps/vela-mobile/src/services/mobile-auth.ts`
 - Modify: `apps/vela-mobile/src/services/mobile-auth.test.ts`
 - Modify: `apps/vela-mobile/src/test/secret-leak-helpers.ts`
-
-### Mobile services
-
 - Create: `apps/vela-mobile/src/services/mobile-api-client.ts`
 - Create: `apps/vela-mobile/src/services/mobile-api-client.test.ts`
 - Create: `apps/vela-mobile/src/services/mobile-srs.ts`
@@ -798,7 +681,7 @@ Automated checks and the configured Simulator flow are merge gates. The physical
 - Create: `apps/vela-mobile/src/services/mobile-services.ts`
 - Create: `apps/vela-mobile/src/services/mobile-services.test.ts`
 
-### Query and presentation
+### Query/presentation
 
 - Create: `apps/vela-mobile/src/services/mobile-query-auth-isolation.ts`
 - Create: `apps/vela-mobile/src/services/mobile-query-auth-isolation.test.ts`
@@ -811,59 +694,39 @@ Automated checks and the configured Simulator flow are merge gates. The physical
 - Modify: `apps/vela-mobile/src/pages/HomePage.vue`
 - Modify: `apps/vela-mobile/src/pages/HomePage.test.ts`
 
-## Acceptance-Criteria Mapping
+## Acceptance Mapping
 
-| Acceptance criterion | Design coverage |
+| Criterion | Coverage |
 | --- | --- |
-| Returning user reaches Home through restored auth | HPA-206 gate plus enabled query after usable session |
-| Home displays `/api/srs/stats` due count | Mobile SRS service and Home selector |
-| Expired/rejected token cannot expose another user’s data | 401-only generation guards, shared recovery, user-scoped key, cancellation, and cache cleanup |
-| Loading, empty, failure, and retry states are accessible | Exhaustive view union including auth-recovery loading and manual retry |
-| Signing out clears user data | Cancel then clear QueryClient |
+| Restored user reaches Home | HPA-206 gate + enabled query |
+| Home displays stats count | Mobile SRS service + selector |
+| Rejected/expired token cannot leak another user’s data | 401-only generation guard, shared recovery, user key, cancellation, cache clear |
+| Accessible loading/empty/failure/retry | Exhaustive view including auth recovery and manual retry |
+| Sign-out clears user data | Cancel then clear |
 | Count agrees with web/API | Manual matrix |
-| Tests cover primary states and auth/cache isolation | Shared, concurrency, timeout, query, cache, and component suites |
-| Simulator and physical iPhone verification | Simulator merge gate plus device closure gate |
+| Tests cover states/isolation | Concurrency, timeout, service, query, cache, UI suites |
+| Simulator/device verification | Merge gate + closure gate |
 
 ## Risks and Mitigations
 
-### Successful response discarded by soft refresh
-
-Return non-401 responses before generation comparison. Generation guards only auth-mutating 401 paths.
-
-### Concurrent 401s duplicate cleanup or refresh
-
-Use one recovery promise per owner/generation, reuse `refreshPromise`, and permit one terminal cleanup.
-
-### Feature request hangs
-
-Keep the client timeout active through body consumption. Shared auth-recovery waiters settle on the current attempt rather than waiting for later retries.
-
-### Transient refresh failure destroys credential
-
-Return `session_recovery_pending`, preserve HPA-206 retry state, and never terminally clean up due solely to transport/server refresh failure.
-
-### Previous-user cache flashes after sign-in
-
-User-scope the key, disable without usable identity, and cancel then clear on identity loss.
-
-### Token leakage or API-prefix escape
-
-Keep bearer application inside the coordinator, reject Authorization overrides case-insensitively, use parsed pathname boundaries, and extend secret-leak tests.
-
-### Scope grows into review execution
-
-Home presents count/status only. Due-card retrieval and review navigation remain later work.
+- **Successful response discarded during refresh:** return non-401 before generation comparison.
+- **Duplicate refresh/cleanup:** one recovery promise per owner/generation.
+- **Hanging feature request/body:** bounded transport attempts, bounded body read, bounded existing auth operations.
+- **Transient refresh deletes credential:** settle as pending recovery; retain HPA-206 state/credential.
+- **Previous-user cache flash:** user key, disable, cancel then clear.
+- **Token/path leakage:** coordinator-owned bearer, header rejection, parsed path boundaries, secret-leak tests.
+- **Scope expansion:** count/status only; review execution later.
 
 ## Implementation Sequence
 
-1. Shared SRS contract, package description, and user-scoped stats key.
-2. Shared API URL normalization and case-insensitive header ownership.
-3. Coordinator request contract, non-401 ordering, and single-flight 401 recovery.
-4. Mobile API timeout/error normalization and SRS service provisioning.
-5. QueryClient boot, exact retry predicate, and native focus bridge.
-6. Auth-driven cache isolation and pending-recovery refetch behavior.
-7. Due-count composable with silent race recovery and separate manual-retry state.
-8. Home selector/presentation and accessibility states.
-9. Simulator merge-gate evidence and physical-device closure evidence.
+1. Shared contract, package description, and user-scoped stats key.
+2. URL/header boundary and bounded feature transport.
+3. Non-401 ordering plus single-flight current-401 recovery.
+4. API body timeout/error normalization and SRS service provisioning.
+5. QueryClient boot, retry predicate, and native focus bridge.
+6. Cache isolation and pending-auth-recovery refetch.
+7. Composable control-race/manual-retry behavior and pure selector.
+8. Home presentation/accessibility.
+9. Simulator merge-gate and physical-device closure evidence.
 
-Each stage must leave existing web authentication, web SRS loading behavior, mobile OAuth restoration, and sign-out behavior unchanged except for the explicitly shared contract, package description, and stats-key signature.
+Each stage must leave existing web authentication, web SRS loading, mobile OAuth restoration, and sign-out behavior unchanged except for the shared contract, package description, and stats-key signature.

--- a/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
+++ b/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
@@ -72,7 +72,7 @@ The mobile app does not install TanStack Query, does not alias `@vela/common` to
 | Retry | Retry only `network` and `server`, at most twice |
 | Auth abstraction | Feature code consumes a stable session-capability selector, not raw auth operation/error fields |
 | Module resolution | Mobile Quasar and Vitest alias `@vela/common` to source while retaining the workspace dependency |
-| Cache isolation | User-scope keys; disable without usable identity; cancel then clear on sign-out/identity loss |
+| Cache isolation | User-scope keys; disable without a usable session; cancel then clear on sign-out/identity loss |
 | Foreground/Home refresh | Refetch on native foreground and every Home mount |
 | Manual retry | Track manual retry independently from background fetch |
 | Cached zero | Keep stale-data warning because time or another client can make reviews due |
@@ -501,8 +501,8 @@ export function selectMobileFeatureSessionStatus(
 The selector alone understands the auth state machine:
 
 - ordinary verified idle state -> `usable`;
-- refresh/persist/verify operation or retry state for an authenticated user -> `recovering`;
-- restoration, sign-out, cleanup, terminal state, or missing user -> `unavailable` unless the authenticated recovery state explicitly retains a usable prior session.
+- refresh/persist/verify operation or retry state for an authenticated user -> `recovering`, preserving whether the prior verified session remains usable;
+- restoration, sign-out, cleanup, terminal state, or missing user -> `unavailable`.
 
 `useDueReviewCount()` watches this semantic status. A transition from same-user `recovering` to `usable` triggers one refetch. This keeps the dependency one-directional without introducing a feature-specific event API into the coordinator.
 
@@ -521,9 +521,17 @@ export function retryDueCountQuery(failureCount: number, error: unknown): boolea
 ```
 
 ```ts
+const queryEnabled = computed(
+  () =>
+    sessionStatus.value.kind === 'usable' ||
+    (sessionStatus.value.kind === 'recovering' && sessionStatus.value.sessionUsable),
+);
+
 useQuery({
-  queryKey: computed(() => srsKeys.stats(userId.value)),
-  enabled: computed(() => sessionStatus.value.kind !== 'unavailable'),
+  queryKey: computed(() =>
+    srsKeys.stats(sessionStatus.value.kind === 'unavailable' ? null : sessionStatus.value.userId),
+  ),
+  enabled: queryEnabled,
   queryFn: ({ signal }) => fetchStatsWithSessionRaceRecovery(signal),
   refetchOnMount: 'always',
   refetchOnWindowFocus: 'always',
@@ -541,14 +549,14 @@ For `session_changed` or a dispatch-time `session_unavailable` race:
 
 If the silent retry repeats while Home remains usable, show a generic manual-recovery error. Never leave an empty, settled, invisible-error state.
 
-For `session_recovery_pending`:
+For `session_recovery_pending` while the prior session is still usable:
 
 - do not immediately retry;
 - with cache, keep normal zero/positive content and let the auth gate/banner own recovery messaging;
 - without cache, show accessible session-recovery loading;
 - watch only `MobileFeatureSessionStatus`;
 - after same-user `recovering -> usable`, refetch once; and
-- if status becomes unavailable, let the gate replace Home.
+- if the selector becomes unavailable or recovering-but-unusable, disable the query and let the gate replace Home.
 
 ### Native foreground integration and cache isolation
 
@@ -562,11 +570,11 @@ Keep existing resume diagnostics. Add no polling or background task.
 
 Install auth/cache isolation once from `App.vue` using the injected coordinator and imported `mobileQueryClient`:
 
-1. Enable authenticated queries only for a usable/recovering identified user as defined above.
-2. Sign-out, terminal cleanup, or identity change cancels in-flight queries.
-3. Await cancellation before cache removal.
+1. Enable authenticated queries only for `usable` or `recovering` with `sessionUsable: true`.
+2. Sign-out, terminal cleanup, unusable recovery, or identity change cancels in-flight queries.
+3. Await cancellation before cache removal for sign-out, terminal cleanup, or identity change.
 4. Failed durable cleanup still leaves cache cleared.
-5. Soft refresh failure retains cached data while the prior session remains usable.
+5. Soft refresh failure retains cached data only while the prior session remains usable.
 6. Backgrounding does not clear.
 
 A non-401 may return after generation promotion; canceled-query semantics and user-scoped keys prevent repopulation after identity loss.
@@ -592,15 +600,15 @@ type DueReviewView =
 Rules:
 
 - initial no-data fetch -> loading;
-- no data plus pending auth recovery -> recovery loading;
-- pending recovery with cache -> zero/positive, no Home-specific error;
+- no data plus usable pending auth recovery -> recovery loading;
+- usable pending recovery with cache -> zero/positive, no Home-specific error;
 - zero/positive remains during background fetch;
 - retryable failure without/with cache -> blocking/cached error;
 - `invalid_request` -> generic non-retryable defect;
 - `invalid_response` -> generic manually retryable failure;
 - repeated control race while usable -> generic manually retryable failure;
 - caller cancellation -> no visible error; and
-- unauthorized -> gate removes Home.
+- unauthorized/unusable auth -> gate removes Home.
 
 Home copy and semantics:
 
@@ -623,7 +631,7 @@ Home copy and semantics:
 - Parse complete production response and reject invalid fields.
 - Ignore unknown fields.
 - Distinguish users and JLPT filters in the stats key.
-- Assert the identity-warning comment remains adjacent to unscoped sibling SRS keys.
+- Add and review the source warning immediately beside the identity-unscoped sibling SRS keys; do not add a brittle test that asserts comment text.
 - Confirm `@vela/common` source aliases in mobile Quasar and Vitest config.
 - Run mobile tests from `apps/vela-mobile` without a prebuilt `packages/common/dist`.
 - Confirm the common package header covers domain contracts.
@@ -671,15 +679,16 @@ Home copy and semantics:
 
 - QueryClient singleton/plugin identity and boot order.
 - Exact two-retry network/server predicate; all other codes false.
+- Query is disabled for `unavailable` and `recovering` with `sessionUsable: false`.
 - First same-user session race silently retries once.
 - Repeated race produces visible manual recovery, never blank UI.
-- Pending recovery with cache retains count.
-- Pending recovery without cache shows recovery loading.
+- Usable pending recovery with cache retains count.
+- Usable pending recovery without cache shows recovery loading.
 - Same-user `recovering -> usable` refetches once.
 - Composable does not inspect raw auth operation/retry/error fields.
 - Native focus updates and enabled-only refetch.
 - Sign-out/terminal cleanup cancel before clear.
-- Soft refresh failure retains usable cache.
+- Soft refresh failure retains cache only while session remains usable.
 - Identity change cannot select previous data.
 - Manual/background flags are distinct.
 - All loading, zero, positive, error, retry, stale, recovery, and defect states are accessible.

--- a/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
+++ b/docs/superpowers/specs/2026-07-30-mobile-authenticated-due-review-count-design.md
@@ -10,24 +10,24 @@
 
 Deliver the smallest production-shaped Vela Mobile product flow: a returning iOS user restores a secure Cognito session, reaches Home, and sees the current authenticated `due_today` value returned by `GET /api/srs/stats`.
 
-This slice establishes the reusable mobile boundaries for authenticated feature requests and user-scoped server-state caching without importing the web Home page or exposing Cognito tokens to feature components.
+This slice establishes reusable mobile boundaries for authenticated feature requests and user-scoped server-state caching without importing the web Home page or exposing Cognito tokens to feature components.
 
 ## Current State
 
-HPA-204 established the native API environment contract, absolute mobile API base URL, and approved Capacitor CORS behavior.
+HPA-204 established the absolute mobile API base URL and approved Capacitor CORS behavior.
 
 HPA-206 established the single mobile Cognito session owner. The mobile auth coordinator now:
 
-- restores a Keychain-backed refresh credential during app initialization;
+- restores a Keychain-backed refresh credential during initialization;
 - keeps ID and access tokens in process memory only;
-- refreshes the active token bundle proactively and when the app resumes;
+- refreshes the active token bundle proactively and on app resume;
 - verifies candidate sessions through `/api/auth/session` before exposing protected content;
 - marks protected content usable only while a verified active bundle remains valid; and
 - clears local session material during sign-out or terminal credential failure.
 
-HPA-206 intentionally did not expose a general token accessor or authenticated feature client. Its only authenticated API call is the coordinator-owned `/api/auth/session` verification request. HPA-207 introduces that feature-request boundary.
+HPA-206 intentionally did not expose a general token accessor or authenticated feature client. HPA-207 introduces that feature-request boundary.
 
-The API already exposes `GET /api/srs/stats`. It applies the shared Cognito ID-token middleware and returns:
+The API already exposes `GET /api/srs/stats`. It applies Cognito ID-token middleware and returns:
 
 ```ts
 interface SRSStats {
@@ -45,47 +45,45 @@ interface SRSStats {
 }
 ```
 
-The web application owns an equivalent TypeScript interface and a web-specific SRS service. `@vela/common` already owns the shared `srsKeys` query-key factory, but its stats key is not currently scoped by authenticated user.
-
-The mobile Home route currently renders only the M1 scaffold identity and version. The mobile app does not yet install TanStack Query.
+The web application owns an equivalent interface and a web-specific SRS service. `@vela/common` already owns `srsKeys`, but its stats key is not scoped by authenticated user. The mobile app does not yet install TanStack Query, and Home still renders the M1 scaffold.
 
 ## Approved Decisions
 
 | Area | Decision |
 | --- | --- |
-| Product scope | Display only the authenticated due-review count and its required states |
-| Backend | Reuse the existing `GET /api/srs/stats` endpoint unchanged |
+| Product scope | Display only the authenticated due-review count and required states |
+| Backend | Reuse `GET /api/srs/stats` unchanged |
 | Shared contract | Move the complete `SRSStats` response contract into `@vela/common` |
-| Contract validation | Parse the complete stats payload at the mobile service boundary before caching it |
+| Contract validation | Parse the complete payload at the mobile service boundary before caching |
 | Token ownership | ID tokens remain private to the mobile auth coordinator |
-| Feature request surface | Add a coordinator-owned authenticated API request operation; do not add `getIdToken()` |
-| URL safety | Authenticated requests accept only paths beneath the configured Vela API base URL |
-| Unauthorized response | A current-session 401 enters auth recovery or terminal cleanup; Home never renders an unauthorized data error |
-| Expiry race | If the request token expires in flight, refresh and retry once before treating the session as unusable |
+| Feature request surface | Add a coordinator-owned authenticated request operation; do not add `getIdToken()` |
+| URL safety | Permit only paths beneath the configured Vela API base URL |
+| Unauthorized response | A current-session 401 enters auth recovery or terminal cleanup; Home never renders an unauthorized-data state |
+| Expiry race | If the request token expires in flight, refresh and retry once before declaring the session unusable |
 | Stale request race | A response from an older auth generation cannot invalidate a replacement session |
-| Server state | Install TanStack Query in the mobile application |
-| Query key | Include the authenticated user ID in the stats key |
+| Server state | Install TanStack Query in Vela Mobile |
+| Query key | Include authenticated user ID in the stats key |
 | Foreground refresh | Bridge native app active state to TanStack Query focus state |
-| Home re-entry refresh | Refetch whenever Home mounts, even if cached data is still fresh |
-| Cache isolation | Disable queries immediately when the session is unusable, user-scope every key, and clear mobile query state on sign-out or identity loss |
+| Home re-entry | Refetch whenever Home mounts, even if cached data is still fresh |
+| Cache isolation | Disable immediately when auth is unusable, user-scope keys, and clear mobile query state on sign-out or identity loss |
 | Cached refetch failure | Keep the last verified count visible with a non-blocking retry message |
 | Review navigation | Do not add a Start Review action in HPA-207 |
-| Platform | Native iOS remains the supported authenticated runtime for this milestone |
+| Platform | Native iOS remains the authenticated runtime for this milestone |
 
 ## Scope
 
 HPA-207 includes:
 
-- a shared SRS statistics contract;
-- a user-scoped SRS stats query key;
-- a coordinator-owned authenticated mobile request capability;
+- a shared SRS statistics contract and parser;
+- a user-scoped stats query key;
+- a coordinator-owned authenticated request capability;
 - a mobile JSON API client with normalized failures;
 - a mobile SRS stats service;
-- TanStack Query bootstrap for Vela Mobile;
+- TanStack Query bootstrap;
 - native foreground-to-query-focus integration;
-- authenticated query lifecycle and cache cleanup;
-- a minimal mobile Home due-count presentation;
-- unit and component coverage for service, query, auth isolation, and view states; and
+- auth-driven query lifecycle and cache cleanup;
+- a minimal Home due-count presentation;
+- unit/component tests for services, query behavior, auth isolation, and view states; and
 - Simulator and physical-device verification evidence.
 
 ## Non-goals
@@ -94,14 +92,12 @@ HPA-207 includes:
 - fetching individual due cards;
 - dashboard parity with the web application;
 - daily goals, streaks, mastery summaries, or learning shortcuts;
-- persistent offline query storage;
-- offline due-deck generation;
-- connectivity monitoring through a new native plugin;
-- background polling;
+- persistent offline query storage or offline due-deck generation;
+- a new connectivity plugin, background polling, or background tasks;
 - Android support;
 - remote Cognito global sign-out;
-- refactoring the web page into a shared presentation component; and
-- final mobile navigation or visual polish.
+- sharing the web Home presentation; and
+- final navigation or visual polish.
 
 ## Architecture
 
@@ -123,7 +119,7 @@ TanStack Query uses srsKeys.stats(userId)
 Mobile SRS service requests "srs/stats"
                     |
                     v
-Mobile API client asks coordinator to send authenticated request
+Mobile API client delegates authenticated transport
                     |
                     v
 Coordinator attaches current in-memory Cognito ID token
@@ -132,13 +128,13 @@ Coordinator attaches current in-memory Cognito ID token
 GET {VITE_MOBILE_API_URL}srs/stats
 ```
 
-The reverse auth-failure path is:
+The auth-failure path is:
 
 ```text
 Current authenticated request returns 401
                     |
                     v
-Coordinator validates request generation and token expiry
+Coordinator checks request generation and token expiry
                     |
           +---------+---------+
           |                   |
@@ -152,14 +148,14 @@ Refresh and retry once      Terminal session cleanup
 sessionUsable becomes false if recovery cannot continue
                     |
                     v
-MobileAuthGate hides Home and query cache is cleared
+MobileAuthGate hides Home and query state is cleared
 ```
 
 ### One token owner
 
 `apps/vela-mobile/src/services/mobile-auth.ts` remains the only owner of active Cognito token material.
 
-The public coordinator contract gains a request operation rather than a token accessor:
+The coordinator contract gains a request operation instead of a token accessor:
 
 ```ts
 export type MobileAuthenticatedApiRequest = {
@@ -181,32 +177,25 @@ export type MobileAuthCoordinator = {
 };
 ```
 
-Feature code never receives an ID token. The coordinator constructs the final request, applies `Authorization: Bearer <id-token>`, and performs the fetch through its injected transport.
+Feature code never receives an ID token. The coordinator constructs the request, owns `Authorization`, and performs the fetch through its injected transport.
 
-The request method rejects without network activity unless all of these are true:
+The method rejects without network activity unless the coordinator is initialized, not disposing, authenticated, session-usable, and backed by an active verified bundle and user.
 
-- the coordinator is initialized and not disposing;
-- `state.phase === 'authenticated'`;
-- `state.sessionUsable === true`;
-- an active verified bundle exists;
-- an authenticated user exists; and
-- the request path resolves beneath the configured API base URL.
-
-Callers cannot override `Authorization`. The coordinator owns that header even when other headers are supplied.
+Callers cannot override `Authorization`.
 
 ### URL containment
 
-The mobile API base URL is expected to end at the Vela API prefix, for example `https://vela.example/api/`.
+The mobile API base URL ends at the API prefix, for example `https://vela.example/api/`.
 
-`requestAuthenticatedApi()` accepts a relative feature path such as `srs/stats`. It rejects:
+`requestAuthenticatedApi()` accepts a relative path such as `srs/stats`. It rejects:
 
 - absolute URLs;
 - scheme-relative URLs;
-- paths beginning with `/` that could escape the configured `/api/` prefix;
+- root-relative paths that could escape `/api/`;
 - `.` or `..` path segments; and
-- any URL whose resolved origin or base-path prefix differs from `config.api.url`.
+- any result whose origin or base-path prefix differs from `config.api.url`.
 
-This validation prevents a future feature service from accidentally sending an ID token to an unrelated host or to a non-API route on the same host.
+This prevents a future feature service from sending an ID token to an unrelated host or non-API route.
 
 ### Auth generation and 401 handling
 
@@ -214,20 +203,20 @@ Every request captures the active session owner and `activeBundleGeneration` bef
 
 When the response arrives:
 
-1. If the coordinator has been disposed, the request is treated as cancelled.
-2. If the active owner or generation changed, the response belongs to a stale session. It is rejected without mutating current auth state.
-3. Any non-401 response is returned to the feature client.
-4. For a current-generation 401, the coordinator rechecks token expiry.
-5. If the captured ID token expired while the request was in flight, the coordinator queues the existing refresh path and retries the feature request once after successful verified promotion.
-6. If the token was still valid when rejected, or the single retry also returns 401, the coordinator performs terminal session cleanup.
-7. If refresh fails transiently, existing HPA-206 retry state is retained; protected content remains available only while an older verified token is still usable.
-8. If refresh proves the durable credential unusable, the existing terminal cleanup path returns the user to authentication.
+1. Disposal or caller abort terminates the request without auth mutation.
+2. If the active owner or generation changed, reject as a stale-session request without mutating current auth state.
+3. Return every non-401 response to the feature client.
+4. For a current-generation 401, recheck the captured token expiry.
+5. If the token expired in flight, queue the existing refresh path and retry the feature request once after verified promotion.
+6. If the token was still valid when rejected, or the one retry also returns 401, perform terminal session cleanup.
+7. If refresh fails transiently, retain the existing HPA-206 retry state. Protected content remains usable only while the prior verified token remains valid.
+8. If refresh proves the durable credential unusable, use the existing terminal cleanup path.
 
-The request method does not treat 403 as proof that the Cognito credential is invalid. A 403 remains an API authorization failure handled by the mobile API client.
+A 403 is not proof that the Cognito credential is invalid and remains a feature-level API error.
 
 ### Shared SRS contract
 
-Create `packages/common/src/contracts/srs.ts` and export:
+Create `packages/common/src/contracts/srs.ts`:
 
 ```ts
 export interface SRSStats {
@@ -247,20 +236,13 @@ export interface SRSStats {
 export function parseSrsStats(value: unknown): SRSStats;
 ```
 
-The parser enforces:
+The parser requires all count fields to be non-negative integers, `average_ease_factor` to be finite and non-negative, `accuracy_rate` to be finite and between 0 and 100, and every nested field to exist. Unknown additional fields are ignored.
 
-- all count fields are non-negative integers;
-- `average_ease_factor` is a finite non-negative number;
-- `accuracy_rate` is a finite number from 0 through 100; and
-- no required nested field is missing.
-
-Unknown additional fields are ignored so the API can add backward-compatible metadata later.
-
-The web SRS service imports and re-exports `SRSStats` from `@vela/common`, preserving the current service API while removing its duplicate contract.
+The web SRS service imports and re-exports `SRSStats`, preserving its public service type while removing the duplicate contract.
 
 ### User-scoped query key
 
-Change the shared stats key to:
+Change the shared key to:
 
 ```ts
 srsKeys.stats(userId: string | null, jlpt?: number[])
@@ -272,25 +254,23 @@ It produces:
 ['srs', 'stats', userId, jlpt]
 ```
 
-HPA-207 calls it with the authenticated `MobileAuthUser.userId` and no JLPT filter.
-
-The explicit user ID ensures that cached data for one identity cannot be selected by a component rendering another identity. This remains required even though sign-out also clears the cache: key isolation is the correctness boundary, while clearing is memory and defense-in-depth cleanup.
+HPA-207 supplies `MobileAuthUser.userId` and no JLPT filter. User identity in the key is the correctness boundary; cache clearing is defense-in-depth cleanup.
 
 ### Mobile API client
 
-Create a Vela-owned client in `apps/vela-mobile/src/services/mobile-api-client.ts`.
+Create `apps/vela-mobile/src/services/mobile-api-client.ts`.
 
-Its responsibilities are:
+It:
 
-- accept a relative API path and request options;
-- delegate authenticated transport to the coordinator;
-- request JSON through an explicit `Accept: application/json` header;
-- parse successful JSON bodies;
-- preserve the TanStack Query abort signal;
-- classify failures without UI copy; and
-- avoid logging request headers, token-bearing objects, or raw identity responses.
+- accepts a relative path and request options;
+- delegates authenticated transport to the coordinator;
+- sends `Accept: application/json`;
+- parses successful JSON;
+- preserves the TanStack Query abort signal;
+- classifies failures without UI copy; and
+- never logs authorization headers, token-bearing objects, or raw identity responses.
 
-Use a stable error union:
+Use this stable error union:
 
 ```ts
 export type MobileApiErrorCode =
@@ -303,23 +283,20 @@ export type MobileApiErrorCode =
   | 'invalid_response';
 ```
 
-`unauthorized` is observable for unit tests and non-visual control flow, but Home does not render it. The coordinator auth transition disables the query and the gate replaces Home.
-
-HTTP behavior:
-
-| Outcome | Client classification |
+| Outcome | Classification |
 | --- | --- |
-| Request aborted | Preserve abort semantics; do not show an error |
+| Caller abort | Preserve abort semantics; no visible error |
 | No usable session before dispatch | `session_unavailable` |
-| Session generation changes during request | `session_changed` |
-| Final 401 after coordinator recovery rules | `unauthorized` |
+| Session generation changes | `session_changed` |
+| Final 401 after coordinator recovery | `unauthorized` |
 | 403 | `forbidden` |
-| Fetch rejects without caller abort | `network` |
-| 5xx | `server` |
-| Other non-2xx | `server` for this read-only slice |
-| Invalid JSON or invalid stats shape | `invalid_response` |
+| Fetch rejection without caller abort | `network` |
+| Non-2xx other than 401/403 | `server` |
+| Invalid JSON or stats shape | `invalid_response` |
 
-### Mobile SRS service
+`unauthorized` exists for tests and control flow, but Home does not render it because the coordinator disables authenticated content.
+
+### Mobile SRS service and provisioning
 
 Create `apps/vela-mobile/src/services/mobile-srs.ts`:
 
@@ -329,23 +306,29 @@ export type MobileSrsService = {
 };
 ```
 
-`getStats()` calls `srs/stats`, forwards the abort signal, and runs `parseSrsStats()` before returning. No page component builds URLs, headers, or response shapes.
+`getStats()` calls `srs/stats`, forwards the abort signal, and runs `parseSrsStats()` before returning.
 
-The service is created from the authenticated API client during mobile boot and provided through a typed Vue injection key. Tests can provide a deterministic fake service without mocking global fetch.
+Create `apps/vela-mobile/src/services/mobile-services.ts` with typed injection keys and a provider function that accepts the already-created auth coordinator. The existing `mobile-auth` boot creates the coordinator, provides it, calls the mobile-services provider, and only then starts initialization. This avoids exposing a coordinator singleton or relying on cross-boot injection lookup.
+
+Tests can provide deterministic fake services without mocking global fetch.
 
 ### TanStack Query bootstrap
 
 Add workspace dependencies on `@vela/common` and `@tanstack/vue-query` to `@vela/mobile`.
 
-Create `apps/vela-mobile/src/boot/query.ts` to:
+Create `apps/vela-mobile/src/boot/query.ts` to create a QueryClient through `createQueryClient()`, install `VueQueryPlugin`, and export the mobile query client for lifecycle and auth-isolation wiring.
 
-- create a mobile QueryClient through the existing `createQueryClient()` factory;
-- install `VueQueryPlugin`; and
-- export the mobile query client for lifecycle and auth-isolation wiring.
+The boot order becomes:
 
-Add `query` before `mobile-auth` in `getMobileBootFiles()` so application components and later boot files can rely on the plugin.
+```text
+main
+query
+mobile-auth
+capacitor-lifecycle (Capacitor only)
+diagnostic-cold-entry (development only)
+```
 
-The due-count query overrides only the behavior specific to this product slice:
+All boot files finish before `App.vue` mounts. The due-count query overrides only slice-specific behavior:
 
 ```ts
 useQuery({
@@ -358,67 +341,46 @@ useQuery({
 });
 ```
 
-The shared five-minute stale and ten-minute garbage-collection defaults remain. `always` is intentional: the issue requires refresh on Home activation and foreground resume, even when the last result is younger than the shared stale window.
+The shared stale and garbage-collection defaults remain. `always` is required because Home activation and foreground resume must refresh even while data is nominally fresh.
 
-`retryDueCountQuery` retries network and server failures up to the shared query retry limit. It does not retry:
-
-- `session_unavailable`;
-- `session_changed`;
-- `unauthorized`;
-- `forbidden`;
-- `invalid_response`; or
-- caller cancellation.
+Automatic retries apply only to network and server failures, up to the shared retry limit. They do not apply to cancellation, session-unavailable, session-changed, unauthorized, forbidden, or invalid-response errors. A user may still manually retry visible `forbidden` or `invalid_response` failures; the distinction is that they are not repeated automatically.
 
 ### Native foreground integration
 
-The existing Capacitor lifecycle boot remains the single product-level bridge for native application activation.
-
-Extend it to subscribe to `appStateChange` and call:
+Extend the existing Capacitor lifecycle boot to subscribe to `appStateChange` and call:
 
 ```ts
 focusManager.setFocused(event.isActive);
 ```
 
-The existing resume diagnostics behavior remains available. The lifecycle adapter and tests cover both inactive and active transitions.
-
-TanStack Query then refetches the active due-count query when iOS returns Vela to the foreground. No polling or background task is added.
+Keep existing resume diagnostics behavior. Tests cover inactive and active transitions. No polling or background task is added.
 
 ### Auth and cache isolation
 
-Create `apps/vela-mobile/src/services/mobile-query-auth-isolation.ts` and install it once from `App.vue` after both the auth coordinator and QueryClient are available.
+Create `apps/vela-mobile/src/services/mobile-query-auth-isolation.ts` and install it once from `App.vue` after the QueryClient and coordinator have been provided.
 
-It watches the public auth tuple, especially:
+It watches `sessionUsable`, `user?.userId`, `operation`, and `phase`.
 
-- `state.sessionUsable`;
-- `state.user?.userId`;
-- `state.operation`; and
-- `state.phase`.
+Rules:
 
-Its rules are:
+1. Queries are enabled only with a usable session and user ID.
+2. A usable-to-unusable transition immediately stops Home from selecting authenticated data.
+3. Sign-out start, terminal cleanup start, or identity change cancels in-flight queries and clears the mobile QueryClient.
+4. Failed durable sign-out cleanup still leaves query data cleared.
+5. A soft in-session refresh failure does not clear while `sessionUsable` remains true.
+6. Ordinary backgrounding does not clear.
 
-1. Queries are enabled only while a usable session and user ID are present.
-2. A transition from usable to unusable immediately makes Home stop selecting authenticated query data.
-3. When sign-out starts, terminal cleanup starts, or identity changes, cancel all in-flight mobile queries.
-4. Clear the mobile QueryClient after cancellation.
-5. Never retain previous-user data for a later sign-in, including when durable sign-out cleanup fails.
-6. Do not clear the cache during a soft in-session refresh failure while `sessionUsable` remains true.
-7. Do not clear on ordinary backgrounding.
-
-Clearing the complete mobile QueryClient is acceptable in M1 because every current mobile server-state query is authenticated and user-specific. Later public or durable server-state slices can narrow the cleanup filters if necessary.
+Clearing the complete QueryClient is acceptable in M1 because all current mobile server state is authenticated and user-specific.
 
 ### Due-count composable
 
 Create `apps/vela-mobile/src/composables/useDueReviewCount.ts`.
 
-It injects the coordinator and mobile SRS service, derives the current user ID, and owns the TanStack query configuration. It returns query state and an explicit `retry()` action to the page.
+It injects the auth coordinator and SRS service, derives user ID, owns the query configuration, and returns query state plus an explicit `retry()` action. It contains no display copy and performs no navigation.
 
-The composable does not contain display copy and does not navigate. Unauthorized navigation remains the responsibility of `MobileAuthGate` through coordinator state.
+### Home view selector
 
-### Home view model
-
-Create a pure selector in `apps/vela-mobile/src/components/home/due-review-view.ts`.
-
-It converts query state into an exhaustive presentation union:
+Create `apps/vela-mobile/src/components/home/due-review-view.ts`:
 
 ```ts
 type DueReviewView =
@@ -429,199 +391,172 @@ type DueReviewView =
   | { kind: 'cached_error'; count: number; message: string; retrying: boolean };
 ```
 
-The selector never receives or returns `unauthorized`; those states remove the authenticated content surface.
+Rules:
 
-View rules:
-
-- no data plus pending fetch produces `loading`;
+- no data plus initial fetch produces `loading`;
 - `due_today === 0` produces `zero`;
 - `due_today > 0` produces `positive`;
-- a background refetch retains zero or positive content with `refreshing: true`;
-- a retryable failure with no data produces `blocking_error`;
-- a retryable refetch failure with cached data produces `cached_error`;
-- invalid-response and forbidden failures use a generic safe failure message and remain manually retryable only when the query policy permits a manual request; and
-- abort and session-change outcomes do not produce visible failures.
+- background fetch keeps zero/positive content with `refreshing: true`;
+- visible failure without data produces `blocking_error`;
+- visible refetch failure with cached data produces `cached_error`;
+- every non-auth visible failure offers manual Retry;
+- cancellation and session-change outcomes produce no visible failure; and
+- unauthorized is never a Home view because auth state removes the content surface.
 
 ### Home presentation
 
-Replace the M1 scaffold content in `HomePage.vue` with a focused “Today’s review” surface.
-
-Required states:
+Replace the M1 scaffold in `HomePage.vue` with a focused “Today’s review” surface.
 
 #### Initial loading
 
-- Show a spinner or skeleton.
-- Use `role="status"` and `aria-live="polite"`.
+- Spinner or skeleton.
+- `role="status"` and `aria-live="polite"`.
 - Copy: “Loading your review count…”
 
 #### Zero due
 
-- Display `0` prominently.
+- Prominent `0`.
 - Copy: “You’re caught up for now.”
-- Do not show a disabled or misleading review action.
+- No disabled or misleading review action.
 
 #### Positive due
 
-- Display the integer prominently.
-- Use singular copy for one item and plural copy for all other counts.
-- Example: “1 word is due for review” / “12 words are due for review.”
+- Prominent integer.
+- Singular/plural copy: “1 word is due for review” or “12 words are due for review.”
 
 #### Background refresh
 
 - Keep the last verified count visible.
-- Add a subtle `role="status"` indication: “Refreshing review count…”
+- Add `role="status"`: “Refreshing review count…”
 - Do not replace verified content with a blocking spinner.
 
 #### Blocking failure
 
-- Use `role="alert"` for the message.
+- `role="alert"`.
 - Network copy: “Vela couldn’t load your review count. Check your connection and try again.”
 - Other safe copy: “Vela couldn’t load your review count. Please try again.”
-- Show a Retry button.
+- Retry button.
 
 #### Cached refresh failure
 
 - Keep the last verified count visible.
-- Show a non-blocking alert: “This count may be out of date.”
-- Show Retry.
+- Non-blocking alert: “This count may be out of date.”
+- Retry button.
 
 #### Retrying
 
-- Disable the Retry button.
-- Set its loading state and accessible label to “Retrying review count.”
+- Disable Retry.
+- Loading state and accessible label: “Retrying review count.”
 
 #### Unauthorized
 
-- Render no Home-specific unauthorized message.
-- The coordinator makes the session unusable and `MobileAuthGate` returns the user to authentication.
+- No Home-specific message.
+- The coordinator makes the session unusable and `MobileAuthGate` returns to authentication.
 
-The page does not expose app version, environment, or scaffold labels after this change. Development diagnostics remain accessible from More.
+The page no longer displays app version, environment, or scaffold labels. Development diagnostics remain under More.
 
 ## Error Handling
 
 ### Network and server failures
 
-Network and 5xx failures do not mutate authentication state. They remain query errors and support manual retry. A cached value remains visible during a failed refetch.
+They do not mutate authentication state. They remain query errors and support manual retry. Cached verified data remains visible during a failed refetch.
 
 ### Invalid API shape
 
-An invalid stats payload is never cached. It becomes `invalid_response`, shows safe generic copy, and emits no raw response body to logs.
+Invalid stats are never cached. The client returns `invalid_response`, Home shows safe generic copy, and raw response content is not logged.
 
 ### Unauthorized session
 
-A final current-generation 401 is an auth concern, not a Home concern. The coordinator owns recovery and cleanup, the query becomes disabled, the cache is cleared, and the gate removes protected content.
+A final current-generation 401 is an auth concern. The coordinator owns recovery/cleanup, the query disables, the cache clears, and the gate removes protected content.
 
 ### Sign-out during request
 
-Sign-out increments the auth generation, marks the session unusable before cleanup, cancels query work, and clears cache state. A late response from the prior generation cannot repopulate or invalidate the current session.
+Sign-out increments auth generation, marks the session unusable before cleanup, cancels query work, and clears cache. A late prior-generation response cannot repopulate data or invalidate the current session.
 
 ### Identity replacement
 
-Although multi-account switching is outside the MVP, a later sign-in after sign-out receives a different user-scoped key. It cannot select previous-user data even if asynchronous cache cleanup has not completed.
+A later sign-in receives a different user-scoped key and cannot select previous-user data even if asynchronous cleanup has not completed.
 
 ## Testing Strategy
 
-### Shared package tests
+### Shared package
 
-Cover:
+- Parse a complete production-shaped response.
+- Reject missing, negative, fractional, or non-finite required values.
+- Reject accuracy outside 0–100.
+- Ignore unknown additional fields.
+- Produce distinct stats keys for distinct users and JLPT filters.
 
-- parsing a complete production-shaped stats response;
-- rejecting missing `due_today`;
-- rejecting negative and fractional count fields;
-- rejecting non-finite metrics;
-- rejecting accuracy outside 0–100;
-- ignoring unknown additional fields;
-- producing distinct stats keys for distinct users; and
-- preserving JLPT filter identity in the key.
+### Auth coordinator
 
-### Auth coordinator tests
+- Attach the current ID token to an allowed path.
+- Prevent Authorization override.
+- Reject absolute, scheme-relative, root-relative, traversal, and outside-prefix paths.
+- Reject without a usable session.
+- Preserve caller abort behavior.
+- Return non-401 responses without auth mutation.
+- Refresh and retry once when the token expires in flight.
+- Terminally clean up after a still-valid current token or refreshed retry is rejected.
+- Ignore an old-generation 401 for auth mutation.
+- Keep 403 feature-scoped.
+- Handle sign-out racing an in-flight request.
+- Keep token/header values out of logs and rendered errors.
 
-Cover:
+### Mobile API and SRS services
 
-- adding the current ID token to an allowed relative API request;
-- preventing callers from overriding `Authorization`;
-- rejecting absolute, scheme-relative, root-relative, traversal, and outside-prefix paths;
-- rejecting requests without a usable session;
-- preserving caller abort behavior;
-- returning non-401 responses without auth mutation;
-- refreshing and retrying once when a request token expires in flight;
-- terminal cleanup after a still-valid current token is rejected;
-- terminal cleanup after a refreshed retry is rejected;
-- retaining current auth state when an old-generation request returns 401;
-- not treating 403 as terminal Cognito failure;
-- sign-out racing an in-flight request; and
-- token and header values not appearing in logs or rendered errors.
+- Successful JSON parsing and full stats validation.
+- Network, 403, non-2xx, and invalid-response classification.
+- Cancellation and signal forwarding.
+- Exact `srs/stats` path.
+- Typed service provisioning from the coordinator.
 
-### Mobile API and SRS service tests
+### Query bootstrap and lifecycle
 
-Cover:
+- QueryClient installation and boot ordering.
+- `focusManager` inactive/active updates.
+- Foreground refetch for an enabled query.
+- No foreground fetch while signed out.
+- Existing lifecycle diagnostics remain intact.
 
-- successful JSON parsing;
-- full stats contract validation;
-- network classification;
-- 403, 5xx, and invalid-response classification;
-- caller cancellation;
-- signal forwarding; and
-- exact request path `srs/stats`.
+### Cache isolation
 
-### Query bootstrap and lifecycle tests
+- No query during restoration.
+- One initial query after restored authentication becomes usable.
+- User ID appears in the key.
+- Sign-out and terminal cleanup cancel and clear.
+- Soft refresh failure with a usable session retains cache.
+- Identity change cannot select previous-user data.
+- Failed durable cleanup still hides and clears due-count data.
 
-Cover:
+### Home component
 
-- mobile QueryClient installation;
-- boot-file ordering;
-- `focusManager` receiving inactive and active native states;
-- active transition refetching an enabled due-count query;
-- no foreground refetch when signed out; and
-- existing lifecycle diagnostics remaining intact.
-
-### Cache isolation tests
-
-Cover:
-
-- no query while authentication is restoring;
-- one initial query after restored authentication becomes usable;
-- query key includes the restored user ID;
-- sign-out cancels in-flight work and clears cached stats;
-- terminal auth cleanup clears cached stats;
-- soft refresh failure with a still-usable session retains cache;
-- identity change cannot select previous-user data; and
-- failed durable sign-out cleanup still hides and clears due-count data.
-
-### Home component tests
-
-Cover:
-
-- loading copy and live-region semantics;
-- zero-due state;
-- singular positive copy;
-- plural positive copy;
-- blocking network failure;
-- manual retry;
-- disabled/loading retry state;
-- background refreshing with visible cached count;
-- failed background refresh with visible cached count and alert;
-- no Start Review action; and
-- no scaffold version/environment content.
+- Accessible loading state.
+- Zero, singular, and plural states.
+- Blocking network failure and manual retry.
+- Disabled/loading retry state.
+- Background refresh with cached count.
+- Cached refresh failure with alert and Retry.
+- No Start Review action.
+- No scaffold version/environment content.
 
 ## Manual Verification Matrix
 
-Record the account, build/environment, device, timestamp, API or web comparison value, and result for every row.
+Record account, build/environment, device, timestamp, comparison value, and result for every row.
 
 | Scenario | Expected result |
 | --- | --- |
-| Fresh sign-in | Successful Google sign-in opens Home and fetches the authenticated count |
-| Relaunch restoration | Force-close and reopen restores the user without another Google prompt and loads Home |
-| Positive due count | Mobile count matches web/API for the same account at the recorded verification time |
+| Fresh sign-in | Google sign-in opens Home and fetches the authenticated count |
+| Relaunch restoration | Force-close/reopen restores without another Google prompt and loads Home |
+| Positive due count | Mobile matches web/API for the same account at the recorded time |
 | Zero due count | Home displays `0` and the caught-up message |
-| Network failure | Home remains authenticated and shows a retryable failure without exposing stale foreign data |
+| Network failure | Home remains authenticated and shows a retryable failure |
 | Retry | Restoring connectivity and tapping Retry loads the count |
-| Background and resume | Returning Vela to active state refetches the count |
-| Rejected token | Protected Home content disappears and the user returns safely to authentication |
+| Background/resume | Returning Vela to active state refetches the count |
+| Rejected token | Protected Home disappears and authentication is shown |
 | Sign-out | Home data is removed immediately; relaunch remains signed out |
-| Account isolation | A later sign-in cannot display the prior account’s cached count |
-| iOS Simulator | Complete product flow passes in a configured Simulator build |
-| Physical development iPhone | Complete product flow passes on a configured development device |
+| Account isolation | A later sign-in never displays the prior account’s count |
+| iOS Simulator | Complete flow passes in a configured Simulator build |
+| Physical development iPhone | Complete flow passes on a configured device |
 
 ## Expected File Boundaries
 
@@ -645,6 +580,7 @@ Record the account, build/environment, device, timestamp, API or web comparison 
 - Modify: `apps/vela-mobile/src/boot/boot-files.test.ts`
 - Modify: `apps/vela-mobile/src/boot/capacitor-lifecycle.ts`
 - Modify: `apps/vela-mobile/src/boot/capacitor-lifecycle.test.ts`
+- Modify: `apps/vela-mobile/src/boot/mobile-auth.ts`
 
 ### Authenticated request boundary
 
@@ -653,14 +589,14 @@ Record the account, build/environment, device, timestamp, API or web comparison 
 - Modify: `apps/vela-mobile/src/services/mobile-auth.test.ts`
 - Modify: `apps/vela-mobile/src/test/secret-leak-helpers.ts`
 
-### Mobile server-state services
+### Mobile services
 
 - Create: `apps/vela-mobile/src/services/mobile-api-client.ts`
 - Create: `apps/vela-mobile/src/services/mobile-api-client.test.ts`
 - Create: `apps/vela-mobile/src/services/mobile-srs.ts`
 - Create: `apps/vela-mobile/src/services/mobile-srs.test.ts`
-- Create: `apps/vela-mobile/src/boot/mobile-services.ts`
-- Create: `apps/vela-mobile/src/boot/mobile-services.test.ts`
+- Create: `apps/vela-mobile/src/services/mobile-services.ts`
+- Create: `apps/vela-mobile/src/services/mobile-services.test.ts`
 
 ### Query and presentation
 
@@ -679,44 +615,44 @@ Record the account, build/environment, device, timestamp, API or web comparison 
 
 | Acceptance criterion | Design coverage |
 | --- | --- |
-| Returning user reaches Home through restored authentication | Existing HPA-206 gate plus enabled query after `sessionUsable` |
-| Home displays `/api/srs/stats` due count | Mobile SRS service and Home view model |
-| Expired or rejected token cannot expose another user’s data | Generation-aware auth recovery, user-scoped key, disabled query, and cache cleanup |
-| Loading, empty, failure, and retry states are understandable and accessible | Exhaustive Home presentation union and accessibility requirements |
-| Signing out clears user-specific due-count data | Auth-isolation service cancels and clears QueryClient state |
+| Returning user reaches Home through restored auth | Existing HPA-206 gate plus enabled query after `sessionUsable` |
+| Home displays `/api/srs/stats` due count | Mobile SRS service and Home selector |
+| Expired/rejected token cannot expose another user’s data | Generation-aware recovery, user-scoped key, query disable, and cache cleanup |
+| Loading, empty, failure, and retry states are accessible | Exhaustive presentation union and required semantics |
+| Signing out clears user data | Auth-isolation service cancels and clears QueryClient |
 | Count agrees with web/API | Required manual verification matrix |
-| Tests cover primary states and auth/cache isolation | Shared, auth, service, query, cache, and component test sections |
+| Tests cover states and auth/cache isolation | Shared, auth, service, query, cache, and component suites |
 | Simulator and physical iPhone verification | Required matrix rows for both device classes |
 
 ## Risks and Mitigations
 
 ### Token leakage through an overly generic client
 
-Mitigation: keep token application inside the coordinator, validate API path containment, prohibit Authorization overrides, and extend secret-leak tests.
+Keep token application inside the coordinator, validate path containment, prohibit Authorization overrides, and extend secret-leak tests.
 
 ### Late 401 signs out a refreshed session
 
-Mitigation: capture and verify active owner plus auth generation before any 401-driven mutation.
+Capture and verify active owner plus auth generation before any 401-driven mutation.
 
 ### In-flight expiry destroys a valid refresh credential
 
-Mitigation: recheck token expiry on 401, refresh through the existing durable credential path, and retry once before terminal cleanup.
+Recheck expiry on 401, refresh through the existing durable credential path, and retry once before terminal cleanup.
 
 ### Previous-user cache flashes after sign-in
 
-Mitigation: include user ID in the query key and disable queries whenever no usable authenticated identity exists. Cache clearing remains defense in depth.
+Include user ID in the key and disable whenever no usable identity exists. Cache clearing remains defense in depth.
 
 ### Shared query defaults prevent required refresh
 
-Mitigation: set due-count `refetchOnMount` and `refetchOnWindowFocus` to `always` while retaining shared stale and garbage-collection timing.
+Set due-count `refetchOnMount` and `refetchOnWindowFocus` to `always` while retaining shared stale/GC timing.
 
-### Mobile lifecycle refetch is not triggered by browser focus semantics
+### Native lifecycle does not produce browser focus events
 
-Mitigation: explicitly drive TanStack Query `focusManager` from Capacitor app active state.
+Drive TanStack Query `focusManager` explicitly from Capacitor app state.
 
-### Scope grows into the review flow
+### Scope grows into review execution
 
-Mitigation: Home presents count and status only. Review navigation and due-card retrieval remain in the next milestone.
+Home presents count and status only. Review navigation and due-card retrieval remain in the next milestone.
 
 ## Implementation Sequence
 
@@ -724,7 +660,7 @@ The implementation plan should preserve test-driven, independently reviewable bo
 
 1. shared SRS contract and user-scoped query key;
 2. coordinator-owned authenticated request capability and race handling;
-3. mobile API and SRS services;
+3. mobile API/SRS services and provisioning;
 4. TanStack Query boot and native focus bridge;
 5. auth-driven cache isolation;
 6. due-count composable and pure view selector;

--- a/packages/common/src/contracts/srs.test.ts
+++ b/packages/common/src/contracts/srs.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { parseSrsStats, type SRSStats } from './srs';
+
+const validStats: SRSStats = {
+  total_items: 12,
+  due_today: 3,
+  mastery_breakdown: {
+    new: 2,
+    learning: 4,
+    reviewing: 3,
+    mastered: 3,
+  },
+  average_ease_factor: 2.47,
+  total_reviews: 31,
+  accuracy_rate: 87,
+};
+
+describe('parseSrsStats', () => {
+  it('parses the complete production response and ignores additive fields', () => {
+    expect(parseSrsStats({ ...validStats, generated_at: '2026-07-30T00:00:00Z' })).toEqual(
+      validStats,
+    );
+  });
+
+  it.each([
+    ['total_items', { ...validStats, total_items: -1 }],
+    ['due_today', { ...validStats, due_today: 1.5 }],
+    [
+      'mastery_breakdown.new',
+      {
+        ...validStats,
+        mastery_breakdown: { ...validStats.mastery_breakdown, new: Number.NaN },
+      },
+    ],
+    ['average_ease_factor', { ...validStats, average_ease_factor: Number.POSITIVE_INFINITY }],
+    ['accuracy_rate', { ...validStats, accuracy_rate: 101 }],
+  ])('rejects invalid %s', (field, value) => {
+    expect(() => parseSrsStats(value)).toThrow(`invalid_srs_stats:${field}`);
+  });
+
+  it('rejects a missing nested field', () => {
+    const { mastered: _mastered, ...mastery_breakdown } = validStats.mastery_breakdown;
+    void _mastered;
+    expect(() => parseSrsStats({ ...validStats, mastery_breakdown })).toThrow(
+      'invalid_srs_stats:mastery_breakdown.mastered',
+    );
+  });
+});

--- a/packages/common/src/contracts/srs.ts
+++ b/packages/common/src/contracts/srs.ts
@@ -1,0 +1,58 @@
+export interface SRSStats {
+  total_items: number;
+  due_today: number;
+  mastery_breakdown: {
+    new: number;
+    learning: number;
+    reviewing: number;
+    mastered: number;
+  };
+  average_ease_factor: number;
+  total_reviews: number;
+  accuracy_rate: number;
+}
+
+function record(value: unknown, field: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new TypeError(`invalid_srs_stats:${field}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function nonNegativeInteger(value: unknown, field: string): number {
+  if (!Number.isInteger(value) || (value as number) < 0) {
+    throw new TypeError(`invalid_srs_stats:${field}`);
+  }
+  return value as number;
+}
+
+function finiteNonNegative(value: unknown, field: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw new TypeError(`invalid_srs_stats:${field}`);
+  }
+  return value;
+}
+
+export function parseSrsStats(value: unknown): SRSStats {
+  const root = record(value, 'root');
+  const mastery = record(root.mastery_breakdown, 'mastery_breakdown');
+  const accuracyRate = finiteNonNegative(root.accuracy_rate, 'accuracy_rate');
+
+  if (accuracyRate > 100) {
+    throw new TypeError('invalid_srs_stats:accuracy_rate');
+  }
+
+  return {
+    total_items: nonNegativeInteger(root.total_items, 'total_items'),
+    due_today: nonNegativeInteger(root.due_today, 'due_today'),
+    mastery_breakdown: {
+      new: nonNegativeInteger(mastery.new, 'mastery_breakdown.new'),
+      learning: nonNegativeInteger(mastery.learning, 'mastery_breakdown.learning'),
+      reviewing: nonNegativeInteger(mastery.reviewing, 'mastery_breakdown.reviewing'),
+      mastered: nonNegativeInteger(mastery.mastered, 'mastery_breakdown.mastered'),
+    },
+    average_ease_factor: finiteNonNegative(root.average_ease_factor, 'average_ease_factor'),
+    total_reviews: nonNegativeInteger(root.total_reviews, 'total_reviews'),
+    accuracy_rate: accuracyRate,
+  };
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @vela/query - Shared TanStack Query configuration and utilities
+ * @vela/common - Shared TanStack Query configuration, utilities, and domain contracts
  *
  * This package provides shared query configuration, cache timing constants,
  * and query key factories for use across Vela apps (web app and extension).
@@ -24,3 +24,6 @@ export {
 
 // Export shared constants
 export { DEFAULT_DAILY_LESSON_GOAL, DEFAULT_LESSON_DURATION_MINUTES } from './constants';
+
+// Export shared domain contracts
+export { parseSrsStats, type SRSStats } from './contracts/srs';

--- a/packages/common/src/keys.test.ts
+++ b/packages/common/src/keys.test.ts
@@ -108,12 +108,16 @@ describe('srsKeys', () => {
     expect(srsKeys.due(20)).toEqual(['srs', 'due', 20, undefined]);
   });
 
-  it('stats returns correct tuple with jlpt', () => {
-    expect(srsKeys.stats([2, 3])).toEqual(['srs', 'stats', [2, 3]]);
+  it('stats scopes the tuple by user and jlpt', () => {
+    expect(srsKeys.stats('user-1', [2, 3])).toEqual(['srs', 'stats', 'user-1', [2, 3]]);
   });
 
-  it('stats handles undefined jlpt', () => {
-    expect(srsKeys.stats()).toEqual(['srs', 'stats', undefined]);
+  it('stats preserves null user and undefined jlpt', () => {
+    expect(srsKeys.stats(null)).toEqual(['srs', 'stats', null, undefined]);
+  });
+
+  it('stats produces distinct keys for distinct users', () => {
+    expect(srsKeys.stats('user-1')).not.toEqual(srsKeys.stats('user-2'));
   });
 
   it('progress returns correct tuple', () => {

--- a/packages/common/src/keys.ts
+++ b/packages/common/src/keys.ts
@@ -53,8 +53,11 @@ export const dictionaryKeys = {
  */
 export const srsKeys = {
   all: ['srs'] as const,
+  // Identity-unscoped legacy keys. Do not use these for mobile user data until
+  // their identity and cache-isolation contract is redesigned.
   due: (limit?: number, jlpt?: number[]) => [...srsKeys.all, 'due', limit, jlpt] as const,
-  stats: (jlpt?: number[]) => [...srsKeys.all, 'stats', jlpt] as const,
+  stats: (userId: string | null, jlpt?: number[]) =>
+    [...srsKeys.all, 'stats', userId, jlpt] as const,
   progress: (vocabularyId: string) => [...srsKeys.all, 'progress', vocabularyId] as const,
   allProgress: () => [...srsKeys.all, 'all'] as const,
 };

--- a/packages/common/src/keys.ts
+++ b/packages/common/src/keys.ts
@@ -53,12 +53,14 @@ export const dictionaryKeys = {
  */
 export const srsKeys = {
   all: ['srs'] as const,
-  // Identity-unscoped legacy keys. Do not use these for mobile user data until
-  // their identity and cache-isolation contract is redesigned.
+  // No userId scope: responses mix users until the cache-isolation contract is
+  // redesigned. Do not use for mobile user data.
   due: (limit?: number, jlpt?: number[]) => [...srsKeys.all, 'due', limit, jlpt] as const,
   stats: (userId: string | null, jlpt?: number[]) =>
     [...srsKeys.all, 'stats', userId, jlpt] as const,
+  // No userId scope: per-vocabulary progress is not identity-scoped yet.
   progress: (vocabularyId: string) => [...srsKeys.all, 'progress', vocabularyId] as const,
+  // No userId scope: aggregates the active user without a key partition.
   allProgress: () => [...srsKeys.all, 'all'] as const,
 };
 


### PR DESCRIPTION
## Summary

- add a shared validated SRS stats contract and user-scoped stats query key
- add generation-safe authenticated mobile feature requests with bounded, single-flight 401 recovery
- add mobile API/SRS services and scoped cancel-then-remove query-cache isolation (cancel and remove only `srsKeys.stats(previousUserId)` on sign-out/identity loss; no global `queryClient.clear()`; no mutation when there is no prior user)
- replace the mobile Home scaffold with accessible due-count loading, success, failure, and retry states
- normalize malformed response bodies and invalid request headers through stable error contracts

## Why

HPA-207 needs the native Home screen to show the authenticated user's due-review count without exposing bearer tokens to feature code, leaking cached values across accounts, or retrying deterministic response defects as network failures.

## Validation

- `bun run test`: 7/7 Turbo tasks passed
- `apps/vela-mobile`: 49 files / 838 tests passed
- mobile coverage: 95.43% lines
- mobile typecheck and targeted lint passed
- production mobile build passed with the normal environment-validation path
- native builds launched successfully on iPhone 17 and iPhone 17 Pro Simulators
- the real direct-Google OAuth authorization page opened successfully
- final whole-branch review and scoped fix re-review approved

## Merge dependencies

- This draft is stacked on the head of design/plan PR #52. PR #52 must merge, then this branch must be reconciled with the latest `main` before this PR is ready.
- The authenticated Simulator matrix remains incomplete because the available Simulators had no signed-in Google account or test-session credentials. Fresh sign-in, restoration, live positive/zero count comparison, network recovery, retry, foreground refetch, rejected-token cleanup, sign-out cleanup, and account isolation still need recorded Simulator evidence.

## Closure gate

Physical-development-iPhone verification remains required before HPA-207 closes. It is not a merge gate for this implementation PR.

## Tracking

- Linear: HPA-207
- Design and plan: #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mobile Home dashboard showing due reviews, caught-up status, loading progress, refreshes, and actionable retry states.
  * Added authenticated SRS statistics retrieval with session-aware access and user-specific data handling.
* **Bug Fixes**
  * Improved recovery from expired sessions, network failures, server errors, and malformed responses.
  * Updated mobile background/foreground behavior to refresh data appropriately.
  * Prevented stale data from appearing after sign-out or account changes.
* **Documentation**
  * Documented mobile authentication and due-review functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
