### PR TITLE
feat(mobile): add authenticated TTS pronunciation playback

### DIFF
--- a/.github/workflows/build-lint.yml
+++ b/.github/workflows/build-lint.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # Retargeting an existing PR changes its base via the `edited` activity.
+    # Include it so a PR moved to main reports the required checks.
+    types: [opened, synchronize, reopened, edited]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # Retargeting an existing PR changes its base via the `edited` activity.
+    # Include it so a PR moved to main reports the required checks.
+    types: [opened, synchronize, reopened, edited]
   workflow_dispatch:
 
 env:

--- a/apps/vela-api/package.json
+++ b/apps/vela-api/package.json
@@ -9,26 +9,26 @@
     "test:unit": "bun test",
     "test:watch": "bun test --watch",
     "test:coverage": "bun test --coverage",
-    "compile": "tsc --noEmit",
-    "postinstall": "bun run compile"
+    "compile": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/bun": "1.3.6",
     "typescript": "^5.6.3"
   },
   "dependencies": {
+    "@aws/aurora-dsql-node-postgres-connector": "0.1.1",
     "@aws-sdk/client-cognito-identity-provider": "^3.886.0",
     "@aws-sdk/client-dynamodb": "^3.886.0",
     "@aws-sdk/client-s3": "^3.917.0",
+    "@aws-sdk/credential-providers": "3.940.0",
+    "@aws-sdk/dsql-signer": "3.940.0",
     "@aws-sdk/lib-dynamodb": "^3.886.0",
     "@aws-sdk/s3-request-presigner": "^3.917.0",
     "@hono/zod-validator": "^0.7.2",
+    "@vela/common": "workspace:*",
     "aws-jwt-verify": "^5.1.1",
     "hono": "^4.9.5",
-    "zod": "^4.1.5",
-    "@aws/aurora-dsql-node-postgres-connector": "0.1.1",
-    "@aws-sdk/credential-providers": "3.940.0",
-    "@aws-sdk/dsql-signer": "3.940.0",
-    "pg": "8.16.3"
+    "pg": "8.16.3",
+    "zod": "^4.1.5"
   }
 }

--- a/apps/vela-api/src/routes/tts.ts
+++ b/apps/vela-api/src/routes/tts.ts
@@ -12,7 +12,12 @@ import {
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { requireAuth, type AuthContext } from '../middleware/auth';
 import { createHash } from 'crypto';
+import type { TtsApiErrorCode } from '@vela/common';
 import { createTTSProvider } from '../tts/factory';
+
+function ttsError(error: string, code: TtsApiErrorCode) {
+  return { error, code };
+}
 
 /**
  * Generate a cache key that includes userId, provider, and TTS settings
@@ -74,7 +79,13 @@ const createTTSRoute = (env: Env) => {
       const settings = await ttsSettingsDB.get(userId);
 
       if (!settings || !settings.api_key) {
-        return c.json({ error: 'TTS API key not configured. Please configure in Settings.' }, 400);
+        return c.json(
+          ttsError(
+            'TTS API key not configured. Please configure in Settings.',
+            'tts_not_configured',
+          ),
+          400,
+        );
       }
 
       const bucketName = env.TTS_AUDIO_BUCKET_NAME || process.env.TTS_AUDIO_BUCKET_NAME;
@@ -85,7 +96,10 @@ const createTTSRoute = (env: Env) => {
       const providerValue = settings.provider || 'elevenlabs';
       const providerParse = TTSProviderSchema.safeParse(providerValue);
       if (!providerParse.success) {
-        return c.json({ error: 'Invalid TTS provider configuration' }, 400);
+        return c.json(
+          ttsError('Invalid TTS provider configuration', 'tts_invalid_provider_configuration'),
+          400,
+        );
       }
       const provider = providerParse.data;
       const ttsProvider = createTTSProvider(provider);
@@ -115,7 +129,13 @@ const createTTSRoute = (env: Env) => {
             s3Key,
             bucket: bucketName,
           });
-          return c.json({ error: 'Audio service temporarily unavailable. Please try again.' }, 503);
+          return c.json(
+            ttsError(
+              'Audio service temporarily unavailable. Please try again.',
+              'tts_audio_service_unavailable',
+            ),
+            503,
+          );
         }
       }
 
@@ -136,14 +156,14 @@ const createTTSRoute = (env: Env) => {
             userId,
             error,
           });
-          return c.json({ error: 'TTS generation timed out' }, 504);
+          return c.json(ttsError('TTS generation timed out', 'tts_generation_timeout'), 504);
         }
         console.error('TTS provider error', {
           provider,
           userId,
           error,
         });
-        return c.json({ error: 'Failed to generate TTS audio' }, 500);
+        return c.json(ttsError('Failed to generate TTS audio', 'tts_generation_failed'), 500);
       }
 
       // Upload to S3
@@ -165,7 +185,10 @@ const createTTSRoute = (env: Env) => {
           s3Key,
         });
         return c.json(
-          { error: 'Audio was generated but could not be saved. Please try again.' },
+          ttsError(
+            'Audio was generated but could not be saved. Please try again.',
+            'tts_audio_storage_failed',
+          ),
           500,
         );
       }
@@ -185,7 +208,10 @@ const createTTSRoute = (env: Env) => {
           s3Key,
         });
         return c.json(
-          { error: 'Audio was saved but could not be accessed. Please try again.' },
+          ttsError(
+            'Audio was saved but could not be accessed. Please try again.',
+            'tts_audio_access_failed',
+          ),
           500,
         );
       }

--- a/apps/vela-api/src/routes/tts.ts
+++ b/apps/vela-api/src/routes/tts.ts
@@ -20,6 +20,18 @@ function ttsError(error: string, code: TtsApiErrorCode) {
 }
 
 /**
+ * Normalize an error to an allowlisted log shape. Never log raw error values
+ * (which may carry stack traces or server-internal detail) or user-scoped
+ * S3 object keys (which embed the userId).
+ */
+function sanitizeError(error: unknown): { errorName: string; errorMessage: string } {
+  if (error instanceof Error) {
+    return { errorName: error.name, errorMessage: error.message };
+  }
+  return { errorName: 'UnknownError', errorMessage: String(error) };
+}
+
+/**
  * Generate a cache key that includes userId, provider, and TTS settings
  * Format: tts/{userId}/{vocabularyId}/{settingsHash}
  */
@@ -91,7 +103,7 @@ const createTTSRoute = (env: Env) => {
       const bucketName = env.TTS_AUDIO_BUCKET_NAME || process.env.TTS_AUDIO_BUCKET_NAME;
       if (!bucketName) {
         return c.json(
-          ttsError('TTS audio bucket not configured', 'tts_audio_service_unavailable'),
+          ttsError('TTS audio bucket not configured', 'tts_audio_bucket_not_configured'),
           500,
         );
       }
@@ -126,10 +138,8 @@ const createTTSRoute = (env: Env) => {
           // Cache miss — fall through to generate
         } else {
           console.error('S3 cache check failed', {
-            errorName: error.name,
-            errorMessage: error.message,
-            userId,
-            s3Key,
+            ...sanitizeError(error),
+            provider,
             bucket: bucketName,
           });
           return c.json(
@@ -155,16 +165,14 @@ const createTTSRoute = (env: Env) => {
         const errorMessage = error instanceof Error ? error.message : String(error);
         if (errorMessage.toLowerCase().includes('timeout')) {
           console.error('TTS provider timeout', {
+            ...sanitizeError(error),
             provider,
-            userId,
-            error,
           });
           return c.json(ttsError('TTS generation timed out', 'tts_generation_timeout'), 504);
         }
         console.error('TTS provider error', {
+          ...sanitizeError(error),
           provider,
-          userId,
-          error,
         });
         return c.json(ttsError('Failed to generate TTS audio', 'tts_generation_failed'), 500);
       }
@@ -181,11 +189,9 @@ const createTTSRoute = (env: Env) => {
         );
       } catch (uploadError: any) {
         console.error('S3 upload failed after successful TTS generation', {
-          errorName: uploadError.name,
-          errorMessage: uploadError.message,
+          ...sanitizeError(uploadError),
           provider,
-          userId,
-          s3Key,
+          bucket: bucketName,
         });
         return c.json(
           ttsError(
@@ -205,10 +211,8 @@ const createTTSRoute = (env: Env) => {
         );
       } catch (signingError: any) {
         console.error('Failed to generate presigned URL after S3 upload', {
-          errorName: signingError.name,
-          errorMessage: signingError.message,
-          userId,
-          s3Key,
+          ...sanitizeError(signingError),
+          bucket: bucketName,
         });
         return c.json(
           ttsError(
@@ -221,8 +225,8 @@ const createTTSRoute = (env: Env) => {
 
       return c.json({ audioUrl, cached: false });
     } catch (error) {
-      console.error('TTS generation error:', error);
-      return c.json(ttsError('Failed to generate TTS audio', 'tts_generation_failed'), 500);
+      console.error('TTS generation error', sanitizeError(error));
+      return c.json(ttsError('Failed to generate TTS audio', 'tts_unexpected_error'), 500);
     }
   });
 
@@ -281,11 +285,11 @@ const createTTSRoute = (env: Env) => {
           if (error.name === 'NotFound' || error.name === 'NoSuchKey') {
             return c.json({ error: 'Audio not found. Please generate it first.' }, 404);
           }
-          console.error('S3 error:', error);
+          console.error('S3 error', sanitizeError(error));
           return c.json({ error: 'Failed to retrieve audio' }, 500);
         }
       } catch (error) {
-        console.error('Get audio error:', error);
+        console.error('Get audio error', sanitizeError(error));
         return c.json({ error: 'Failed to get audio URL' }, 500);
       }
     },
@@ -314,7 +318,7 @@ const createTTSRoute = (env: Env) => {
 
       return c.json({ success: true, message: 'TTS settings saved successfully' });
     } catch (error) {
-      console.error('Save TTS settings error:', error);
+      console.error('Save TTS settings error', sanitizeError(error));
       return c.json(
         { error: error instanceof Error ? error.message : 'Failed to save TTS settings' },
         500,
@@ -362,7 +366,7 @@ const createTTSRoute = (env: Env) => {
         model: settings.model || null,
       });
     } catch (error) {
-      console.error('Get TTS settings error:', error);
+      console.error('Get TTS settings error', sanitizeError(error));
       return c.json({ error: 'Failed to get TTS settings' }, 500);
     }
   });

--- a/apps/vela-api/src/routes/tts.ts
+++ b/apps/vela-api/src/routes/tts.ts
@@ -320,6 +320,16 @@ const createTTSRoute = (env: Env) => {
           settings.model || '',
         );
 
+        // The effective settings the backend used to derive the cache key. The
+        // client compares these against its GET /tts/settings snapshot to detect
+        // a settings change between the two requests and avoid caching under a
+        // stale identity. Uses the same null/empty convention as GET settings.
+        const effectiveSettings = {
+          provider,
+          voiceId: settings.voice_id || null,
+          model: settings.model || null,
+        };
+
         try {
           await s3Client.send(new HeadObjectCommand({ Bucket: bucketName, Key: s3Key }));
 
@@ -329,7 +339,7 @@ const createTTSRoute = (env: Env) => {
             { expiresIn: 900 },
           );
 
-          return c.json({ audioUrl });
+          return c.json({ audioUrl, effectiveSettings });
         } catch (error: any) {
           if (error.name === 'NotFound' || error.name === 'NoSuchKey') {
             return c.json({ error: 'Audio not found. Please generate it first.' }, 404);

--- a/apps/vela-api/src/routes/tts.ts
+++ b/apps/vela-api/src/routes/tts.ts
@@ -32,7 +32,34 @@ type TtsLogCategory =
  * `error.message` (providers embed the full upstream response body in it), the
  * user ID, user-scoped S3 object keys (which embed the userId), or bucket
  * names. Only the error class name and an operation category are emitted.
+ *
+ * `error.name` is writable and not trusted: third-party or deliberately
+ * constructed errors can place arbitrary content (response bodies, secrets,
+ * object keys) in it. Normalize through a finite allowlist and map anything
+ * unknown to a fixed value.
  */
+const SAFE_ERROR_NAMES = new Set([
+  'Error',
+  'TypeError',
+  'AbortError',
+  'TimeoutError',
+  'NotFound',
+  'NoSuchKey',
+]);
+
+function extractErrorName(error: unknown): string {
+  if (error instanceof Error) return error.name;
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    typeof (error as { name: unknown }).name === 'string'
+  ) {
+    return (error as { name: string }).name;
+  }
+  return 'UnknownError';
+}
+
 function sanitizeError(
   error: unknown,
   category: TtsLogCategory,
@@ -41,15 +68,8 @@ function sanitizeError(
   errorName: string;
   category: TtsLogCategory;
 } {
-  const errorName =
-    error instanceof Error
-      ? error.name
-      : typeof error === 'object' &&
-          error !== null &&
-          'name' in error &&
-          typeof (error as { name: unknown }).name === 'string'
-        ? (error as { name: string }).name
-        : 'UnknownError';
+  const rawName = extractErrorName(error);
+  const errorName = SAFE_ERROR_NAMES.has(rawName) ? rawName : 'UnknownError';
   return { operation: category, errorName, category };
 }
 

--- a/apps/vela-api/src/routes/tts.ts
+++ b/apps/vela-api/src/routes/tts.ts
@@ -90,7 +90,10 @@ const createTTSRoute = (env: Env) => {
 
       const bucketName = env.TTS_AUDIO_BUCKET_NAME || process.env.TTS_AUDIO_BUCKET_NAME;
       if (!bucketName) {
-        return c.json({ error: 'TTS audio bucket not configured' }, 500);
+        return c.json(
+          ttsError('TTS audio bucket not configured', 'tts_audio_service_unavailable'),
+          500,
+        );
       }
 
       const providerValue = settings.provider || 'elevenlabs';
@@ -219,7 +222,7 @@ const createTTSRoute = (env: Env) => {
       return c.json({ audioUrl, cached: false });
     } catch (error) {
       console.error('TTS generation error:', error);
-      return c.json({ error: 'Failed to generate TTS audio' }, 500);
+      return c.json(ttsError('Failed to generate TTS audio', 'tts_generation_failed'), 500);
     }
   });
 

--- a/apps/vela-api/src/routes/tts.ts
+++ b/apps/vela-api/src/routes/tts.ts
@@ -19,16 +19,38 @@ function ttsError(error: string, code: TtsApiErrorCode) {
   return { error, code };
 }
 
+type TtsLogCategory =
+  | 's3_cache_lookup'
+  | 'provider_timeout'
+  | 'provider_generate'
+  | 's3_upload'
+  | 's3_signing'
+  | 'unexpected';
+
 /**
- * Normalize an error to an allowlisted log shape. Never log raw error values
- * (which may carry stack traces or server-internal detail) or user-scoped
- * S3 object keys (which embed the userId).
+ * Normalize an error to an allowlisted log shape. Never log raw error values,
+ * `error.message` (providers embed the full upstream response body in it), the
+ * user ID, user-scoped S3 object keys (which embed the userId), or bucket
+ * names. Only the error class name and an operation category are emitted.
  */
-function sanitizeError(error: unknown): { errorName: string; errorMessage: string } {
-  if (error instanceof Error) {
-    return { errorName: error.name, errorMessage: error.message };
-  }
-  return { errorName: 'UnknownError', errorMessage: String(error) };
+function sanitizeError(
+  error: unknown,
+  category: TtsLogCategory,
+): {
+  operation: TtsLogCategory;
+  errorName: string;
+  category: TtsLogCategory;
+} {
+  const errorName =
+    error instanceof Error
+      ? error.name
+      : typeof error === 'object' &&
+          error !== null &&
+          'name' in error &&
+          typeof (error as { name: unknown }).name === 'string'
+        ? (error as { name: string }).name
+        : 'UnknownError';
+  return { operation: category, errorName, category };
 }
 
 /**
@@ -122,6 +144,16 @@ const createTTSRoute = (env: Env) => {
       const model = settings.model || '';
       const s3Key = generateCacheKey(userId, vocabularyId, provider, voiceId, model);
 
+      // The effective settings the backend used to derive the cache key. The
+      // client compares these against its GET /tts/settings snapshot to detect
+      // a settings change between the two requests and avoid caching under a
+      // stale identity. Uses the same null/empty convention as GET settings.
+      const effectiveSettings = {
+        provider,
+        voiceId: settings.voice_id || null,
+        model: settings.model || null,
+      };
+
       // Check S3 cache first
       try {
         await s3Client.send(new HeadObjectCommand({ Bucket: bucketName, Key: s3Key }));
@@ -132,15 +164,14 @@ const createTTSRoute = (env: Env) => {
           { expiresIn: 900 },
         );
 
-        return c.json({ audioUrl, cached: true });
+        return c.json({ audioUrl, cached: true, effectiveSettings });
       } catch (error: any) {
         if (error.name === 'NotFound' || error.name === 'NoSuchKey') {
           // Cache miss — fall through to generate
         } else {
           console.error('S3 cache check failed', {
-            ...sanitizeError(error),
+            ...sanitizeError(error, 's3_cache_lookup'),
             provider,
-            bucket: bucketName,
           });
           return c.json(
             ttsError(
@@ -165,13 +196,13 @@ const createTTSRoute = (env: Env) => {
         const errorMessage = error instanceof Error ? error.message : String(error);
         if (errorMessage.toLowerCase().includes('timeout')) {
           console.error('TTS provider timeout', {
-            ...sanitizeError(error),
+            ...sanitizeError(error, 'provider_timeout'),
             provider,
           });
           return c.json(ttsError('TTS generation timed out', 'tts_generation_timeout'), 504);
         }
         console.error('TTS provider error', {
-          ...sanitizeError(error),
+          ...sanitizeError(error, 'provider_generate'),
           provider,
         });
         return c.json(ttsError('Failed to generate TTS audio', 'tts_generation_failed'), 500);
@@ -189,9 +220,8 @@ const createTTSRoute = (env: Env) => {
         );
       } catch (uploadError: any) {
         console.error('S3 upload failed after successful TTS generation', {
-          ...sanitizeError(uploadError),
+          ...sanitizeError(uploadError, 's3_upload'),
           provider,
-          bucket: bucketName,
         });
         return c.json(
           ttsError(
@@ -211,8 +241,7 @@ const createTTSRoute = (env: Env) => {
         );
       } catch (signingError: any) {
         console.error('Failed to generate presigned URL after S3 upload', {
-          ...sanitizeError(signingError),
-          bucket: bucketName,
+          ...sanitizeError(signingError, 's3_signing'),
         });
         return c.json(
           ttsError(
@@ -223,9 +252,9 @@ const createTTSRoute = (env: Env) => {
         );
       }
 
-      return c.json({ audioUrl, cached: false });
+      return c.json({ audioUrl, cached: false, effectiveSettings });
     } catch (error) {
-      console.error('TTS generation error', sanitizeError(error));
+      console.error('TTS generation error', sanitizeError(error, 'unexpected'));
       return c.json(ttsError('Failed to generate TTS audio', 'tts_unexpected_error'), 500);
     }
   });
@@ -285,11 +314,11 @@ const createTTSRoute = (env: Env) => {
           if (error.name === 'NotFound' || error.name === 'NoSuchKey') {
             return c.json({ error: 'Audio not found. Please generate it first.' }, 404);
           }
-          console.error('S3 error', sanitizeError(error));
+          console.error('S3 error', sanitizeError(error, 's3_cache_lookup'));
           return c.json({ error: 'Failed to retrieve audio' }, 500);
         }
       } catch (error) {
-        console.error('Get audio error', sanitizeError(error));
+        console.error('Get audio error', sanitizeError(error, 'unexpected'));
         return c.json({ error: 'Failed to get audio URL' }, 500);
       }
     },
@@ -318,7 +347,7 @@ const createTTSRoute = (env: Env) => {
 
       return c.json({ success: true, message: 'TTS settings saved successfully' });
     } catch (error) {
-      console.error('Save TTS settings error', sanitizeError(error));
+      console.error('Save TTS settings error', sanitizeError(error, 'unexpected'));
       return c.json(
         { error: error instanceof Error ? error.message : 'Failed to save TTS settings' },
         500,
@@ -352,9 +381,10 @@ const createTTSRoute = (env: Env) => {
       const providerValue = settings.provider || 'elevenlabs';
       const providerParse = TTSProviderSchema.safeParse(providerValue);
       if (!providerParse.success) {
+        // `storedValue` is a malformed provider enum, not identity-bearing or
+        // secret. The userId is intentionally omitted from logs.
         console.warn('Invalid provider value in TTS settings, falling back to elevenlabs', {
           storedValue: providerValue,
-          userId,
         });
       }
       const provider = providerParse.success ? providerParse.data : 'elevenlabs';
@@ -366,7 +396,7 @@ const createTTSRoute = (env: Env) => {
         model: settings.model || null,
       });
     } catch (error) {
-      console.error('Get TTS settings error', sanitizeError(error));
+      console.error('Get TTS settings error', sanitizeError(error, 'unexpected'));
       return c.json({ error: 'Failed to get TTS settings' }, 500);
     }
   });

--- a/apps/vela-api/src/routes/tts.ts
+++ b/apps/vela-api/src/routes/tts.ts
@@ -45,6 +45,13 @@ const SAFE_ERROR_NAMES = new Set([
   'TimeoutError',
   'NotFound',
   'NoSuchKey',
+  // AWS SDK storage error names — stable, non-secret strings emitted by S3.
+  // Preserved so ops can distinguish throttling, permission, timeout, and
+  // outage conditions instead of collapsing them to UnknownError.
+  'ServiceUnavailable',
+  'AccessDenied',
+  'ThrottlingException',
+  'SlowDown',
 ]);
 
 function extractErrorName(error: unknown): string {
@@ -298,18 +305,27 @@ const createTTSRoute = (env: Env) => {
 
         const settings = await ttsSettingsDB.get(userId);
         if (!settings) {
-          return c.json({ error: 'TTS settings not found. Please configure in Settings.' }, 400);
+          return c.json(
+            ttsError('TTS settings not found. Please configure in Settings.', 'tts_not_configured'),
+            400,
+          );
         }
 
         const bucketName = env.TTS_AUDIO_BUCKET_NAME || process.env.TTS_AUDIO_BUCKET_NAME;
         if (!bucketName) {
-          return c.json({ error: 'TTS audio bucket not configured' }, 500);
+          return c.json(
+            ttsError('TTS audio bucket not configured', 'tts_audio_bucket_not_configured'),
+            500,
+          );
         }
 
         const providerValue = settings.provider || 'elevenlabs';
         const providerParse = TTSProviderSchema.safeParse(providerValue);
         if (!providerParse.success) {
-          return c.json({ error: 'Invalid TTS provider configuration' }, 400);
+          return c.json(
+            ttsError('Invalid TTS provider configuration', 'tts_invalid_provider_configuration'),
+            400,
+          );
         }
         const provider = providerParse.data;
         const s3Key = generateCacheKey(
@@ -342,14 +358,17 @@ const createTTSRoute = (env: Env) => {
           return c.json({ audioUrl, effectiveSettings });
         } catch (error: any) {
           if (error.name === 'NotFound' || error.name === 'NoSuchKey') {
-            return c.json({ error: 'Audio not found. Please generate it first.' }, 404);
+            return c.json(
+              ttsError('Audio not found. Please generate it first.', 'tts_audio_not_found'),
+              404,
+            );
           }
           console.error('S3 error', sanitizeError(error, 's3_cache_lookup'));
-          return c.json({ error: 'Failed to retrieve audio' }, 500);
+          return c.json(ttsError('Failed to retrieve audio', 'tts_audio_access_failed'), 500);
         }
       } catch (error) {
         console.error('Get audio error', sanitizeError(error, 'unexpected'));
-        return c.json({ error: 'Failed to get audio URL' }, 500);
+        return c.json(ttsError('Failed to get audio URL', 'tts_unexpected_error'), 500);
       }
     },
   );
@@ -378,10 +397,7 @@ const createTTSRoute = (env: Env) => {
       return c.json({ success: true, message: 'TTS settings saved successfully' });
     } catch (error) {
       console.error('Save TTS settings error', sanitizeError(error, 'unexpected'));
-      return c.json(
-        { error: error instanceof Error ? error.message : 'Failed to save TTS settings' },
-        500,
-      );
+      return c.json(ttsError('Failed to save TTS settings', 'tts_unexpected_error'), 500);
     }
   });
 

--- a/apps/vela-api/test/routes/tts.test.ts
+++ b/apps/vela-api/test/routes/tts.test.ts
@@ -74,8 +74,24 @@ function createTestApp(env: Env = TEST_ENV) {
 // Serialize every argument of a console call to a single string so a test can
 // assert that a secret or identity-bearing value does not appear anywhere in
 // the logged payload (not just as a top-level property).
+//
+// Error objects have non-enumerable `name`/`message`/`stack`, so
+// JSON.stringify(new Error('secret')) returns '{}' and would hide any secret
+// embedded in those properties from the leak assertions. Serialize Error
+// arguments via their own properties first, then fall back to JSON.stringify
+// for everything else.
+function serializeError(error: Error): string {
+  return [error.name, error.message, error.stack].filter(Boolean).join('\n');
+}
+
 function serializeLogArgs(args: unknown[]): string {
-  return args.map((arg) => (typeof arg === 'string' ? arg : JSON.stringify(arg))).join('\n');
+  return args
+    .map((arg) => {
+      if (typeof arg === 'string') return arg;
+      if (arg instanceof Error) return serializeError(arg);
+      return JSON.stringify(arg);
+    })
+    .join('\n');
 }
 
 describe('TTS Route', () => {

--- a/apps/vela-api/test/routes/tts.test.ts
+++ b/apps/vela-api/test/routes/tts.test.ts
@@ -360,6 +360,10 @@ describe('TTS Route', () => {
       });
 
       expect(res.status).toBe(500);
+      expect(await res.json()).toEqual({
+        error: 'TTS audio bucket not configured',
+        code: 'tts_audio_bucket_not_configured',
+      });
     });
 
     test('returns 400 for invalid provider in settings', async () => {
@@ -531,6 +535,84 @@ describe('TTS Route', () => {
         error: 'Audio was generated but could not be saved. Please try again.',
         code: 'tts_audio_storage_failed',
       });
+    });
+
+    test('S3 cache check failure logs sanitized error without s3Key or userId', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockTtsSettingsDB.get.mockResolvedValueOnce({
+        user_id: 'test-user-id',
+        provider: 'elevenlabs',
+        api_key: 'test-api-key',
+        voice_id: null,
+        model: null,
+      });
+      mockS3Client.send.mockRejectedValueOnce(new Error('S3 connection reset'));
+
+      const app = createTestApp();
+      await app.request('/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ vocabularyId: 'vocab-1', text: '日本語' }),
+      });
+
+      const loggedArg = errorSpy.mock.calls[0][1] as Record<string, unknown>;
+      expect(loggedArg).not.toHaveProperty('s3Key');
+      expect(loggedArg).not.toHaveProperty('userId');
+      expect(loggedArg).not.toHaveProperty('error');
+      expect(loggedArg).toHaveProperty('errorName', 'Error');
+      expect(loggedArg).toHaveProperty('errorMessage', 'S3 connection reset');
+      errorSpy.mockRestore();
+    });
+
+    test('provider error logs sanitized error without userId or raw error', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockTtsSettingsDB.get.mockResolvedValueOnce({
+        user_id: 'test-user-id',
+        provider: 'elevenlabs',
+        api_key: 'test-api-key',
+        voice_id: null,
+        model: null,
+      });
+      const notFoundError = new Error('Not found');
+      (notFoundError as any).name = 'NotFound';
+      mockS3Client.send.mockRejectedValueOnce(notFoundError);
+      mockTTSProvider.generate.mockRejectedValueOnce(new Error('Provider API key invalid'));
+
+      const app = createTestApp();
+      await app.request('/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ vocabularyId: 'vocab-1', text: '日本語' }),
+      });
+
+      const loggedArg = errorSpy.mock.calls[0][1] as Record<string, unknown>;
+      expect(loggedArg).not.toHaveProperty('userId');
+      expect(loggedArg).not.toHaveProperty('error');
+      expect(loggedArg).toHaveProperty('errorName', 'Error');
+      expect(loggedArg).toHaveProperty('errorMessage', 'Provider API key invalid');
+      errorSpy.mockRestore();
+    });
+
+    test('outer catch logs sanitized error and returns unexpected-error code', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockTtsSettingsDB.get.mockRejectedValueOnce(new Error('DynamoDB connection lost'));
+
+      const app = createTestApp();
+      const res = await app.request('/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ vocabularyId: 'vocab-1', text: '日本語' }),
+      });
+
+      expect(res.status).toBe(500);
+      expect(await res.json()).toEqual({
+        error: 'Failed to generate TTS audio',
+        code: 'tts_unexpected_error',
+      });
+      const loggedArg = errorSpy.mock.calls[0][1] as Record<string, unknown>;
+      expect(loggedArg).toHaveProperty('errorName', 'Error');
+      expect(loggedArg).toHaveProperty('errorMessage', 'DynamoDB connection lost');
+      errorSpy.mockRestore();
     });
   });
 

--- a/apps/vela-api/test/routes/tts.test.ts
+++ b/apps/vela-api/test/routes/tts.test.ts
@@ -728,8 +728,44 @@ describe('TTS Route', () => {
       const res = await app.request('/audio/vocab-1');
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { audioUrl: string };
+      const body = (await res.json()) as {
+        audioUrl: string;
+        effectiveSettings?: { provider: string; voiceId: string | null; model: string | null };
+      };
       expect(body.audioUrl).toBe('https://s3.example.com/cached-audio.mp3');
+      // The audio lookup response echoes the effective settings used to derive
+      // the S3 key so clients can detect a GET settings / GET audio race.
+      expect(body.effectiveSettings).toEqual({
+        provider: 'elevenlabs',
+        voiceId: null,
+        model: null,
+      });
+    });
+
+    test('echoes effective settings with non-null voice and model', async () => {
+      mockTtsSettingsDB.get.mockResolvedValueOnce({
+        user_id: 'test-user-id',
+        provider: 'openai',
+        api_key: 'test-api-key',
+        voice_id: 'alloy',
+        model: 'tts-1',
+      });
+      mockS3Client.send.mockResolvedValueOnce({}); // HeadObject succeeds
+      mockGetSignedUrl.mockResolvedValueOnce('https://s3.example.com/cached-audio.mp3');
+
+      const app = createTestApp();
+      const res = await app.request('/audio/vocab-1');
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        audioUrl: string;
+        effectiveSettings?: { provider: string; voiceId: string | null; model: string | null };
+      };
+      expect(body.effectiveSettings).toEqual({
+        provider: 'openai',
+        voiceId: 'alloy',
+        model: 'tts-1',
+      });
     });
 
     test('returns 404 when audio is not cached', async () => {

--- a/apps/vela-api/test/routes/tts.test.ts
+++ b/apps/vela-api/test/routes/tts.test.ts
@@ -326,7 +326,7 @@ describe('TTS Route', () => {
       expect(mockTTSProvider.generate).toHaveBeenCalledTimes(1);
     });
 
-    test('returns 400 when no TTS settings configured', async () => {
+    test('returns a stable code when TTS is not configured', async () => {
       mockTtsSettingsDB.get.mockResolvedValueOnce(null);
 
       const app = createTestApp();
@@ -337,8 +337,10 @@ describe('TTS Route', () => {
       });
 
       expect(res.status).toBe(400);
-      const body = (await res.json()) as { error: string };
-      expect(body.error).toContain('TTS API key not configured');
+      expect(await res.json()).toEqual({
+        error: 'TTS API key not configured. Please configure in Settings.',
+        code: 'tts_not_configured',
+      });
     });
 
     test('returns 500 when TTS_AUDIO_BUCKET_NAME is not configured', async () => {
@@ -377,6 +379,10 @@ describe('TTS Route', () => {
       });
 
       expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({
+        error: 'Invalid TTS provider configuration',
+        code: 'tts_invalid_provider_configuration',
+      });
     });
 
     test('returns 400 when vocabularyId is missing', async () => {
@@ -401,6 +407,20 @@ describe('TTS Route', () => {
       expect(res.status).toBe(400);
     });
 
+    test('leaves request-validator failures uncoded', async () => {
+      const app = createTestApp();
+      const res = await app.request('/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ vocabularyId: '', text: '' }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { success: boolean; code?: string };
+      expect(body).toMatchObject({ success: false });
+      expect(body).not.toHaveProperty('code');
+    });
+
     test('returns 503 when S3 cache check fails with unexpected error', async () => {
       mockTtsSettingsDB.get.mockResolvedValueOnce({
         user_id: 'test-user-id',
@@ -421,6 +441,10 @@ describe('TTS Route', () => {
       });
 
       expect(res.status).toBe(503);
+      expect(await res.json()).toEqual({
+        error: 'Audio service temporarily unavailable. Please try again.',
+        code: 'tts_audio_service_unavailable',
+      });
     });
 
     test('returns 504 when TTS provider times out', async () => {
@@ -445,6 +469,10 @@ describe('TTS Route', () => {
       });
 
       expect(res.status).toBe(504);
+      expect(await res.json()).toEqual({
+        error: 'TTS generation timed out',
+        code: 'tts_generation_timeout',
+      });
     });
 
     test('returns 500 when TTS provider fails', async () => {
@@ -468,6 +496,10 @@ describe('TTS Route', () => {
       });
 
       expect(res.status).toBe(500);
+      expect(await res.json()).toEqual({
+        error: 'Failed to generate TTS audio',
+        code: 'tts_generation_failed',
+      });
     });
 
     test('returns 500 when S3 upload fails', async () => {
@@ -495,6 +527,10 @@ describe('TTS Route', () => {
       });
 
       expect(res.status).toBe(500);
+      expect(await res.json()).toEqual({
+        error: 'Audio was generated but could not be saved. Please try again.',
+        code: 'tts_audio_storage_failed',
+      });
     });
   });
 
@@ -587,8 +623,10 @@ describe('TTS Route', () => {
       });
 
       expect(res.status).toBe(500);
-      const body = (await res.json()) as { error: string };
-      expect(body.error).toContain('could not be accessed');
+      expect(await res.json()).toEqual({
+        error: 'Audio was saved but could not be accessed. Please try again.',
+        code: 'tts_audio_access_failed',
+      });
     });
 
     test('returns 500 when settings lookup fails during generate', async () => {

--- a/apps/vela-api/test/routes/tts.test.ts
+++ b/apps/vela-api/test/routes/tts.test.ts
@@ -685,6 +685,31 @@ describe('TTS Route', () => {
       expect(serializeLogArgs(errorSpy.mock.calls[0])).not.toContain('DynamoDB connection lost');
       errorSpy.mockRestore();
     });
+
+    test('sanitizeError maps an unknown error name to UnknownError and does not leak the raw name', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const SECRET_MARKER = 'sk-leaked-name-secret-XYZ';
+      // error.name is writable; a hostile or third-party error can place
+      // arbitrary content (secrets, response bodies, object keys) in it.
+      // The sanitizer must normalize it through the allowlist and never emit
+      // the raw value.
+      const hostileError = new Error('upstream body');
+      hostileError.name = `HostileError:${SECRET_MARKER}`;
+      mockTtsSettingsDB.get.mockRejectedValueOnce(hostileError);
+
+      const app = createTestApp();
+      await app.request('/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ vocabularyId: 'vocab-1', text: '日本語' }),
+      });
+
+      const loggedArg = errorSpy.mock.calls[0][1] as Record<string, unknown>;
+      expect(loggedArg).toHaveProperty('errorName', 'UnknownError');
+      expect(loggedArg).not.toHaveProperty('errorMessage');
+      expect(serializeLogArgs(errorSpy.mock.calls[0])).not.toContain(SECRET_MARKER);
+      errorSpy.mockRestore();
+    });
   });
 
   describe('GET /audio/:vocabularyId - Get cached audio URL', () => {

--- a/apps/vela-api/test/routes/tts.test.ts
+++ b/apps/vela-api/test/routes/tts.test.ts
@@ -71,6 +71,13 @@ function createTestApp(env: Env = TEST_ENV) {
   return app;
 }
 
+// Serialize every argument of a console call to a single string so a test can
+// assert that a secret or identity-bearing value does not appear anywhere in
+// the logged payload (not just as a top-level property).
+function serializeLogArgs(args: unknown[]): string {
+  return args.map((arg) => (typeof arg === 'string' ? arg : JSON.stringify(arg))).join('\n');
+}
+
 describe('TTS Route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -139,6 +146,27 @@ describe('TTS Route', () => {
       expect(res.status).toBe(200);
       const body = (await res.json()) as { provider: string };
       expect(body.provider).toBe('elevenlabs');
+    });
+
+    test('invalid provider value warns with the stored value but without the userId', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockTtsSettingsDB.get.mockResolvedValueOnce({
+        user_id: 'test-user-id',
+        provider: 'invalid-provider',
+        api_key: 'key',
+        voice_id: null,
+        model: null,
+      });
+
+      const app = createTestApp();
+      await app.request('/settings');
+
+      expect(warnSpy).toHaveBeenCalled();
+      const loggedArg = warnSpy.mock.calls[0][1] as Record<string, unknown>;
+      expect(loggedArg).toHaveProperty('storedValue', 'invalid-provider');
+      expect(loggedArg).not.toHaveProperty('userId');
+      expect(serializeLogArgs(warnSpy.mock.calls[0])).not.toContain('test-user-id');
+      warnSpy.mockRestore();
     });
 
     test('returns 500 on database error', async () => {
@@ -284,9 +312,20 @@ describe('TTS Route', () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { audioUrl: string; cached: boolean };
+      const body = (await res.json()) as {
+        audioUrl: string;
+        cached: boolean;
+        effectiveSettings?: { provider: string; voiceId: string | null; model: string | null };
+      };
       expect(body.audioUrl).toBe('https://s3.example.com/audio.mp3');
       expect(body.cached).toBe(true);
+      // The cache-hit response echoes the effective settings used to derive the
+      // S3 key so clients can detect a GET/POST settings race.
+      expect(body.effectiveSettings).toEqual({
+        provider: 'elevenlabs',
+        voiceId: null,
+        model: null,
+      });
       expect(mockTTSProvider.generate).not.toHaveBeenCalled();
     });
 
@@ -320,9 +359,20 @@ describe('TTS Route', () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { audioUrl: string; cached: boolean };
+      const body = (await res.json()) as {
+        audioUrl: string;
+        cached: boolean;
+        effectiveSettings?: { provider: string; voiceId: string | null; model: string | null };
+      };
       expect(body.audioUrl).toBe('https://s3.example.com/new-audio.mp3');
       expect(body.cached).toBe(false);
+      // The generation response reports the effective settings the backend
+      // used, so the mobile client can skip caching on a GET/POST race.
+      expect(body.effectiveSettings).toEqual({
+        provider: 'elevenlabs',
+        voiceId: null,
+        model: null,
+      });
       expect(mockTTSProvider.generate).toHaveBeenCalledTimes(1);
     });
 
@@ -537,7 +587,7 @@ describe('TTS Route', () => {
       });
     });
 
-    test('S3 cache check failure logs sanitized error without s3Key or userId', async () => {
+    test('S3 cache check failure logs sanitized error without s3Key, userId, bucket, or error message', async () => {
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       mockTtsSettingsDB.get.mockResolvedValueOnce({
         user_id: 'test-user-id',
@@ -558,13 +608,19 @@ describe('TTS Route', () => {
       const loggedArg = errorSpy.mock.calls[0][1] as Record<string, unknown>;
       expect(loggedArg).not.toHaveProperty('s3Key');
       expect(loggedArg).not.toHaveProperty('userId');
+      expect(loggedArg).not.toHaveProperty('bucket');
       expect(loggedArg).not.toHaveProperty('error');
+      expect(loggedArg).not.toHaveProperty('errorMessage');
       expect(loggedArg).toHaveProperty('errorName', 'Error');
-      expect(loggedArg).toHaveProperty('errorMessage', 'S3 connection reset');
+      expect(loggedArg).toHaveProperty('category', 's3_cache_lookup');
+      // The raw error message must not leak into any serialized log argument.
+      expect(serializeLogArgs(errorSpy.mock.calls[0])).not.toContain('S3 connection reset');
+      expect(serializeLogArgs(errorSpy.mock.calls[0])).not.toContain('test-user-id');
+      expect(serializeLogArgs(errorSpy.mock.calls[0])).not.toContain('test-bucket');
       errorSpy.mockRestore();
     });
 
-    test('provider error logs sanitized error without userId or raw error', async () => {
+    test('provider error logs no upstream body, userId, bucket, or s3 key', async () => {
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       mockTtsSettingsDB.get.mockResolvedValueOnce({
         user_id: 'test-user-id',
@@ -576,7 +632,13 @@ describe('TTS Route', () => {
       const notFoundError = new Error('Not found');
       (notFoundError as any).name = 'NotFound';
       mockS3Client.send.mockRejectedValueOnce(notFoundError);
-      mockTTSProvider.generate.mockRejectedValueOnce(new Error('Provider API key invalid'));
+      // Mirrors OpenAIProvider/ElevenLabsProvider/GeminiProvider, which embed the
+      // full upstream response body in error.message. The secret and user id
+      // embedded here must not reach application logs.
+      const SECRET_MARKER = 'sk-leaked-upstream-secret-XYZ';
+      mockTTSProvider.generate.mockRejectedValueOnce(
+        new Error(`OpenAI TTS API error 401: {"secret":"${SECRET_MARKER}","user":"test-user-id"}`),
+      );
 
       const app = createTestApp();
       await app.request('/generate', {
@@ -587,9 +649,16 @@ describe('TTS Route', () => {
 
       const loggedArg = errorSpy.mock.calls[0][1] as Record<string, unknown>;
       expect(loggedArg).not.toHaveProperty('userId');
+      expect(loggedArg).not.toHaveProperty('bucket');
+      expect(loggedArg).not.toHaveProperty('s3Key');
       expect(loggedArg).not.toHaveProperty('error');
+      expect(loggedArg).not.toHaveProperty('errorMessage');
       expect(loggedArg).toHaveProperty('errorName', 'Error');
-      expect(loggedArg).toHaveProperty('errorMessage', 'Provider API key invalid');
+      expect(loggedArg).toHaveProperty('category', 'provider_generate');
+      const serialized = serializeLogArgs(errorSpy.mock.calls[0]);
+      expect(serialized).not.toContain(SECRET_MARKER);
+      expect(serialized).not.toContain('test-user-id');
+      expect(serialized).not.toContain('test-bucket');
       errorSpy.mockRestore();
     });
 
@@ -611,7 +680,9 @@ describe('TTS Route', () => {
       });
       const loggedArg = errorSpy.mock.calls[0][1] as Record<string, unknown>;
       expect(loggedArg).toHaveProperty('errorName', 'Error');
-      expect(loggedArg).toHaveProperty('errorMessage', 'DynamoDB connection lost');
+      expect(loggedArg).toHaveProperty('category', 'unexpected');
+      expect(loggedArg).not.toHaveProperty('errorMessage');
+      expect(serializeLogArgs(errorSpy.mock.calls[0])).not.toContain('DynamoDB connection lost');
       errorSpy.mockRestore();
     });
   });

--- a/apps/vela-api/test/routes/tts.test.ts
+++ b/apps/vela-api/test/routes/tts.test.ts
@@ -80,6 +80,12 @@ function createTestApp(env: Env = TEST_ENV) {
 // embedded in those properties from the leak assertions. Serialize Error
 // arguments via their own properties first, then fall back to JSON.stringify
 // for everything else.
+//
+// The JSON.stringify fallback uses a replacer so a nested Error (e.g.
+// `{ provider, userId, error: new Error('secret') }`) is also expanded —
+// without the replacer JSON.stringify renders a nested Error as `{}` and the
+// secret leaks past the assertion. This guards against a regression that
+// restores the raw error object inside a logged payload.
 function serializeError(error: Error): string {
   return [error.name, error.message, error.stack].filter(Boolean).join('\n');
 }
@@ -89,10 +95,36 @@ function serializeLogArgs(args: unknown[]): string {
     .map((arg) => {
       if (typeof arg === 'string') return arg;
       if (arg instanceof Error) return serializeError(arg);
-      return JSON.stringify(arg);
+      return JSON.stringify(arg, (_key, value) =>
+        value instanceof Error
+          ? { name: value.name, message: value.message, stack: value.stack }
+          : value,
+      );
     })
     .join('\n');
 }
+
+describe('serializeLogArgs', () => {
+  // The unsafe logging pattern these tests guard against used objects such as
+  // `{ provider, userId, error }`. A nested Error's own properties are
+  // non-enumerable, so plain JSON.stringify renders it as `{}` and a secret
+  // embedded in the error would slip past the leak assertions. The replacer
+  // must expand nested Errors so a regression that restores a raw nested
+  // error is caught.
+  test('expands a nested Error and exposes its message', () => {
+    const SECRET_MARKER = 'sk-leaked-nested-secret-XYZ';
+    const serialized = serializeLogArgs([
+      'TTS provider error',
+      { provider: 'elevenlabs', userId: 'test-user-id', error: new Error(SECRET_MARKER) },
+    ]);
+    expect(serialized).toContain(SECRET_MARKER);
+  });
+
+  test('expands a top-level Error argument', () => {
+    const serialized = serializeLogArgs([new Error('top-level secret')]);
+    expect(serialized).toContain('top-level secret');
+  });
+});
 
 describe('TTS Route', () => {
   beforeEach(() => {

--- a/apps/vela-mobile/scripts/verify-production-diagnostics.mjs
+++ b/apps/vela-mobile/scripts/verify-production-diagnostics.mjs
@@ -1,7 +1,18 @@
 import { readdir, readFile } from 'node:fs/promises';
 import { relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { IOS_INTERACTION_PRODUCTION_FORBIDDEN_TOKENS } from '../src/diagnostics/ios-interaction-contract.ts';
+
+const PRODUCTION_FORBIDDEN_TOKENS = [
+  'ios-interaction-diagnostics',
+  'ios-interaction-entry',
+  'iOS Interaction Diagnostics',
+  '/diagnostics/ios-interactions',
+  'vela:dev:ios-interaction-cold-entry',
+  'tts-pronunciation-diagnostics',
+  'tts-pronunciation-entry',
+  '/diagnostics/tts-pronunciation',
+  'Pronunciation diagnostics',
+];
 
 const defaultRoot = fileURLToPath(new URL('../src-capacitor/www/', import.meta.url));
 
@@ -41,7 +52,7 @@ export async function findDiagnosticTokens(root, tokens) {
 }
 
 export function findProductionDiagnosticTokens(root) {
-  return findDiagnosticTokens(root, IOS_INTERACTION_PRODUCTION_FORBIDDEN_TOKENS);
+  return findDiagnosticTokens(root, PRODUCTION_FORBIDDEN_TOKENS);
 }
 
 if (import.meta.main) {

--- a/apps/vela-mobile/scripts/verify-production-diagnostics.test.mjs
+++ b/apps/vela-mobile/scripts/verify-production-diagnostics.test.mjs
@@ -8,13 +8,19 @@ import {
   findProductionDiagnosticTokens,
 } from './verify-production-diagnostics.mjs';
 import { IOS_INTERACTION_PRODUCTION_FORBIDDEN_TOKENS } from '../src/diagnostics/ios-interaction-contract.ts';
+import {
+  TTS_PRONUNCIATION_DIAGNOSTIC_LABEL,
+  TTS_PRONUNCIATION_DIAGNOSTIC_PATH,
+  TTS_PRONUNCIATION_DIAGNOSTICS_MARKER,
+  TTS_PRONUNCIATION_ENTRY_TEST_ID,
+} from '../src/diagnostics/tts-pronunciation-contract.ts';
 
 const forbiddenTokens = [...IOS_INTERACTION_PRODUCTION_FORBIDDEN_TOKENS];
 const ttsForbiddenTokens = [
-  '/diagnostics/tts-pronunciation',
-  'Pronunciation diagnostics',
-  'tts-pronunciation-diagnostics',
-  'tts-pronunciation-entry',
+  TTS_PRONUNCIATION_DIAGNOSTIC_PATH,
+  TTS_PRONUNCIATION_DIAGNOSTIC_LABEL,
+  TTS_PRONUNCIATION_DIAGNOSTICS_MARKER,
+  TTS_PRONUNCIATION_ENTRY_TEST_ID,
 ];
 
 describe('verify-production-diagnostics', () => {
@@ -43,10 +49,10 @@ describe('verify-production-diagnostics', () => {
     await writeFile(artifact, `const leaked=${JSON.stringify(ttsForbiddenTokens.join(' '))}`);
 
     expect(await findProductionDiagnosticTokens(root)).toEqual([
-      { path: artifact, token: '/diagnostics/tts-pronunciation' },
-      { path: artifact, token: 'Pronunciation diagnostics' },
-      { path: artifact, token: 'tts-pronunciation-diagnostics' },
-      { path: artifact, token: 'tts-pronunciation-entry' },
+      { path: artifact, token: TTS_PRONUNCIATION_DIAGNOSTIC_PATH },
+      { path: artifact, token: TTS_PRONUNCIATION_DIAGNOSTIC_LABEL },
+      { path: artifact, token: TTS_PRONUNCIATION_DIAGNOSTICS_MARKER },
+      { path: artifact, token: TTS_PRONUNCIATION_ENTRY_TEST_ID },
     ]);
   });
 

--- a/apps/vela-mobile/scripts/verify-production-diagnostics.test.mjs
+++ b/apps/vela-mobile/scripts/verify-production-diagnostics.test.mjs
@@ -10,6 +10,12 @@ import {
 import { IOS_INTERACTION_PRODUCTION_FORBIDDEN_TOKENS } from '../src/diagnostics/ios-interaction-contract.ts';
 
 const forbiddenTokens = [...IOS_INTERACTION_PRODUCTION_FORBIDDEN_TOKENS];
+const ttsForbiddenTokens = [
+  '/diagnostics/tts-pronunciation',
+  'Pronunciation diagnostics',
+  'tts-pronunciation-diagnostics',
+  'tts-pronunciation-entry',
+];
 
 describe('verify-production-diagnostics', () => {
   it('returns no matches when emitted JavaScript excludes every forbidden token', async () => {
@@ -28,6 +34,19 @@ describe('verify-production-diagnostics', () => {
         path: artifact,
         token,
       },
+    ]);
+  });
+
+  it('finds every TTS diagnostic token in emitted JavaScript', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'vela-prod-scan-'));
+    const artifact = join(root, 'app.js');
+    await writeFile(artifact, `const leaked=${JSON.stringify(ttsForbiddenTokens.join(' '))}`);
+
+    expect(await findProductionDiagnosticTokens(root)).toEqual([
+      { path: artifact, token: '/diagnostics/tts-pronunciation' },
+      { path: artifact, token: 'Pronunciation diagnostics' },
+      { path: artifact, token: 'tts-pronunciation-diagnostics' },
+      { path: artifact, token: 'tts-pronunciation-entry' },
     ]);
   });
 

--- a/apps/vela-mobile/src/audio/html-audio-player.test.ts
+++ b/apps/vela-mobile/src/audio/html-audio-player.test.ts
@@ -5,6 +5,17 @@ import { HtmlAudioPlayer } from './html-audio-player';
 type AudioEvent = 'ended' | 'error' | 'pause';
 type AudioListener = () => void;
 
+function deferredPlayRejection(): {
+  promise: Promise<void>;
+  reject: (error: unknown) => void;
+} {
+  let rejectPromise!: (error: unknown) => void;
+  const promise = new Promise<void>((_resolve, reject) => {
+    rejectPromise = reject;
+  });
+  return { promise, reject: rejectPromise };
+}
+
 class FakeAudioElement {
   private readonly listeners = new Map<AudioEvent, Set<AudioListener>>();
   private source: string;
@@ -19,6 +30,7 @@ class FakeAudioElement {
   constructor(
     url: string,
     private readonly playError: unknown,
+    private readonly playPromise: Promise<void> | undefined,
   ) {
     this.source = url;
   }
@@ -59,6 +71,9 @@ class FakeAudioElement {
 
   play(): Promise<void> {
     this.playCalls += 1;
+    if (this.playPromise) {
+      return this.playPromise;
+    }
     if (this.playError !== undefined) {
       return Promise.reject(this.playError);
     }
@@ -84,11 +99,13 @@ class FakeAudioElement {
 
 class FakeAudioFactory {
   nextPlayError: unknown;
+  nextPlayPromise: Promise<void> | undefined;
   readonly elements: FakeAudioElement[] = [];
 
   readonly create = (url: string): FakeAudioElement => {
-    const element = new FakeAudioElement(url, this.nextPlayError);
+    const element = new FakeAudioElement(url, this.nextPlayError, this.nextPlayPromise);
     this.nextPlayError = undefined;
+    this.nextPlayPromise = undefined;
     this.elements.push(element);
     return element;
   };
@@ -123,6 +140,30 @@ describe('HtmlAudioPlayer', () => {
     expect(factory.activeElements()).toHaveLength(1);
 
     factory.elementFor('https://audio.example.test/two.mp3').dispatch('ended');
+    await expect(second.finished).resolves.toEqual({ kind: 'ended' });
+  });
+
+  it('ignores a deferred play rejection after restart releases the original playback', async () => {
+    const deferredPlay = deferredPlayRejection();
+    factory.nextPlayPromise = deferredPlay.promise;
+    const first = player.play('https://audio.example.test/deferred-one.mp3');
+    const firstElement = factory.elementFor('https://audio.example.test/deferred-one.mp3');
+
+    const second = player.play('https://audio.example.test/deferred-two.mp3');
+    const secondElement = factory.elementFor('https://audio.example.test/deferred-two.mp3');
+
+    await expect(first.finished).resolves.toEqual({ kind: 'stopped', reason: 'restart' });
+    expect(firstElement.listenerCount()).toBe(0);
+    expect(firstElement.src).toBe('');
+
+    deferredPlay.reject(new Error('late play rejection'));
+    await Promise.resolve();
+
+    await expect(first.finished).resolves.toEqual({ kind: 'stopped', reason: 'restart' });
+    expect(firstElement.listenerCount()).toBe(0);
+    expect(factory.activeElements()).toEqual([secondElement]);
+
+    secondElement.dispatch('ended');
     await expect(second.finished).resolves.toEqual({ kind: 'ended' });
   });
 

--- a/apps/vela-mobile/src/audio/html-audio-player.test.ts
+++ b/apps/vela-mobile/src/audio/html-audio-player.test.ts
@@ -25,6 +25,10 @@ class FakeAudioElement {
   pauseCalls = 0;
   playCalls = 0;
   crossOriginAssignments = 0;
+  // Mirrors HTMLMediaElement.ended: tests set this true to reproduce the
+  // browser's natural-completion state, where `pause` fires before `ended`
+  // while `ended` is already true.
+  ended = false;
   readonly operations: string[] = [];
 
   constructor(
@@ -274,6 +278,22 @@ describe('HtmlAudioPlayer', () => {
     const handle = player.play('https://audio.example.test/ended.mp3');
     const element = factory.elementFor('https://audio.example.test/ended.mp3');
 
+    element.dispatch('ended');
+
+    await expect(handle.finished).resolves.toEqual({ kind: 'ended' });
+    expect(element.listenerCount()).toBe(0);
+  });
+
+  it('reports natural completion as ended when the browser fires pause before ended', async () => {
+    // Reproduces the real HTML media event order at natural completion:
+    // `ended` is already true when `pause` fires, then `ended` fires. Without
+    // the `ended` guard the pause listener would settle as an external
+    // interruption before `ended` could report successful completion.
+    const handle = player.play('https://audio.example.test/natural-end.mp3');
+    const element = factory.elementFor('https://audio.example.test/natural-end.mp3');
+
+    element.ended = true;
+    element.dispatch('pause');
     element.dispatch('ended');
 
     await expect(handle.finished).resolves.toEqual({ kind: 'ended' });

--- a/apps/vela-mobile/src/audio/html-audio-player.test.ts
+++ b/apps/vela-mobile/src/audio/html-audio-player.test.ts
@@ -1,0 +1,249 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MobileAudioError } from './mobile-audio-contract';
+import { HtmlAudioPlayer } from './html-audio-player';
+
+type AudioEvent = 'ended' | 'error' | 'pause';
+type AudioListener = () => void;
+
+class FakeAudioElement {
+  private readonly listeners = new Map<AudioEvent, Set<AudioListener>>();
+  private source: string;
+  private playbackTime = 12;
+
+  preload = '';
+  pauseCalls = 0;
+  playCalls = 0;
+  crossOriginAssignments = 0;
+  readonly operations: string[] = [];
+
+  constructor(
+    url: string,
+    private readonly playError: unknown,
+  ) {
+    this.source = url;
+  }
+
+  get src(): string {
+    return this.source;
+  }
+
+  set src(value: string) {
+    this.operations.push(`src:${value}`);
+    this.source = value;
+  }
+
+  get currentTime(): number {
+    return this.playbackTime;
+  }
+
+  set currentTime(value: number) {
+    this.operations.push(`currentTime:${value}`);
+    this.playbackTime = value;
+  }
+
+  set crossOrigin(_value: string | null) {
+    this.crossOriginAssignments += 1;
+  }
+
+  addEventListener(type: AudioEvent, listener: AudioListener): void {
+    const listeners = this.listeners.get(type) ?? new Set<AudioListener>();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+    this.operations.push(`add:${type}`);
+  }
+
+  removeEventListener(type: AudioEvent, listener: AudioListener): void {
+    this.listeners.get(type)?.delete(listener);
+    this.operations.push(`remove:${type}`);
+  }
+
+  play(): Promise<void> {
+    this.playCalls += 1;
+    if (this.playError !== undefined) {
+      return Promise.reject(this.playError);
+    }
+    return Promise.resolve();
+  }
+
+  pause(): void {
+    this.pauseCalls += 1;
+    this.operations.push('pause');
+    this.dispatch('pause');
+  }
+
+  dispatch(type: AudioEvent): void {
+    for (const listener of [...(this.listeners.get(type) ?? [])]) {
+      listener();
+    }
+  }
+
+  listenerCount(): number {
+    return [...this.listeners.values()].reduce((count, listeners) => count + listeners.size, 0);
+  }
+}
+
+class FakeAudioFactory {
+  nextPlayError: unknown;
+  readonly elements: FakeAudioElement[] = [];
+
+  readonly create = (url: string): FakeAudioElement => {
+    const element = new FakeAudioElement(url, this.nextPlayError);
+    this.nextPlayError = undefined;
+    this.elements.push(element);
+    return element;
+  };
+
+  elementFor(url: string): FakeAudioElement {
+    const element = this.elements.find((candidate) => candidate.src === url);
+    if (!element) {
+      throw new Error(`No audio element for ${url}`);
+    }
+    return element;
+  }
+
+  activeElements(): FakeAudioElement[] {
+    return this.elements.filter((element) => element.src !== '');
+  }
+}
+
+describe('HtmlAudioPlayer', () => {
+  let factory: FakeAudioFactory;
+  let player: HtmlAudioPlayer;
+
+  beforeEach(() => {
+    factory = new FakeAudioFactory();
+    player = new HtmlAudioPlayer(factory.create);
+  });
+
+  it('settles restart before synchronous pause can become interruption', async () => {
+    const first = player.play('https://audio.example.test/one.mp3');
+    const second = player.play('https://audio.example.test/two.mp3');
+
+    await expect(first.finished).resolves.toEqual({ kind: 'stopped', reason: 'restart' });
+    expect(factory.activeElements()).toHaveLength(1);
+
+    factory.elementFor('https://audio.example.test/two.mp3').dispatch('ended');
+    await expect(second.finished).resolves.toEqual({ kind: 'ended' });
+  });
+
+  it('maps a rejected play caused by user activation to gesture_required', async () => {
+    factory.nextPlayError = new DOMException('Not allowed', 'NotAllowedError');
+
+    await expect(player.play('https://audio.example.test/mizu.mp3').finished).rejects.toMatchObject(
+      {
+        name: 'MobileAudioError',
+        code: 'gesture_required',
+      },
+    );
+  });
+
+  it('maps a media element error to media_unavailable', async () => {
+    const handle = player.play('https://audio.example.test/missing.mp3');
+    factory.elementFor('https://audio.example.test/missing.mp3').dispatch('error');
+
+    await expect(handle.finished).rejects.toMatchObject({
+      name: 'MobileAudioError',
+      code: 'media_unavailable',
+    });
+  });
+
+  it('maps any other play rejection to playback_failed and preserves the cause', async () => {
+    const cause = new Error('decoder rejected playback');
+    factory.nextPlayError = cause;
+
+    await expect(player.play('https://audio.example.test/failed.mp3').finished).rejects.toEqual(
+      new MobileAudioError('playback_failed', { cause }),
+    );
+  });
+
+  it('treats an unexplained active pause as an external interruption', async () => {
+    const handle = player.play('https://audio.example.test/paused.mp3');
+    factory.elementFor('https://audio.example.test/paused.mp3').dispatch('pause');
+
+    await expect(handle.finished).resolves.toEqual({ kind: 'interrupted', reason: 'external' });
+  });
+
+  it('stops explicitly as user intent and cleans up in safe order', async () => {
+    const handle = player.play('https://audio.example.test/stopped.mp3');
+    const element = factory.elementFor('https://audio.example.test/stopped.mp3');
+
+    handle.stop();
+
+    await expect(handle.finished).resolves.toEqual({ kind: 'stopped', reason: 'user' });
+    expect(element.pauseCalls).toBe(1);
+    expect(element.currentTime).toBe(0);
+    expect(element.src).toBe('');
+    expect(element.listenerCount()).toBe(0);
+    expect(element.operations).toEqual([
+      'add:ended',
+      'add:error',
+      'add:pause',
+      'remove:ended',
+      'remove:error',
+      'remove:pause',
+      'pause',
+      'currentTime:0',
+      'src:',
+    ]);
+  });
+
+  it('settles a background interruption before pausing and releasing the element', async () => {
+    const handle = player.play('https://audio.example.test/background.mp3');
+    const element = factory.elementFor('https://audio.example.test/background.mp3');
+
+    player.interruptActive('background');
+
+    await expect(handle.finished).resolves.toEqual({
+      kind: 'interrupted',
+      reason: 'background',
+    });
+    expect(element.pauseCalls).toBe(1);
+    expect(element.listenerCount()).toBe(0);
+    expect(element.src).toBe('');
+  });
+
+  it('settles dispose before synchronous pause and makes repeated disposal harmless', async () => {
+    const handle = player.play('https://audio.example.test/dispose.mp3');
+    const element = factory.elementFor('https://audio.example.test/dispose.mp3');
+
+    player.dispose();
+    player.dispose();
+
+    await expect(handle.finished).resolves.toEqual({ kind: 'stopped', reason: 'dispose' });
+    expect(element.pauseCalls).toBe(1);
+    expect(element.listenerCount()).toBe(0);
+    expect(element.src).toBe('');
+  });
+
+  it('removes listeners after natural settlement', async () => {
+    const handle = player.play('https://audio.example.test/ended.mp3');
+    const element = factory.elementFor('https://audio.example.test/ended.mp3');
+
+    element.dispatch('ended');
+
+    await expect(handle.finished).resolves.toEqual({ kind: 'ended' });
+    expect(element.listenerCount()).toBe(0);
+  });
+
+  it('settles each handle exactly once when later events and stop race with completion', async () => {
+    const handle = player.play('https://audio.example.test/race.mp3');
+    const element = factory.elementFor('https://audio.example.test/race.mp3');
+
+    element.dispatch('ended');
+    element.dispatch('error');
+    element.dispatch('pause');
+    handle.stop('restart');
+
+    await expect(handle.finished).resolves.toEqual({ kind: 'ended' });
+    expect(element.pauseCalls).toBe(0);
+  });
+
+  it('preloads automatically, starts immediately, and leaves cross-origin unset', () => {
+    player.play('https://audio.example.test/configured.mp3');
+    const element = factory.elementFor('https://audio.example.test/configured.mp3');
+
+    expect(element.preload).toBe('auto');
+    expect(element.playCalls).toBe(1);
+    expect(element.crossOriginAssignments).toBe(0);
+  });
+});

--- a/apps/vela-mobile/src/audio/html-audio-player.test.ts
+++ b/apps/vela-mobile/src/audio/html-audio-player.test.ts
@@ -188,6 +188,20 @@ describe('HtmlAudioPlayer', () => {
     });
   });
 
+  it('releases the media element after a playback rejection', async () => {
+    const handle = player.play('https://audio.example.test/rejected.mp3');
+    const element = factory.elementFor('https://audio.example.test/rejected.mp3');
+
+    element.dispatch('error');
+
+    await expect(handle.finished).rejects.toMatchObject({
+      name: 'MobileAudioError',
+      code: 'media_unavailable',
+    });
+    expect(element.listenerCount()).toBe(0);
+    expect(element.src).toBe('');
+  });
+
   it('maps any other play rejection to playback_failed and preserves the cause', async () => {
     const cause = new Error('decoder rejected playback');
     factory.nextPlayError = cause;

--- a/apps/vela-mobile/src/audio/html-audio-player.test.ts
+++ b/apps/vela-mobile/src/audio/html-audio-player.test.ts
@@ -217,9 +217,11 @@ describe('HtmlAudioPlayer', () => {
 
   it('treats an unexplained active pause as an external interruption', async () => {
     const handle = player.play('https://audio.example.test/paused.mp3');
-    factory.elementFor('https://audio.example.test/paused.mp3').dispatch('pause');
+    const element = factory.elementFor('https://audio.example.test/paused.mp3');
+    element.dispatch('pause');
 
     await expect(handle.finished).resolves.toEqual({ kind: 'interrupted', reason: 'external' });
+    expect(element.src).toBe('');
   });
 
   it('stops explicitly as user intent and cleans up in safe order', async () => {
@@ -282,6 +284,7 @@ describe('HtmlAudioPlayer', () => {
 
     await expect(handle.finished).resolves.toEqual({ kind: 'ended' });
     expect(element.listenerCount()).toBe(0);
+    expect(element.src).toBe('');
   });
 
   it('reports natural completion as ended when the browser fires pause before ended', async () => {
@@ -298,6 +301,7 @@ describe('HtmlAudioPlayer', () => {
 
     await expect(handle.finished).resolves.toEqual({ kind: 'ended' });
     expect(element.listenerCount()).toBe(0);
+    expect(element.src).toBe('');
   });
 
   it('settles each handle exactly once when later events and stop race with completion', async () => {
@@ -310,7 +314,11 @@ describe('HtmlAudioPlayer', () => {
     handle.stop('restart');
 
     await expect(handle.finished).resolves.toEqual({ kind: 'ended' });
-    expect(element.pauseCalls).toBe(0);
+    // `ended` settles via resolveAndRelease, which calls pause() once during
+    // resource release. The subsequent error/pause/stop events are no-ops
+    // because the playback is already settled.
+    expect(element.pauseCalls).toBe(1);
+    expect(element.src).toBe('');
   });
 
   it('preloads automatically, starts immediately, and leaves cross-origin unset', () => {

--- a/apps/vela-mobile/src/audio/html-audio-player.ts
+++ b/apps/vela-mobile/src/audio/html-audio-player.ts
@@ -1,8 +1,10 @@
 import {
   MobileAudioError,
+  type MobileAudioInterruptionReason,
   type MobileAudioPlaybackHandle,
   type MobileAudioPlaybackOutcome,
   type MobileAudioPlayer,
+  type MobileAudioStopReason,
 } from './mobile-audio-contract';
 
 type AudioEvent = 'ended' | 'error' | 'pause';
@@ -77,7 +79,7 @@ export class HtmlAudioPlayer implements MobileAudioPlayer {
     };
   }
 
-  interruptActive(reason: 'background' | 'external'): void {
+  interruptActive(reason: MobileAudioInterruptionReason): void {
     const playback = this.active;
     if (!playback) {
       return;
@@ -90,14 +92,14 @@ export class HtmlAudioPlayer implements MobileAudioPlayer {
     this.stopActive('dispose');
   }
 
-  private stopActive(reason: 'restart' | 'user' | 'dispose'): void {
+  private stopActive(reason: MobileAudioStopReason): void {
     const playback = this.active;
     if (playback) {
       this.stop(playback, reason);
     }
   }
 
-  private stop(playback: ActivePlayback, reason: 'restart' | 'user' | 'dispose'): void {
+  private stop(playback: ActivePlayback, reason: MobileAudioStopReason): void {
     this.resolveAndRelease(playback, { kind: 'stopped', reason });
   }
 

--- a/apps/vela-mobile/src/audio/html-audio-player.ts
+++ b/apps/vela-mobile/src/audio/html-audio-player.ts
@@ -62,7 +62,7 @@ export class HtmlAudioPlayer implements MobileAudioPlayer {
       resolve: resolveFinished,
       reject: rejectFinished,
       listeners: {
-        ended: () => this.resolve(playback, { kind: 'ended' }),
+        ended: () => this.resolveAndRelease(playback, { kind: 'ended' }),
         error: () => this.reject(playback, new MobileAudioError('media_unavailable')),
         pause: () => {
           // Browsers fire `pause` before `ended` at natural completion. The
@@ -70,7 +70,10 @@ export class HtmlAudioPlayer implements MobileAudioPlayer {
           // ended listener instead of misreporting a natural end as an
           // external interruption.
           if (playback.audio?.ended) return;
-          this.resolve(playback, { kind: 'interrupted', reason: 'external' });
+          this.resolveAndRelease(playback, {
+            kind: 'interrupted',
+            reason: 'external',
+          });
         },
       },
     };

--- a/apps/vela-mobile/src/audio/html-audio-player.ts
+++ b/apps/vela-mobile/src/audio/html-audio-player.ts
@@ -14,6 +14,12 @@ type HtmlAudioElement = {
   src: string;
   preload: string;
   currentTime: number;
+  // The HTMLMediaElement `ended` IDL attribute is true once playback has
+  // reached the end of the resource. Browsers fire `pause` before `ended` at
+  // natural completion (HTML spec: timeupdate -> pause -> ended), and `ended`
+  // is already true when the `pause` event fires, so the pause listener uses
+  // this to distinguish a natural-end pause from an external interruption.
+  ended: boolean;
   play(): Promise<void> | void;
   pause(): void;
   addEventListener(type: AudioEvent, listener: AudioListener): void;
@@ -58,7 +64,14 @@ export class HtmlAudioPlayer implements MobileAudioPlayer {
       listeners: {
         ended: () => this.resolve(playback, { kind: 'ended' }),
         error: () => this.reject(playback, new MobileAudioError('media_unavailable')),
-        pause: () => this.resolve(playback, { kind: 'interrupted', reason: 'external' }),
+        pause: () => {
+          // Browsers fire `pause` before `ended` at natural completion. The
+          // `ended` IDL attribute is already true by then, so defer to the
+          // ended listener instead of misreporting a natural end as an
+          // external interruption.
+          if (playback.audio?.ended) return;
+          this.resolve(playback, { kind: 'interrupted', reason: 'external' });
+        },
       },
     };
 

--- a/apps/vela-mobile/src/audio/html-audio-player.ts
+++ b/apps/vela-mobile/src/audio/html-audio-player.ts
@@ -1,0 +1,200 @@
+import {
+  MobileAudioError,
+  type MobileAudioPlaybackHandle,
+  type MobileAudioPlaybackOutcome,
+  type MobileAudioPlayer,
+} from './mobile-audio-contract';
+
+type AudioEvent = 'ended' | 'error' | 'pause';
+type AudioListener = () => void;
+
+type HtmlAudioElement = {
+  src: string;
+  preload: string;
+  currentTime: number;
+  play(): Promise<void> | void;
+  pause(): void;
+  addEventListener(type: AudioEvent, listener: AudioListener): void;
+  removeEventListener(type: AudioEvent, listener: AudioListener): void;
+};
+
+type ActivePlayback = {
+  audio: HtmlAudioElement | null;
+  settled: boolean;
+  resolve: (outcome: MobileAudioPlaybackOutcome) => void;
+  reject: (error: MobileAudioError) => void;
+  listeners: Record<AudioEvent, AudioListener>;
+};
+
+type HtmlAudioElementFactory = (url: string) => HtmlAudioElement;
+
+const defaultAudioElementFactory: HtmlAudioElementFactory = (url) => new Audio(url);
+
+export class HtmlAudioPlayer implements MobileAudioPlayer {
+  private active: ActivePlayback | null = null;
+
+  constructor(private readonly createAudio: HtmlAudioElementFactory = defaultAudioElementFactory) {}
+
+  play(url: string): MobileAudioPlaybackHandle {
+    this.stopActive('restart');
+
+    const audio = this.createAudio(url);
+    audio.preload = 'auto';
+
+    let resolveFinished!: (outcome: MobileAudioPlaybackOutcome) => void;
+    let rejectFinished!: (error: MobileAudioError) => void;
+    const finished = new Promise<MobileAudioPlaybackOutcome>((resolve, reject) => {
+      resolveFinished = resolve;
+      rejectFinished = reject;
+    });
+
+    const playback: ActivePlayback = {
+      audio,
+      settled: false,
+      resolve: resolveFinished,
+      reject: rejectFinished,
+      listeners: {
+        ended: () => this.resolve(playback, { kind: 'ended' }),
+        error: () => this.reject(playback, new MobileAudioError('media_unavailable')),
+        pause: () => this.resolve(playback, { kind: 'interrupted', reason: 'external' }),
+      },
+    };
+
+    this.attachListeners(playback);
+    this.active = playback;
+
+    try {
+      void Promise.resolve(audio.play()).catch((cause: unknown) => {
+        this.reject(playback, this.playError(cause));
+      });
+    } catch (cause) {
+      this.reject(playback, this.playError(cause));
+    }
+
+    return {
+      finished,
+      stop: (reason = 'user') => this.stop(playback, reason),
+    };
+  }
+
+  interruptActive(reason: 'background' | 'external'): void {
+    const playback = this.active;
+    if (!playback) {
+      return;
+    }
+
+    this.resolveAndRelease(playback, { kind: 'interrupted', reason });
+  }
+
+  dispose(): void {
+    this.stopActive('dispose');
+  }
+
+  private stopActive(reason: 'restart' | 'user' | 'dispose'): void {
+    const playback = this.active;
+    if (playback) {
+      this.stop(playback, reason);
+    }
+  }
+
+  private stop(playback: ActivePlayback, reason: 'restart' | 'user' | 'dispose'): void {
+    this.resolveAndRelease(playback, { kind: 'stopped', reason });
+  }
+
+  private resolveAndRelease(playback: ActivePlayback, outcome: MobileAudioPlaybackOutcome): void {
+    const audio = this.resolve(playback, outcome);
+    if (audio) {
+      this.resetAndRelease(audio);
+    }
+  }
+
+  private resolve(
+    playback: ActivePlayback,
+    outcome: MobileAudioPlaybackOutcome,
+  ): HtmlAudioElement | null {
+    const audio = this.settle(playback);
+    if (audio) {
+      playback.resolve(outcome);
+    }
+    return audio;
+  }
+
+  private reject(playback: ActivePlayback, error: MobileAudioError): void {
+    const audio = this.settle(playback);
+    if (audio) {
+      playback.reject(error);
+    }
+  }
+
+  private settle(playback: ActivePlayback): HtmlAudioElement | null {
+    if (playback.settled) {
+      return null;
+    }
+
+    playback.settled = true;
+    const audio = playback.audio;
+    if (!audio) {
+      return null;
+    }
+
+    this.detachListeners(audio, playback.listeners);
+    if (this.active === playback) {
+      this.active = null;
+    }
+    playback.audio = null;
+    return audio;
+  }
+
+  private attachListeners(playback: ActivePlayback): void {
+    const audio = playback.audio;
+    if (!audio) {
+      return;
+    }
+
+    audio.addEventListener('ended', playback.listeners.ended);
+    audio.addEventListener('error', playback.listeners.error);
+    audio.addEventListener('pause', playback.listeners.pause);
+  }
+
+  private detachListeners(
+    audio: HtmlAudioElement,
+    listeners: Record<AudioEvent, AudioListener>,
+  ): void {
+    audio.removeEventListener('ended', listeners.ended);
+    audio.removeEventListener('error', listeners.error);
+    audio.removeEventListener('pause', listeners.pause);
+  }
+
+  private resetAndRelease(audio: HtmlAudioElement): void {
+    try {
+      audio.pause();
+    } catch {
+      // The outcome is already settled; continue releasing the media resource.
+    }
+
+    try {
+      audio.currentTime = 0;
+    } catch {
+      // Some media elements reject seeking before metadata is available.
+    }
+
+    try {
+      audio.src = '';
+    } catch {
+      // Release is best effort after the public handle has settled.
+    }
+  }
+
+  private playError(cause: unknown): MobileAudioError {
+    if (
+      typeof cause === 'object' &&
+      cause !== null &&
+      'name' in cause &&
+      cause.name === 'NotAllowedError'
+    ) {
+      return new MobileAudioError('gesture_required', { cause });
+    }
+
+    return new MobileAudioError('playback_failed', { cause });
+  }
+}

--- a/apps/vela-mobile/src/audio/html-audio-player.ts
+++ b/apps/vela-mobile/src/audio/html-audio-player.ts
@@ -123,6 +123,7 @@ export class HtmlAudioPlayer implements MobileAudioPlayer {
     const audio = this.settle(playback);
     if (audio) {
       playback.reject(error);
+      this.resetAndRelease(audio);
     }
   }
 

--- a/apps/vela-mobile/src/audio/mobile-audio-contract.ts
+++ b/apps/vela-mobile/src/audio/mobile-audio-contract.ts
@@ -14,7 +14,12 @@ export class MobileAudioError extends Error {
     options?: { cause?: unknown },
   ) {
     super(code, options);
-    this.name = 'MobileAudioError';
+    Object.defineProperty(this, 'name', {
+      value: 'MobileAudioError',
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
   }
 }
 

--- a/apps/vela-mobile/src/audio/mobile-audio-contract.ts
+++ b/apps/vela-mobile/src/audio/mobile-audio-contract.ts
@@ -1,0 +1,27 @@
+export type MobileAudioPlaybackOutcome =
+  | { kind: 'ended' }
+  | { kind: 'stopped'; reason: 'restart' | 'user' | 'dispose' }
+  | { kind: 'interrupted'; reason: 'background' | 'external' };
+
+export type MobileAudioErrorCode = 'gesture_required' | 'media_unavailable' | 'playback_failed';
+
+export class MobileAudioError extends Error {
+  constructor(
+    readonly code: MobileAudioErrorCode,
+    options?: { cause?: unknown },
+  ) {
+    super(code, options);
+    this.name = 'MobileAudioError';
+  }
+}
+
+export type MobileAudioPlaybackHandle = {
+  finished: Promise<MobileAudioPlaybackOutcome>;
+  stop(reason?: 'restart' | 'user' | 'dispose'): void;
+};
+
+export type MobileAudioPlayer = {
+  play(url: string): MobileAudioPlaybackHandle;
+  interruptActive(reason: 'background' | 'external'): void;
+  dispose(): void;
+};

--- a/apps/vela-mobile/src/audio/mobile-audio-contract.ts
+++ b/apps/vela-mobile/src/audio/mobile-audio-contract.ts
@@ -1,7 +1,10 @@
+export type MobileAudioStopReason = 'restart' | 'user' | 'dispose';
+export type MobileAudioInterruptionReason = 'background' | 'external';
+
 export type MobileAudioPlaybackOutcome =
   | { kind: 'ended' }
-  | { kind: 'stopped'; reason: 'restart' | 'user' | 'dispose' }
-  | { kind: 'interrupted'; reason: 'background' | 'external' };
+  | { kind: 'stopped'; reason: MobileAudioStopReason }
+  | { kind: 'interrupted'; reason: MobileAudioInterruptionReason };
 
 export type MobileAudioErrorCode = 'gesture_required' | 'media_unavailable' | 'playback_failed';
 
@@ -17,11 +20,11 @@ export class MobileAudioError extends Error {
 
 export type MobileAudioPlaybackHandle = {
   finished: Promise<MobileAudioPlaybackOutcome>;
-  stop(reason?: 'restart' | 'user' | 'dispose'): void;
+  stop(reason?: MobileAudioStopReason): void;
 };
 
 export type MobileAudioPlayer = {
   play(url: string): MobileAudioPlaybackHandle;
-  interruptActive(reason: 'background' | 'external'): void;
+  interruptActive(reason: MobileAudioInterruptionReason): void;
   dispose(): void;
 };

--- a/apps/vela-mobile/src/auth/mobile-auth-contract.ts
+++ b/apps/vela-mobile/src/auth/mobile-auth-contract.ts
@@ -112,12 +112,14 @@ export type MobileAuthState = {
 /* global HeadersInit, RequestInit */
 export type MobileAuthenticatedApiRequest = {
   path: string;
+  transportTimeoutMs?: number;
   init?: Omit<RequestInit, 'headers'> & { headers?: HeadersInit };
 };
 
 export type MobileAuthenticatedApiRequestErrorCode =
   | 'invalid_request_path'
   | 'invalid_request_headers'
+  | 'invalid_request_timeout'
   | 'request_timeout'
   | 'session_unavailable'
   | 'session_changed'

--- a/apps/vela-mobile/src/boot/capacitor-lifecycle.test.ts
+++ b/apps/vela-mobile/src/boot/capacitor-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import type { PluginListenerHandle } from '@capacitor/core';
 import { focusManager } from '@tanstack/vue-query';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mobileLifecycleState, resetMobileLifecycleForTests } from 'src/services/mobile-lifecycle';
 import { registerCapacitorLifecycle, resetCapacitorLifecycleForTests } from './capacitor-lifecycle';
 
 describe('Capacitor lifecycle', () => {
@@ -13,6 +14,7 @@ describe('Capacitor lifecycle', () => {
 
   it('registers resume diagnostics and native focus listeners once', async () => {
     resetCapacitorLifecycleForTests();
+    resetMobileLifecycleForTests();
     setFocused = vi.spyOn(focusManager, 'setFocused');
     const addListener = vi.fn(async (name: 'resume' | 'appStateChange', listener: () => void) => {
       if (name === 'appStateChange') {
@@ -28,6 +30,10 @@ describe('Capacitor lifecycle', () => {
     expect(addListener).toHaveBeenCalledWith('appStateChange', expect.any(Function));
     expect(setFocused).toHaveBeenNthCalledWith(1, false);
     expect(setFocused).toHaveBeenNthCalledWith(2, true);
+    expect(mobileLifecycleState.isActive.value).toBe(true);
+    expect(mobileLifecycleState.lastBecameInactiveAt.value).not.toBeNull();
+    expect(mobileLifecycleState.lastBecameActiveAt.value).not.toBeNull();
+    expect(mobileLifecycleState.resumeCount.value).toBe(0);
   });
 
   it('shares one native listener registration across concurrent callers', async () => {

--- a/apps/vela-mobile/src/boot/capacitor-lifecycle.ts
+++ b/apps/vela-mobile/src/boot/capacitor-lifecycle.ts
@@ -2,7 +2,7 @@ import { App } from '@capacitor/app';
 import type { PluginListenerHandle } from '@capacitor/core';
 import { focusManager } from '@tanstack/vue-query';
 import { defineBoot } from '#q-app/wrappers';
-import { recordAppResume } from 'src/services/mobile-lifecycle';
+import { recordAppResume, recordAppStateChange } from 'src/services/mobile-lifecycle';
 
 export type ResumeAppAdapter = {
   addListener(eventName: 'resume', listener: () => void): Promise<PluginListenerHandle>;
@@ -25,6 +25,7 @@ export async function registerCapacitorLifecycle(adapter: ResumeAppAdapter = App
       handles.push(await adapter.addListener('resume', () => recordAppResume()));
       handles.push(
         await adapter.addListener('appStateChange', (event) => {
+          recordAppStateChange(event.isActive);
           focusManager.setFocused(event.isActive);
         }),
       );

--- a/apps/vela-mobile/src/boot/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/boot/mobile-auth.test.ts
@@ -3,6 +3,7 @@ import type { MobileAuthCoordinatorDependencies } from '../services/mobile-auth'
 
 const mocks = vi.hoisted(() => {
   const coordinator = {
+    state: {},
     initialize: vi.fn(() => new Promise<void>(() => {})),
   };
   return {
@@ -51,7 +52,9 @@ const mocks = vi.hoisted(() => {
     },
     coordinator,
     createCoordinator: vi.fn((_dependencies: unknown) => coordinator),
+    ttsService: { clearUser: vi.fn() },
     provideMobileServices: vi.fn(),
+    installMobileTtsAuthIsolation: vi.fn(),
     createTransactionStore: vi.fn(),
     createIosStore: vi.fn(),
     createUnsupportedStore: vi.fn(),
@@ -78,6 +81,9 @@ vi.mock('../services/mobile-auth', async (importOriginal) => {
 });
 vi.mock('../services/mobile-services', () => ({
   provideMobileServices: mocks.provideMobileServices,
+}));
+vi.mock('../services/mobile-tts-auth-isolation', () => ({
+  installMobileTtsAuthIsolation: mocks.installMobileTtsAuthIsolation,
 }));
 vi.mock('../auth/oauth-transaction-store', () => ({
   createOAuthTransactionStore: mocks.createTransactionStore,
@@ -117,6 +123,7 @@ describe('mobile auth boot', () => {
     mocks.createIosStore.mockReturnValue(mocks.sessionStore);
     mocks.createUnsupportedStore.mockReturnValue(mocks.unsupportedSessionStore);
     mocks.createInstallationStore.mockReturnValue(mocks.installationStore);
+    mocks.provideMobileServices.mockReturnValue({ ttsService: mocks.ttsService });
   });
 
   it('injects Keychain storage only on native iOS', () => {
@@ -160,7 +167,7 @@ describe('mobile auth boot', () => {
     expect(mocks.secureStorage.remove).not.toHaveBeenCalled();
   });
 
-  it('provides services with the coordinator before starting initialization without blocking mount', () => {
+  it('provides services, installs TTS isolation, then starts initialization without blocking mount', () => {
     const app = { provide: vi.fn() };
 
     const result = runBoot({ app });
@@ -168,8 +175,15 @@ describe('mobile auth boot', () => {
     expect(result).toBeUndefined();
     expect(app.provide).toHaveBeenCalledWith(MOBILE_AUTH_KEY, mocks.coordinator);
     expect(mocks.provideMobileServices).toHaveBeenCalledWith(app, mocks.coordinator);
+    expect(mocks.installMobileTtsAuthIsolation).toHaveBeenCalledWith({
+      state: mocks.coordinator.state,
+      ttsService: mocks.ttsService,
+    });
     expect(mocks.coordinator.initialize).toHaveBeenCalledOnce();
     expect(mocks.provideMobileServices.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.coordinator.initialize.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+    expect(mocks.installMobileTtsAuthIsolation.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.coordinator.initialize.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
     );
   });

--- a/apps/vela-mobile/src/boot/mobile-auth.ts
+++ b/apps/vela-mobile/src/boot/mobile-auth.ts
@@ -13,6 +13,7 @@ import { createOAuthTransactionStore } from '../auth/oauth-transaction-store';
 import { config } from '../config';
 import { createMobileAuthCoordinator, MOBILE_AUTH_KEY } from '../services/mobile-auth';
 import { provideMobileServices } from '../services/mobile-services';
+import { installMobileTtsAuthIsolation } from '../services/mobile-tts-auth-isolation';
 
 export default defineBoot(({ app }) => {
   const isNativeIos = Capacitor.isNativePlatform() && Capacitor.getPlatform() === 'ios';
@@ -62,6 +63,7 @@ export default defineBoot(({ app }) => {
   });
 
   app.provide(MOBILE_AUTH_KEY, coordinator);
-  provideMobileServices(app, coordinator);
+  const services = provideMobileServices(app, coordinator);
+  installMobileTtsAuthIsolation({ state: coordinator.state, ttsService: services.ttsService });
   void coordinator.initialize();
 });

--- a/apps/vela-mobile/src/components/mobile/TtsPronunciationDiagnosticsEntry.test.ts
+++ b/apps/vela-mobile/src/components/mobile/TtsPronunciationDiagnosticsEntry.test.ts
@@ -1,0 +1,33 @@
+import { mount } from '@vue/test-utils';
+import { Quasar } from 'quasar';
+import { createMemoryHistory, createRouter } from 'vue-router';
+import { describe, expect, it, vi } from 'vitest';
+import TtsPronunciationDiagnosticsEntry from './TtsPronunciationDiagnosticsEntry.vue';
+import { pushMobileRoute } from 'src/router/mobile-navigation';
+
+vi.mock('src/router/mobile-navigation', () => ({
+  pushMobileRoute: vi.fn().mockResolvedValue({ kind: 'pushed' }),
+}));
+
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [{ path: '/', component: { template: '<div />' } }],
+});
+
+function mountEntry() {
+  return mount(TtsPronunciationDiagnosticsEntry, {
+    global: {
+      plugins: [Quasar, router],
+    },
+  });
+}
+
+describe('TtsPronunciationDiagnosticsEntry', () => {
+  it('navigates to authenticated TTS diagnostics', async () => {
+    const wrapper = mountEntry();
+
+    await wrapper.get('[data-testid="tts-pronunciation-entry"]').trigger('click');
+
+    expect(pushMobileRoute).toHaveBeenCalledWith(router, '/diagnostics/tts-pronunciation');
+  });
+});

--- a/apps/vela-mobile/src/components/mobile/TtsPronunciationDiagnosticsEntry.vue
+++ b/apps/vela-mobile/src/components/mobile/TtsPronunciationDiagnosticsEntry.vue
@@ -1,0 +1,34 @@
+<template>
+  <q-list>
+    <q-item
+      clickable
+      class="mobile-touch-target"
+      :data-testid="TTS_PRONUNCIATION_ENTRY_TEST_ID"
+      @click="openDiagnostics"
+    >
+      <q-item-section avatar><q-icon name="record_voice_over" /></q-item-section>
+      <q-item-section>
+        <q-item-label>{{ TTS_PRONUNCIATION_DIAGNOSTIC_LABEL }}</q-item-label>
+        <q-item-label caption>Authenticated Japanese TTS playback</q-item-label>
+      </q-item-section>
+    </q-item>
+  </q-list>
+</template>
+
+<script setup lang="ts">
+import { useRouter } from 'vue-router';
+import {
+  TTS_PRONUNCIATION_DIAGNOSTIC_LABEL,
+  TTS_PRONUNCIATION_DIAGNOSTIC_PATH,
+  TTS_PRONUNCIATION_ENTRY_TEST_ID,
+} from 'src/diagnostics/tts-pronunciation-contract';
+import { pushMobileRoute } from 'src/router/mobile-navigation';
+
+const router = useRouter();
+
+function openDiagnostics(): void {
+  void pushMobileRoute(router, TTS_PRONUNCIATION_DIAGNOSTIC_PATH).catch((error: unknown) => {
+    console.error('Opening pronunciation diagnostics failed', error);
+  });
+}
+</script>

--- a/apps/vela-mobile/src/composables/useDueReviewCount.test.ts
+++ b/apps/vela-mobile/src/composables/useDueReviewCount.test.ts
@@ -342,6 +342,7 @@ describe('useDueReviewCount', () => {
 describe('retryDueCountQuery', () => {
   it.each([
     [0, new MobileApiError('client', { status: 400 }), false],
+    [0, new MobileApiError('client', { status: 429 }), false],
     [0, new MobileApiError('network'), true],
     [0, new MobileApiError('server', { status: 500 }), true],
     [2, new MobileApiError('network'), false],

--- a/apps/vela-mobile/src/composables/useDueReviewCount.test.ts
+++ b/apps/vela-mobile/src/composables/useDueReviewCount.test.ts
@@ -341,8 +341,9 @@ describe('useDueReviewCount', () => {
 
 describe('retryDueCountQuery', () => {
   it.each([
+    [0, new MobileApiError('client', { status: 400 }), false],
     [0, new MobileApiError('network'), true],
-    [1, new MobileApiError('server'), true],
+    [0, new MobileApiError('server', { status: 500 }), true],
     [2, new MobileApiError('network'), false],
     [0, new MobileApiError('unauthorized'), false],
     [0, new Error('network'), false],

--- a/apps/vela-mobile/src/composables/usePronunciationDiagnostic.test.ts
+++ b/apps/vela-mobile/src/composables/usePronunciationDiagnostic.test.ts
@@ -1,0 +1,593 @@
+import { flushPromises } from '@vue/test-utils';
+import { nextTick, reactive, ref, type Ref } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MobileAuthState } from '../auth/mobile-auth-contract';
+import {
+  MobileAudioError,
+  type MobileAudioPlaybackHandle,
+  type MobileAudioPlaybackOutcome,
+  type MobileAudioPlayer,
+} from '../audio/mobile-audio-contract';
+import {
+  MobileTtsError,
+  type MobileTtsErrorCode,
+  type MobileTtsService,
+  type PreparedPronunciation,
+} from '../services/mobile-tts';
+import {
+  INVALID_PRONUNCIATION_DIAGNOSTIC_URL,
+  usePronunciationDiagnostic,
+} from './usePronunciationDiagnostic';
+
+const INPUT = { vocabularyId: '水:ミズ', text: '水' } as const;
+const PREPARED: PreparedPronunciation = {
+  audioUrl: 'https://audio.example.test/mizu.mp3',
+  source: 'generated',
+  expiresAt: 10_000,
+  timings: { settingsMs: 12, generateMs: 34 },
+};
+const REFRESHED: PreparedPronunciation = {
+  audioUrl: 'https://audio.example.test/mizu-refreshed.mp3',
+  source: 'server-cache',
+  expiresAt: 20_000,
+  timings: { settingsMs: 7, generateMs: 0 },
+};
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function controllablePlaybackHandle() {
+  const result = deferred<MobileAudioPlaybackOutcome>();
+  const stop = vi.fn((reason: 'restart' | 'user' | 'dispose' = 'user') => {
+    result.resolve({ kind: 'stopped', reason });
+  });
+  const publicHandle: MobileAudioPlaybackHandle = { finished: result.promise, stop };
+  return { ...result, publicHandle, stop };
+}
+
+function resolvedPlaybackHandle(
+  outcome: MobileAudioPlaybackOutcome = { kind: 'ended' },
+): MobileAudioPlaybackHandle {
+  return { finished: Promise.resolve(outcome), stop: vi.fn() };
+}
+
+function rejectedPlaybackHandle(error: MobileAudioError): MobileAudioPlaybackHandle {
+  return { finished: Promise.reject(error), stop: vi.fn() };
+}
+
+function usableAuthState(userId = 'user-1'): MobileAuthState {
+  return {
+    phase: 'authenticated',
+    operation: 'idle',
+    sessionUsable: true,
+    errorCode: null,
+    retryAction: null,
+    notice: null,
+    user: { userId, email: null },
+  };
+}
+
+function setUsable(state: MobileAuthState, userId = 'user-1'): void {
+  Object.assign(state, usableAuthState(userId));
+}
+
+function setRecovering(state: MobileAuthState, userId = 'user-1'): void {
+  Object.assign(state, {
+    ...usableAuthState(userId),
+    operation: 'refreshing' as const,
+    sessionUsable: false,
+  });
+}
+
+function setSignedOut(state: MobileAuthState): void {
+  Object.assign(state, {
+    phase: 'signedOut' as const,
+    operation: 'idle' as const,
+    sessionUsable: false,
+    errorCode: null,
+    retryAction: null,
+    notice: null,
+    user: null,
+  });
+}
+
+describe('usePronunciationDiagnostic', () => {
+  let now: number;
+  let authState: MobileAuthState;
+  let isActive: Ref<boolean>;
+  let tts: {
+    preparePronunciation: ReturnType<typeof vi.fn<MobileTtsService['preparePronunciation']>>;
+    invalidatePronunciation: ReturnType<typeof vi.fn<MobileTtsService['invalidatePronunciation']>>;
+    clearUser: ReturnType<typeof vi.fn<MobileTtsService['clearUser']>>;
+    clearAll: ReturnType<typeof vi.fn<MobileTtsService['clearAll']>>;
+  };
+  let audio: {
+    play: ReturnType<typeof vi.fn<MobileAudioPlayer['play']>>;
+    interruptActive: ReturnType<typeof vi.fn<MobileAudioPlayer['interruptActive']>>;
+    dispose: ReturnType<typeof vi.fn<MobileAudioPlayer['dispose']>>;
+  };
+
+  function createController() {
+    return usePronunciationDiagnostic({
+      input: INPUT,
+      authState,
+      ttsService: tts,
+      audioPlayer: audio,
+      lifecycleState: { isActive },
+      now: () => now,
+    });
+  }
+
+  beforeEach(() => {
+    now = 1_000;
+    authState = reactive(usableAuthState());
+    isActive = ref(true);
+    tts = {
+      preparePronunciation: vi.fn<MobileTtsService['preparePronunciation']>(),
+      invalidatePronunciation: vi.fn<MobileTtsService['invalidatePronunciation']>(),
+      clearUser: vi.fn<MobileTtsService['clearUser']>(),
+      clearAll: vi.fn<MobileTtsService['clearAll']>(),
+    };
+    audio = {
+      play: vi.fn<MobileAudioPlayer['play']>(),
+      interruptActive: vi.fn<MobileAudioPlayer['interruptActive']>(),
+      dispose: vi.fn<MobileAudioPlayer['dispose']>(),
+    };
+  });
+
+  it('moves idle to preparing to playing to ready', async () => {
+    tts.preparePronunciation.mockResolvedValue(PREPARED);
+    const handle = controllablePlaybackHandle();
+    audio.play.mockReturnValue(handle.publicHandle);
+    const controller = createController();
+
+    expect(controller.state.value).toEqual({ kind: 'idle' });
+    const action = controller.playOrRetry();
+    expect(controller.state.value).toEqual({
+      kind: 'preparing',
+      attempt: 1,
+      recoveringSession: false,
+    });
+    await flushPromises();
+    expect(controller.state.value.kind).toBe('playing');
+
+    handle.resolve({ kind: 'ended' });
+    await action;
+    expect(controller.state.value).toEqual({
+      kind: 'ready',
+      pronunciation: PREPARED,
+      notice: null,
+    });
+    expect(controller.counters.completedPlays.value).toBe(1);
+    expect(controller.counters.preparations.value).toBe(1);
+    expect(controller.counters.playbackAttempts.value).toBe(1);
+    expect(controller.counters.tapToPlayAttemptMs.value).toBe(0);
+  });
+
+  it('retains prepared audio after gesture rejection', async () => {
+    tts.preparePronunciation.mockResolvedValue(PREPARED);
+    audio.play.mockReturnValue(rejectedPlaybackHandle(new MobileAudioError('gesture_required')));
+    const controller = createController();
+
+    await controller.playOrRetry();
+
+    expect(controller.state.value).toMatchObject({
+      kind: 'ready',
+      pronunciation: PREPARED,
+      notice: 'gesture_required',
+    });
+    expect(controller.counters.gestureRejections.value).toBe(1);
+    expect(controller.counters.lastError.value).toBe('gesture_required');
+  });
+
+  it('ignores a second tap while preparation is pending', async () => {
+    const preparation = deferred<PreparedPronunciation>();
+    tts.preparePronunciation.mockReturnValue(preparation.promise);
+    audio.play.mockReturnValue(resolvedPlaybackHandle());
+    const controller = createController();
+
+    const first = controller.playOrRetry();
+    const second = controller.playOrRetry();
+
+    expect(tts.preparePronunciation).toHaveBeenCalledTimes(1);
+    expect(controller.state.value.kind).toBe('preparing');
+
+    preparation.resolve(PREPARED);
+    await Promise.all([first, second]);
+    expect(controller.counters.completedPlays.value).toBe(1);
+  });
+
+  it('restarts active playback before starting a replacement', async () => {
+    tts.preparePronunciation.mockResolvedValue(PREPARED);
+    const firstHandle = controllablePlaybackHandle();
+    const secondHandle = controllablePlaybackHandle();
+    audio.play.mockReturnValueOnce(firstHandle.publicHandle).mockImplementationOnce(() => {
+      firstHandle.stop('restart');
+      return secondHandle.publicHandle;
+    });
+    const controller = createController();
+
+    const firstAction = controller.playOrRetry();
+    await flushPromises();
+    expect(controller.state.value.kind).toBe('playing');
+
+    const secondAction = controller.playOrRetry();
+    expect(firstHandle.stop).toHaveBeenCalledWith('restart');
+    expect(firstHandle.stop).toHaveBeenCalledTimes(1);
+    expect(audio.play).toHaveBeenCalledTimes(2);
+    expect(controller.state.value.kind).toBe('playing');
+
+    secondHandle.resolve({ kind: 'ended' });
+    await Promise.all([firstAction, secondAction]);
+    expect(controller.state.value).toMatchObject({ kind: 'ready', pronunciation: PREPARED });
+    expect(controller.counters.completedPlays.value).toBe(1);
+  });
+
+  it('replays a live ready URL directly without preparing again', async () => {
+    tts.preparePronunciation.mockResolvedValue(PREPARED);
+    audio.play.mockReturnValue(resolvedPlaybackHandle());
+    const controller = createController();
+
+    await controller.playOrRetry();
+    const replay = controller.playOrRetry();
+
+    expect(audio.play).toHaveBeenCalledTimes(2);
+    expect(audio.play).toHaveBeenLastCalledWith(PREPARED.audioUrl);
+    expect(tts.preparePronunciation).toHaveBeenCalledTimes(1);
+    await replay;
+  });
+
+  it.each<MobileTtsErrorCode>([
+    'invalid_input',
+    'not_configured',
+    'unauthorized',
+    'forbidden',
+    'network',
+    'service_unavailable',
+    'generation_timeout',
+    'generation_failed',
+    'invalid_response',
+  ])('keeps %s failure manual-retry only', async (code) => {
+    tts.preparePronunciation.mockRejectedValue(new MobileTtsError(code));
+    const controller = createController();
+
+    await controller.playOrRetry();
+
+    expect(tts.preparePronunciation).toHaveBeenCalledTimes(1);
+    expect(controller.state.value).toEqual({
+      kind: 'error',
+      error: code,
+      pronunciation: null,
+    });
+  });
+
+  it('starts a fresh logical action only after an explicit manual retry', async () => {
+    tts.preparePronunciation
+      .mockRejectedValueOnce(new MobileTtsError('network'))
+      .mockResolvedValueOnce(PREPARED);
+    audio.play.mockReturnValue(resolvedPlaybackHandle());
+    const controller = createController();
+
+    await controller.playOrRetry();
+
+    expect(tts.preparePronunciation).toHaveBeenCalledTimes(1);
+    expect(controller.state.value).toEqual({
+      kind: 'error',
+      error: 'network',
+      pronunciation: null,
+    });
+
+    await controller.playOrRetry();
+    expect(tts.preparePronunciation).toHaveBeenCalledTimes(2);
+    expect(controller.counters.completedPlays.value).toBe(1);
+  });
+
+  it.each(['session_changed', 'session_unavailable'] as const)(
+    'retries one same-user %s control race',
+    async (code) => {
+      tts.preparePronunciation
+        .mockRejectedValueOnce(new MobileTtsError(code))
+        .mockResolvedValueOnce(PREPARED);
+      audio.play.mockReturnValue(resolvedPlaybackHandle());
+      const controller = createController();
+
+      await controller.playOrRetry();
+
+      expect(tts.preparePronunciation).toHaveBeenCalledTimes(2);
+      expect(controller.state.value.kind).toBe('ready');
+    },
+  );
+
+  it.each(['session_changed', 'session_unavailable'] as const)(
+    'surfaces a second same-user %s control failure for manual retry',
+    async (code) => {
+      tts.preparePronunciation.mockRejectedValue(new MobileTtsError(code));
+      const controller = createController();
+
+      await controller.playOrRetry();
+
+      expect(tts.preparePronunciation).toHaveBeenCalledTimes(2);
+      expect(controller.state.value).toEqual({
+        kind: 'error',
+        error: code,
+        pronunciation: null,
+      });
+    },
+  );
+
+  it('waits for same-user pending recovery and continues once when usable', async () => {
+    const firstPreparation = deferred<PreparedPronunciation>();
+    tts.preparePronunciation
+      .mockReturnValueOnce(firstPreparation.promise)
+      .mockResolvedValueOnce(PREPARED);
+    audio.play.mockReturnValue(resolvedPlaybackHandle());
+    const controller = createController();
+
+    const action = controller.playOrRetry();
+    setRecovering(authState);
+    firstPreparation.reject(new MobileTtsError('session_recovery_pending'));
+    await flushPromises();
+
+    expect(controller.state.value).toEqual({
+      kind: 'preparing',
+      attempt: 1,
+      recoveringSession: true,
+    });
+    expect(tts.preparePronunciation).toHaveBeenCalledTimes(1);
+
+    setUsable(authState);
+    await nextTick();
+    await action;
+    expect(tts.preparePronunciation).toHaveBeenCalledTimes(2);
+    expect(controller.state.value.kind).toBe('ready');
+  });
+
+  it('continues once when recovery completed before the pending error settles', async () => {
+    tts.preparePronunciation
+      .mockRejectedValueOnce(new MobileTtsError('session_recovery_pending'))
+      .mockResolvedValueOnce(PREPARED);
+    audio.play.mockReturnValue(resolvedPlaybackHandle());
+    const controller = createController();
+
+    await controller.playOrRetry();
+
+    expect(tts.preparePronunciation).toHaveBeenCalledTimes(2);
+    expect(controller.state.value.kind).toBe('ready');
+  });
+
+  it('surfaces a second recovery-pending failure without a third request', async () => {
+    const firstPreparation = deferred<PreparedPronunciation>();
+    tts.preparePronunciation
+      .mockReturnValueOnce(firstPreparation.promise)
+      .mockRejectedValueOnce(new MobileTtsError('session_recovery_pending'));
+    const controller = createController();
+
+    const action = controller.playOrRetry();
+    setRecovering(authState);
+    firstPreparation.reject(new MobileTtsError('session_recovery_pending'));
+    await flushPromises();
+    setUsable(authState);
+    await nextTick();
+    await action;
+
+    expect(tts.preparePronunciation).toHaveBeenCalledTimes(2);
+    expect(controller.state.value).toEqual({
+      kind: 'error',
+      error: 'session_recovery_pending',
+      pronunciation: null,
+    });
+  });
+
+  it('cancels pending recovery after identity replacement', async () => {
+    const preparation = deferred<PreparedPronunciation>();
+    tts.preparePronunciation.mockReturnValue(preparation.promise);
+    const controller = createController();
+
+    const action = controller.playOrRetry();
+    setRecovering(authState);
+    preparation.reject(new MobileTtsError('session_recovery_pending'));
+    await flushPromises();
+    setUsable(authState, 'user-2');
+    await nextTick();
+    await action;
+
+    expect(tts.preparePronunciation).toHaveBeenCalledTimes(1);
+    expect(controller.state.value).toEqual({ kind: 'idle' });
+  });
+
+  it('invalidates every settings partition before proactively refreshing an expired URL', async () => {
+    tts.preparePronunciation.mockResolvedValueOnce(PREPARED).mockResolvedValueOnce(REFRESHED);
+    audio.play.mockReturnValue(resolvedPlaybackHandle());
+    const controller = createController();
+    await controller.playOrRetry();
+
+    now = PREPARED.expiresAt;
+    await controller.playOrRetry();
+
+    expect(tts.invalidatePronunciation).toHaveBeenCalledWith('user-1', '水:ミズ');
+    expect(tts.invalidatePronunciation).toHaveBeenCalledTimes(1);
+    expect(tts.preparePronunciation).toHaveBeenCalledTimes(2);
+    expect(audio.play).toHaveBeenLastCalledWith(REFRESHED.audioUrl);
+    expect(controller.counters.urlRefreshes.value).toBe(1);
+  });
+
+  it('refreshes once after media failure and requires a new tap to play', async () => {
+    tts.preparePronunciation.mockResolvedValueOnce(PREPARED).mockResolvedValueOnce(REFRESHED);
+    audio.play.mockReturnValue(rejectedPlaybackHandle(new MobileAudioError('media_unavailable')));
+    const controller = createController();
+
+    await controller.playOrRetry();
+
+    expect(tts.invalidatePronunciation).toHaveBeenCalledWith('user-1', '水:ミズ');
+    expect(tts.invalidatePronunciation).toHaveBeenCalledTimes(1);
+    expect(tts.preparePronunciation).toHaveBeenCalledTimes(2);
+    expect(audio.play).toHaveBeenCalledTimes(1);
+    expect(controller.state.value).toEqual({
+      kind: 'ready',
+      pronunciation: REFRESHED,
+      notice: 'audio_refreshed',
+    });
+    expect(controller.counters.urlRefreshes.value).toBe(1);
+  });
+
+  it('does not perform a second automatic refresh in one expired-URL tap', async () => {
+    tts.preparePronunciation.mockResolvedValueOnce(PREPARED).mockResolvedValueOnce(REFRESHED);
+    audio.play
+      .mockReturnValueOnce(resolvedPlaybackHandle())
+      .mockReturnValueOnce(rejectedPlaybackHandle(new MobileAudioError('media_unavailable')));
+    const controller = createController();
+    await controller.playOrRetry();
+
+    now = PREPARED.expiresAt;
+    await controller.playOrRetry();
+
+    expect(tts.preparePronunciation).toHaveBeenCalledTimes(2);
+    expect(tts.invalidatePronunciation).toHaveBeenCalledTimes(2);
+    expect(controller.state.value).toEqual({
+      kind: 'error',
+      error: 'media_unavailable',
+      pronunciation: null,
+    });
+  });
+
+  it('surfaces refresh transport failure without automatically retrying it', async () => {
+    tts.preparePronunciation
+      .mockResolvedValueOnce(PREPARED)
+      .mockRejectedValueOnce(new MobileTtsError('network'));
+    audio.play.mockReturnValue(rejectedPlaybackHandle(new MobileAudioError('media_unavailable')));
+    const controller = createController();
+
+    await controller.playOrRetry();
+
+    expect(tts.preparePronunciation).toHaveBeenCalledTimes(2);
+    expect(controller.state.value).toEqual({
+      kind: 'error',
+      error: 'network',
+      pronunciation: null,
+    });
+  });
+
+  it('interrupts playback in the background and never auto-resumes', async () => {
+    tts.preparePronunciation.mockResolvedValue(PREPARED);
+    const handle = controllablePlaybackHandle();
+    audio.play.mockReturnValue(handle.publicHandle);
+    audio.interruptActive.mockImplementation(() => {
+      handle.resolve({ kind: 'interrupted', reason: 'background' });
+    });
+    const controller = createController();
+    const action = controller.playOrRetry();
+    await flushPromises();
+
+    isActive.value = false;
+    await nextTick();
+    await action;
+    expect(audio.interruptActive).toHaveBeenCalledWith('background');
+    expect(controller.state.value).toEqual({
+      kind: 'interrupted',
+      pronunciation: PREPARED,
+      reason: 'background',
+    });
+    expect(controller.counters.interruptions.value).toBe(1);
+
+    isActive.value = true;
+    await nextTick();
+    expect(audio.play).toHaveBeenCalledTimes(1);
+    expect(controller.state.value.kind).toBe('interrupted');
+  });
+
+  it('stops active playback and discards stale settlement after sign-out', async () => {
+    tts.preparePronunciation.mockResolvedValue(PREPARED);
+    const handle = controllablePlaybackHandle();
+    audio.play.mockReturnValue(handle.publicHandle);
+    const controller = createController();
+    const action = controller.playOrRetry();
+    await flushPromises();
+
+    setSignedOut(authState);
+    await nextTick();
+    await action;
+
+    expect(handle.stop).toHaveBeenCalledWith('dispose');
+    expect(controller.state.value).toEqual({ kind: 'idle' });
+  });
+
+  it('aborts preparation and rejects stale completion after dispose', async () => {
+    const preparation = deferred<PreparedPronunciation>();
+    tts.preparePronunciation.mockReturnValue(preparation.promise);
+    const controller = createController();
+    const action = controller.playOrRetry();
+    const signal = tts.preparePronunciation.mock.calls[0]?.[1]?.signal;
+
+    controller.dispose();
+    preparation.resolve(PREPARED);
+    await action;
+
+    expect(signal?.aborted).toBe(true);
+    expect(audio.dispose).toHaveBeenCalledTimes(1);
+    expect(audio.play).not.toHaveBeenCalled();
+    expect(controller.state.value).toEqual({ kind: 'idle' });
+  });
+
+  it('provides targeted diagnostic invalidation without clearing another user', async () => {
+    tts.preparePronunciation.mockResolvedValue(PREPARED);
+    audio.play.mockReturnValue(resolvedPlaybackHandle());
+    const controller = createController();
+    await controller.playOrRetry();
+
+    controller.invalidatePronunciation();
+
+    expect(tts.invalidatePronunciation).toHaveBeenCalledWith('user-1', '水:ミズ');
+    expect(tts.clearUser).not.toHaveBeenCalled();
+    expect(tts.clearAll).not.toHaveBeenCalled();
+    expect(controller.state.value).toEqual({ kind: 'idle' });
+  });
+
+  it('replaces only the diagnostic URL copy when simulating invalid media', async () => {
+    tts.preparePronunciation.mockResolvedValue(PREPARED);
+    audio.play.mockReturnValue(resolvedPlaybackHandle());
+    const controller = createController();
+    await controller.playOrRetry();
+
+    controller.simulateInvalidUrl();
+
+    expect(controller.state.value).toMatchObject({
+      kind: 'ready',
+      pronunciation: { ...PREPARED, audioUrl: INVALID_PRONUNCIATION_DIAGNOSTIC_URL },
+    });
+    expect(PREPARED.audioUrl).toBe('https://audio.example.test/mizu.mp3');
+    expect(tts.invalidatePronunciation).not.toHaveBeenCalled();
+  });
+
+  it('clears diagnostic counters without changing prepared state', async () => {
+    tts.preparePronunciation.mockResolvedValue(PREPARED);
+    audio.play.mockReturnValue(resolvedPlaybackHandle());
+    const controller = createController();
+    await controller.playOrRetry();
+    expect(controller.counters.completedPlays.value).toBe(1);
+
+    controller.clearCounters();
+
+    expect(controller.counters.preparations.value).toBe(0);
+    expect(controller.counters.playbackAttempts.value).toBe(0);
+    expect(controller.counters.completedPlays.value).toBe(0);
+    expect(controller.counters.gestureRejections.value).toBe(0);
+    expect(controller.counters.interruptions.value).toBe(0);
+    expect(controller.counters.urlRefreshes.value).toBe(0);
+    expect(controller.counters.tapToPlayAttemptMs.value).toBeNull();
+    expect(controller.counters.lastError.value).toBeNull();
+    expect(controller.state.value.kind).toBe('ready');
+  });
+});

--- a/apps/vela-mobile/src/composables/usePronunciationDiagnostic.test.ts
+++ b/apps/vela-mobile/src/composables/usePronunciationDiagnostic.test.ts
@@ -236,6 +236,32 @@ describe('usePronunciationDiagnostic', () => {
     expect(controller.counters.completedPlays.value).toBe(1);
   });
 
+  it('refreshes an expired URL when retrying from the playing state', async () => {
+    tts.preparePronunciation.mockResolvedValueOnce(PREPARED).mockResolvedValueOnce(REFRESHED);
+    const firstHandle = controllablePlaybackHandle();
+    audio.play
+      .mockReturnValueOnce(firstHandle.publicHandle)
+      .mockReturnValueOnce(resolvedPlaybackHandle());
+    const controller = createController();
+
+    const firstAction = controller.playOrRetry();
+    await flushPromises();
+    expect(controller.state.value.kind).toBe('playing');
+
+    now = PREPARED.expiresAt;
+    const secondAction = controller.playOrRetry();
+    await flushPromises();
+    await secondAction;
+
+    expect(tts.invalidatePronunciation).toHaveBeenCalledWith('user-1', '水:ミズ');
+    expect(tts.preparePronunciation).toHaveBeenCalledTimes(2);
+    expect(audio.play).toHaveBeenLastCalledWith(REFRESHED.audioUrl);
+    expect(controller.counters.urlRefreshes.value).toBe(1);
+
+    firstHandle.resolve({ kind: 'stopped', reason: 'restart' });
+    await firstAction;
+  });
+
   it('replays a live ready URL directly without preparing again', async () => {
     tts.preparePronunciation.mockResolvedValue(PREPARED);
     audio.play.mockReturnValue(resolvedPlaybackHandle());

--- a/apps/vela-mobile/src/composables/usePronunciationDiagnostic.test.ts
+++ b/apps/vela-mobile/src/composables/usePronunciationDiagnostic.test.ts
@@ -7,6 +7,7 @@ import {
   type MobileAudioPlaybackHandle,
   type MobileAudioPlaybackOutcome,
   type MobileAudioPlayer,
+  type MobileAudioStopReason,
 } from '../audio/mobile-audio-contract';
 import {
   MobileTtsError,
@@ -51,7 +52,7 @@ function deferred<T>(): Deferred<T> {
 
 function controllablePlaybackHandle() {
   const result = deferred<MobileAudioPlaybackOutcome>();
-  const stop = vi.fn((reason: 'restart' | 'user' | 'dispose' = 'user') => {
+  const stop = vi.fn((reason: MobileAudioStopReason = 'user') => {
     result.resolve({ kind: 'stopped', reason });
   });
   const publicHandle: MobileAudioPlaybackHandle = { finished: result.promise, stop };
@@ -595,6 +596,75 @@ describe('usePronunciationDiagnostic', () => {
     });
     expect(PREPARED.audioUrl).toBe('https://audio.example.test/mizu.mp3');
     expect(tts.invalidatePronunciation).not.toHaveBeenCalled();
+  });
+
+  it('retains a live pronunciation after a playback_failed error', async () => {
+    tts.preparePronunciation.mockResolvedValue(PREPARED);
+    audio.play.mockReturnValue(rejectedPlaybackHandle(new MobileAudioError('playback_failed')));
+    const controller = createController();
+    await controller.playOrRetry();
+
+    expect(controller.state.value).toEqual({
+      kind: 'error',
+      error: 'playback_failed',
+      pronunciation: PREPARED,
+    });
+    expect(controller.counters.lastError.value).toBe('playback_failed');
+  });
+
+  it('clears an expired pronunciation after a playback_failed error', async () => {
+    tts.preparePronunciation.mockResolvedValue(PREPARED);
+    audio.play.mockReturnValue(rejectedPlaybackHandle(new MobileAudioError('playback_failed')));
+    const controller = createController();
+    now = PREPARED.expiresAt;
+    await controller.playOrRetry();
+
+    expect(controller.state.value).toEqual({
+      kind: 'error',
+      error: 'playback_failed',
+      pronunciation: null,
+    });
+  });
+
+  it('replaces the diagnostic URL copy when simulating invalid media from interrupted', async () => {
+    tts.preparePronunciation.mockResolvedValue(PREPARED);
+    const handle = controllablePlaybackHandle();
+    audio.play.mockReturnValue(handle.publicHandle);
+    audio.interruptActive.mockImplementation(() => {
+      handle.resolve({ kind: 'interrupted', reason: 'background' });
+    });
+    const controller = createController();
+    const action = controller.playOrRetry();
+    await flushPromises();
+
+    isActive.value = false;
+    await nextTick();
+    await action;
+
+    expect(controller.state.value.kind).toBe('interrupted');
+    controller.simulateInvalidUrl();
+
+    expect(controller.state.value).toMatchObject({
+      kind: 'interrupted',
+      pronunciation: { ...PREPARED, audioUrl: INVALID_PRONUNCIATION_DIAGNOSTIC_URL },
+      reason: 'background',
+    });
+  });
+
+  it('replaces the diagnostic URL copy when simulating invalid media from error with a retained pronunciation', async () => {
+    tts.preparePronunciation.mockResolvedValue(PREPARED);
+    audio.play.mockReturnValue(rejectedPlaybackHandle(new MobileAudioError('playback_failed')));
+    const controller = createController();
+    await controller.playOrRetry();
+
+    expect(controller.state.value.kind).toBe('error');
+    controller.simulateInvalidUrl();
+
+    expect(controller.state.value).toMatchObject({
+      kind: 'error',
+      error: 'playback_failed',
+      pronunciation: { ...PREPARED, audioUrl: INVALID_PRONUNCIATION_DIAGNOSTIC_URL },
+    });
   });
 
   it('clears diagnostic counters without changing prepared state', async () => {

--- a/apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts
+++ b/apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts
@@ -1,0 +1,510 @@
+import { computed, readonly, ref, watch, type ComputedRef, type Ref } from 'vue';
+import {
+  selectMobileFeatureSessionStatus,
+  type MobileFeatureSessionStatus,
+} from '../auth/mobile-feature-session-status';
+import type { MobileAuthState } from '../auth/mobile-auth-contract';
+import {
+  MobileAudioError,
+  type MobileAudioErrorCode,
+  type MobileAudioPlaybackHandle,
+  type MobileAudioPlayer,
+} from '../audio/mobile-audio-contract';
+import { mobileLifecycleState } from '../services/mobile-lifecycle';
+import {
+  MobileTtsError,
+  type MobilePronunciationInput,
+  type MobileTtsErrorCode,
+  type MobileTtsService,
+  type PreparedPronunciation,
+} from '../services/mobile-tts';
+
+export const INVALID_PRONUNCIATION_DIAGNOSTIC_URL =
+  'https://example.invalid/vela-tts-diagnostic.mp3';
+
+export type ReadyNotice = 'gesture_required' | 'audio_refreshed';
+
+export type PronunciationDiagnosticError = MobileTtsErrorCode | MobileAudioErrorCode;
+
+export type PronunciationDiagnosticState =
+  | { kind: 'idle' }
+  | { kind: 'preparing'; attempt: number; recoveringSession: boolean }
+  | { kind: 'ready'; pronunciation: PreparedPronunciation; notice: ReadyNotice | null }
+  | { kind: 'playing'; pronunciation: PreparedPronunciation }
+  | {
+      kind: 'interrupted';
+      pronunciation: PreparedPronunciation;
+      reason: 'background' | 'external';
+    }
+  | {
+      kind: 'error';
+      error: PronunciationDiagnosticError;
+      pronunciation: PreparedPronunciation | null;
+    };
+
+export type PronunciationDiagnosticCounters = {
+  preparations: Readonly<Ref<number>>;
+  playbackAttempts: Readonly<Ref<number>>;
+  completedPlays: Readonly<Ref<number>>;
+  gestureRejections: Readonly<Ref<number>>;
+  interruptions: Readonly<Ref<number>>;
+  urlRefreshes: Readonly<Ref<number>>;
+  tapToPlayAttemptMs: Readonly<Ref<number | null>>;
+  lastError: Readonly<Ref<PronunciationDiagnosticError | null>>;
+};
+
+export type PronunciationDiagnosticController = {
+  state: Readonly<Ref<PronunciationDiagnosticState>>;
+  sessionStatus: ComputedRef<MobileFeatureSessionStatus>;
+  counters: PronunciationDiagnosticCounters;
+  playOrRetry(): Promise<void>;
+  invalidatePronunciation(): void;
+  simulateInvalidUrl(): void;
+  clearCounters(): void;
+  dispose(): void;
+};
+
+export type UsePronunciationDiagnosticOptions = {
+  input: Omit<MobilePronunciationInput, 'userId'>;
+  authState: Readonly<MobileAuthState>;
+  ttsService: MobileTtsService;
+  audioPlayer: MobileAudioPlayer;
+  lifecycleState?: { isActive: Readonly<Ref<boolean>> };
+  now?: () => number;
+};
+
+type ActionContext = {
+  generation: number;
+  userId: string;
+  tapStartedAt: number;
+  continuationConsumed: boolean;
+  urlRefreshConsumed: boolean;
+};
+
+type RecoveryWaiter = {
+  generation: number;
+  userId: string;
+  resolve(canContinue: boolean): void;
+};
+
+function statusUserId(status: MobileFeatureSessionStatus): string | null {
+  return status.kind === 'unavailable' ? null : status.userId;
+}
+
+function isUsableForUser(status: MobileFeatureSessionStatus, userId: string): boolean {
+  return status.kind === 'usable' && status.userId === userId;
+}
+
+function ttsErrorCode(error: unknown): MobileTtsErrorCode {
+  return error instanceof MobileTtsError ? error.code : 'generation_failed';
+}
+
+function audioErrorCode(error: unknown): MobileAudioErrorCode {
+  return error instanceof MobileAudioError ? error.code : 'playback_failed';
+}
+
+function statePronunciation(state: PronunciationDiagnosticState): PreparedPronunciation | null {
+  switch (state.kind) {
+    case 'ready':
+    case 'playing':
+    case 'interrupted':
+      return state.pronunciation;
+    case 'error':
+      return state.pronunciation;
+    case 'idle':
+    case 'preparing':
+      return null;
+  }
+}
+
+export function usePronunciationDiagnostic(
+  options: UsePronunciationDiagnosticOptions,
+): PronunciationDiagnosticController {
+  const now = options.now ?? Date.now;
+  const lifecycle = options.lifecycleState ?? mobileLifecycleState;
+  const sessionStatus = computed(() => selectMobileFeatureSessionStatus(options.authState));
+  const state = ref<PronunciationDiagnosticState>({ kind: 'idle' });
+
+  const preparations = ref(0);
+  const playbackAttempts = ref(0);
+  const completedPlays = ref(0);
+  const gestureRejections = ref(0);
+  const interruptions = ref(0);
+  const urlRefreshes = ref(0);
+  const tapToPlayAttemptMs = ref<number | null>(null);
+  const lastError = ref<PronunciationDiagnosticError | null>(null);
+
+  let operationGeneration = 0;
+  let disposed = false;
+  let requestController: AbortController | null = null;
+  let activeHandle: MobileAudioPlaybackHandle | null = null;
+  let recoveryWaiter: RecoveryWaiter | null = null;
+  let preparedUserId: string | null = null;
+
+  function isCurrent(context: ActionContext): boolean {
+    return !disposed && context.generation === operationGeneration;
+  }
+
+  function resolveRecoveryWaiter(canContinue: boolean): void {
+    const waiter = recoveryWaiter;
+    recoveryWaiter = null;
+    waiter?.resolve(canContinue);
+  }
+
+  function cancelOwnedOperation(stopReason: 'user' | 'dispose', resetState: boolean): void {
+    operationGeneration += 1;
+    requestController?.abort();
+    requestController = null;
+    resolveRecoveryWaiter(false);
+    const handle = activeHandle;
+    activeHandle = null;
+    handle?.stop(stopReason);
+    if (resetState) {
+      preparedUserId = null;
+      state.value = { kind: 'idle' };
+    }
+  }
+
+  function waitForSameUserSession(context: ActionContext): Promise<boolean> {
+    if (!isCurrent(context)) return Promise.resolve(false);
+    if (isUsableForUser(sessionStatus.value, context.userId)) return Promise.resolve(true);
+    if (statusUserId(sessionStatus.value) !== context.userId) return Promise.resolve(false);
+
+    resolveRecoveryWaiter(false);
+    return new Promise<boolean>((resolve) => {
+      recoveryWaiter = {
+        generation: context.generation,
+        userId: context.userId,
+        resolve,
+      };
+    });
+  }
+
+  async function preparePronunciation(
+    context: ActionContext,
+    attempt: number,
+  ): Promise<PreparedPronunciation | null> {
+    if (!isCurrent(context)) return null;
+    state.value = { kind: 'preparing', attempt, recoveringSession: false };
+    preparations.value += 1;
+
+    const controller = new AbortController();
+    requestController = controller;
+    try {
+      const pronunciation = await options.ttsService.preparePronunciation(
+        {
+          userId: context.userId,
+          vocabularyId: options.input.vocabularyId,
+          text: options.input.text,
+        },
+        { signal: controller.signal },
+      );
+      if (!isCurrent(context)) return null;
+      preparedUserId = context.userId;
+      return pronunciation;
+    } catch (error) {
+      if (!isCurrent(context)) return null;
+      const code = ttsErrorCode(error);
+      lastError.value = code;
+
+      const isControlRace = code === 'session_changed' || code === 'session_unavailable';
+      if (
+        isControlRace &&
+        !context.continuationConsumed &&
+        !controller.signal.aborted &&
+        isUsableForUser(sessionStatus.value, context.userId)
+      ) {
+        context.continuationConsumed = true;
+        return preparePronunciation(context, attempt + 1);
+      }
+
+      if (code === 'session_recovery_pending' && !context.continuationConsumed) {
+        context.continuationConsumed = true;
+        state.value = { kind: 'preparing', attempt, recoveringSession: true };
+        const canContinue = await waitForSameUserSession(context);
+        if (canContinue && isCurrent(context)) {
+          return preparePronunciation(context, attempt + 1);
+        }
+        return null;
+      }
+
+      state.value = { kind: 'error', error: code, pronunciation: null };
+      preparedUserId = null;
+      return null;
+    } finally {
+      if (requestController === controller) requestController = null;
+    }
+  }
+
+  function invalidateForRefresh(context: ActionContext): void {
+    options.ttsService.invalidatePronunciation(context.userId, options.input.vocabularyId);
+    context.urlRefreshConsumed = true;
+    urlRefreshes.value += 1;
+    preparedUserId = null;
+  }
+
+  async function refreshAfterMediaFailure(context: ActionContext): Promise<void> {
+    invalidateForRefresh(context);
+    const pronunciation = await preparePronunciation(context, 1);
+    if (!pronunciation || !isCurrent(context)) return;
+    state.value = { kind: 'ready', pronunciation, notice: 'audio_refreshed' };
+  }
+
+  async function handlePlaybackFailure(
+    error: unknown,
+    pronunciation: PreparedPronunciation,
+    context: ActionContext,
+  ): Promise<void> {
+    if (!isCurrent(context)) return;
+    const code = audioErrorCode(error);
+    lastError.value = code;
+
+    if (code === 'gesture_required') {
+      gestureRejections.value += 1;
+      state.value = { kind: 'ready', pronunciation, notice: 'gesture_required' };
+      return;
+    }
+
+    if (code === 'media_unavailable') {
+      if (context.urlRefreshConsumed) {
+        options.ttsService.invalidatePronunciation(context.userId, options.input.vocabularyId);
+        preparedUserId = null;
+        state.value = { kind: 'error', error: code, pronunciation: null };
+        return;
+      }
+      await refreshAfterMediaFailure(context);
+      return;
+    }
+
+    const retainedPronunciation = now() < pronunciation.expiresAt ? pronunciation : null;
+    preparedUserId = retainedPronunciation ? context.userId : null;
+    state.value = { kind: 'error', error: code, pronunciation: retainedPronunciation };
+  }
+
+  async function playPrepared(
+    pronunciation: PreparedPronunciation,
+    context: ActionContext,
+  ): Promise<void> {
+    if (!isCurrent(context)) return;
+    playbackAttempts.value += 1;
+    tapToPlayAttemptMs.value = Math.max(0, now() - context.tapStartedAt);
+
+    let handle: MobileAudioPlaybackHandle;
+    try {
+      handle = options.audioPlayer.play(pronunciation.audioUrl);
+    } catch (error) {
+      await handlePlaybackFailure(error, pronunciation, context);
+      return;
+    }
+
+    if (!isCurrent(context)) {
+      handle.stop('dispose');
+      return;
+    }
+    activeHandle = handle;
+    preparedUserId = context.userId;
+    state.value = { kind: 'playing', pronunciation };
+
+    try {
+      const outcome = await handle.finished;
+      if (!isCurrent(context)) return;
+      if (activeHandle === handle) activeHandle = null;
+
+      switch (outcome.kind) {
+        case 'ended':
+          completedPlays.value += 1;
+          state.value = { kind: 'ready', pronunciation, notice: null };
+          return;
+        case 'stopped':
+          state.value = { kind: 'ready', pronunciation, notice: null };
+          return;
+        case 'interrupted':
+          interruptions.value += 1;
+          state.value = { kind: 'interrupted', pronunciation, reason: outcome.reason };
+          return;
+      }
+    } catch (error) {
+      if (activeHandle === handle) activeHandle = null;
+      await handlePlaybackFailure(error, pronunciation, context);
+    }
+  }
+
+  async function prepareAndPlay(context: ActionContext): Promise<void> {
+    const pronunciation = await preparePronunciation(context, 1);
+    if (!pronunciation || !isCurrent(context)) return;
+    if (!lifecycle.isActive.value || !isUsableForUser(sessionStatus.value, context.userId)) {
+      state.value = { kind: 'ready', pronunciation, notice: null };
+      return;
+    }
+    await playPrepared(pronunciation, context);
+  }
+
+  async function refreshExpiredAndPlay(context: ActionContext): Promise<void> {
+    invalidateForRefresh(context);
+    const pronunciation = await preparePronunciation(context, 1);
+    if (!pronunciation || !isCurrent(context)) return;
+    if (!lifecycle.isActive.value || !isUsableForUser(sessionStatus.value, context.userId)) {
+      state.value = { kind: 'ready', pronunciation, notice: null };
+      return;
+    }
+    await playPrepared(pronunciation, context);
+  }
+
+  function playOrRetry(): Promise<void> {
+    if (disposed || state.value.kind === 'preparing') return Promise.resolve();
+
+    const status = sessionStatus.value;
+    if (status.kind !== 'usable') {
+      cancelOwnedOperation('dispose', true);
+      return Promise.resolve();
+    }
+
+    const previousState = state.value;
+    operationGeneration += 1;
+    requestController?.abort();
+    requestController = null;
+    resolveRecoveryWaiter(false);
+    const context: ActionContext = {
+      generation: operationGeneration,
+      userId: status.userId,
+      tapStartedAt: now(),
+      continuationConsumed: false,
+      urlRefreshConsumed: false,
+    };
+
+    if (previousState.kind === 'playing') {
+      return playPrepared(previousState.pronunciation, context);
+    }
+
+    const pronunciation = statePronunciation(previousState);
+    if (pronunciation) {
+      if (now() >= pronunciation.expiresAt) {
+        return refreshExpiredAndPlay(context);
+      }
+      return playPrepared(pronunciation, context);
+    }
+
+    return prepareAndPlay(context);
+  }
+
+  function invalidatePronunciation(): void {
+    if (disposed) return;
+    const userId = preparedUserId ?? statusUserId(sessionStatus.value);
+    if (userId) {
+      options.ttsService.invalidatePronunciation(userId, options.input.vocabularyId);
+    }
+    cancelOwnedOperation('user', true);
+  }
+
+  function withDiagnosticUrl(pronunciation: PreparedPronunciation): PreparedPronunciation {
+    return { ...pronunciation, audioUrl: INVALID_PRONUNCIATION_DIAGNOSTIC_URL };
+  }
+
+  function simulateInvalidUrl(): void {
+    if (disposed) return;
+    const current = state.value;
+    switch (current.kind) {
+      case 'ready':
+        state.value = {
+          ...current,
+          pronunciation: withDiagnosticUrl(current.pronunciation),
+        };
+        return;
+      case 'interrupted':
+        state.value = {
+          ...current,
+          pronunciation: withDiagnosticUrl(current.pronunciation),
+        };
+        return;
+      case 'error':
+        if (current.pronunciation) {
+          state.value = {
+            ...current,
+            pronunciation: withDiagnosticUrl(current.pronunciation),
+          };
+        }
+        return;
+      case 'idle':
+      case 'preparing':
+      case 'playing':
+        return;
+    }
+  }
+
+  function clearCounters(): void {
+    preparations.value = 0;
+    playbackAttempts.value = 0;
+    completedPlays.value = 0;
+    gestureRejections.value = 0;
+    interruptions.value = 0;
+    urlRefreshes.value = 0;
+    tapToPlayAttemptMs.value = null;
+    lastError.value = null;
+  }
+
+  const stopSessionWatch = watch(sessionStatus, (next, previous) => {
+    const previousUserId = previous ? statusUserId(previous) : null;
+    const nextUserId = statusUserId(next);
+    if (previous && previousUserId !== nextUserId) {
+      cancelOwnedOperation('dispose', true);
+      return;
+    }
+
+    const waiter = recoveryWaiter;
+    if (
+      waiter &&
+      waiter.generation === operationGeneration &&
+      isUsableForUser(next, waiter.userId)
+    ) {
+      resolveRecoveryWaiter(true);
+    }
+  });
+
+  const stopLifecycleWatch = watch(
+    () => lifecycle.isActive.value,
+    (active) => {
+      if (active || disposed) return;
+      options.audioPlayer.interruptActive('background');
+      if (state.value.kind === 'preparing') {
+        cancelOwnedOperation('dispose', true);
+      }
+    },
+  );
+
+  function dispose(): void {
+    if (disposed) return;
+    disposed = true;
+    operationGeneration += 1;
+    requestController?.abort();
+    requestController = null;
+    resolveRecoveryWaiter(false);
+    const handle = activeHandle;
+    activeHandle = null;
+    handle?.stop('dispose');
+    options.audioPlayer.dispose();
+    stopSessionWatch();
+    stopLifecycleWatch();
+    preparedUserId = null;
+    state.value = { kind: 'idle' };
+  }
+
+  return {
+    state: readonly(state),
+    sessionStatus,
+    counters: {
+      preparations: readonly(preparations),
+      playbackAttempts: readonly(playbackAttempts),
+      completedPlays: readonly(completedPlays),
+      gestureRejections: readonly(gestureRejections),
+      interruptions: readonly(interruptions),
+      urlRefreshes: readonly(urlRefreshes),
+      tapToPlayAttemptMs: readonly(tapToPlayAttemptMs),
+      lastError: readonly(lastError),
+    },
+    playOrRetry,
+    invalidatePronunciation,
+    simulateInvalidUrl,
+    clearCounters,
+    dispose,
+  };
+}

--- a/apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts
+++ b/apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts
@@ -7,6 +7,7 @@ import type { MobileAuthState } from '../auth/mobile-auth-contract';
 import {
   MobileAudioError,
   type MobileAudioErrorCode,
+  type MobileAudioInterruptionReason,
   type MobileAudioPlaybackHandle,
   type MobileAudioPlayer,
 } from '../audio/mobile-audio-contract';
@@ -34,7 +35,7 @@ export type PronunciationDiagnosticState =
   | {
       kind: 'interrupted';
       pronunciation: PreparedPronunciation;
-      reason: 'background' | 'external';
+      reason: MobileAudioInterruptionReason;
     }
   | {
       kind: 'error';

--- a/apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts
+++ b/apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts
@@ -373,6 +373,9 @@ export function usePronunciationDiagnostic(
     };
 
     if (previousState.kind === 'playing') {
+      if (now() >= previousState.pronunciation.expiresAt) {
+        return refreshExpiredAndPlay(context);
+      }
       return playPrepared(previousState.pronunciation, context);
     }
 

--- a/apps/vela-mobile/src/diagnostics/tts-pronunciation-contract.ts
+++ b/apps/vela-mobile/src/diagnostics/tts-pronunciation-contract.ts
@@ -1,0 +1,11 @@
+export const TTS_PRONUNCIATION_DIAGNOSTICS_MARKER = 'tts-pronunciation-diagnostics';
+export const TTS_PRONUNCIATION_ENTRY_TEST_ID = 'tts-pronunciation-entry';
+export const TTS_PRONUNCIATION_DIAGNOSTIC_PATH = '/diagnostics/tts-pronunciation';
+export const TTS_PRONUNCIATION_DIAGNOSTIC_LABEL = 'Pronunciation diagnostics';
+
+export const DIAGNOSTIC_WORD = {
+  vocabularyId: '水:ミズ',
+  text: '水',
+  reading: 'みず',
+  translation: 'water',
+} as const;

--- a/apps/vela-mobile/src/pages/MorePage.test.ts
+++ b/apps/vela-mobile/src/pages/MorePage.test.ts
@@ -1,7 +1,8 @@
 import { flushPromises, mount } from '@vue/test-utils';
 import { Quasar, QLayout, QPageContainer } from 'quasar';
 import { defineComponent } from 'vue';
-import { describe, expect, it, vi } from 'vitest';
+import { createMemoryHistory, createRouter } from 'vue-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   MobileAuthenticatedApiRequestError,
   type MobileAuthCoordinator,
@@ -70,6 +71,38 @@ function mountMorePage(coordinator: MobileAuthCoordinator) {
   });
 }
 
+async function mountMorePageForEnvironment(
+  coordinator: MobileAuthCoordinator,
+  isDevelopment: boolean,
+) {
+  vi.stubEnv('DEV', isDevelopment);
+  vi.resetModules();
+  const [{ default: EnvironmentMorePage }, { MOBILE_AUTH_KEY: environmentMobileAuthKey }] =
+    await Promise.all([import('./MorePage.vue'), import('../services/mobile-auth')]);
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/', component: { template: '<div />' } }],
+  });
+  const Host = defineComponent({
+    components: { QLayout, QPageContainer, EnvironmentMorePage },
+    template:
+      '<q-layout view="hHh Lpr fFf"><q-page-container><environment-more-page /></q-page-container></q-layout>',
+  });
+  return mount(Host, {
+    global: {
+      plugins: [Quasar, router],
+      provide: {
+        [environmentMobileAuthKey as symbol]: coordinator,
+      },
+    },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
 describe('MorePage sign out', () => {
   it('calls the mobile coordinator once and exposes progress', async () => {
     const signOut = deferred<void>();
@@ -108,5 +141,21 @@ describe('MorePage sign out', () => {
       warn.mockRestore();
       error.mockRestore();
     }
+  });
+
+  it('includes the TTS diagnostics entry in development', async () => {
+    const wrapper = await mountMorePageForEnvironment(createCoordinatorStub(), true);
+
+    await vi.waitFor(() => {
+      expect(wrapper.find('[data-testid="tts-pronunciation-entry"]').exists()).toBe(true);
+    });
+  });
+
+  it('omits the TTS diagnostics entry in production', async () => {
+    const wrapper = await mountMorePageForEnvironment(createCoordinatorStub(), false);
+
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="tts-pronunciation-entry"]').exists()).toBe(false);
   });
 });

--- a/apps/vela-mobile/src/pages/MorePage.vue
+++ b/apps/vela-mobile/src/pages/MorePage.vue
@@ -14,6 +14,7 @@
         @click="handleSignOut"
       />
       <development-diagnostics-entry v-if="DevelopmentDiagnosticsEntry" />
+      <tts-pronunciation-diagnostics-entry v-if="TtsPronunciationDiagnosticsEntry" />
     </div>
   </q-page>
 </template>
@@ -41,5 +42,9 @@ async function handleSignOut(): Promise<void> {
 
 const DevelopmentDiagnosticsEntry = import.meta.env.DEV
   ? defineAsyncComponent(() => import('src/components/mobile/IosInteractionDiagnosticsEntry.vue'))
+  : null;
+
+const TtsPronunciationDiagnosticsEntry = import.meta.env.DEV
+  ? defineAsyncComponent(() => import('src/components/mobile/TtsPronunciationDiagnosticsEntry.vue'))
   : null;
 </script>

--- a/apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts
+++ b/apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts
@@ -31,7 +31,7 @@ const PageHost = defineComponent({
 });
 
 const SIGNED_URL =
-  'https://audio.example.test/pronunciations/mizu.mp3?X-Amz-Credential=provider-secret&X-Amz-Signature=signed-secret';
+  'https://audio.example.test/tts/sentinel-user-id/sentinel-vocabulary-id/01234567abcdef89?X-Amz-Credential=provider-secret&X-Amz-Signature=signed-secret';
 
 const PREPARED: PreparedPronunciation = {
   audioUrl: SIGNED_URL,
@@ -333,7 +333,7 @@ describe('TtsPronunciationDiagnosticsPage', () => {
     );
   });
 
-  it('renders safe counters, source, timings, and only a redacted audio host and path', () => {
+  it('renders safe counters, source, timings, and only a redacted audio host and hash suffix', () => {
     const controller = controllerFixture(
       { kind: 'ready', pronunciation: PREPARED, notice: 'audio_refreshed' },
       {
@@ -355,7 +355,7 @@ describe('TtsPronunciationDiagnosticsPage', () => {
     expect(wrapper.get('[data-testid="tts-settings-timing"]').text()).toContain('12 ms');
     expect(wrapper.get('[data-testid="tts-generation-timing"]').text()).toContain('345 ms');
     expect(wrapper.get('[data-testid="tts-audio-location"]').text()).toContain(
-      'audio.example.test/pronunciations/mizu.mp3',
+      'audio.example.test/…/abcdef89',
     );
     expect(wrapper.get('[data-testid="tts-tap-timing"]').text()).toContain('48 ms');
     expect(wrapper.get('[data-testid="tts-last-error"]').text()).toContain(
@@ -372,6 +372,8 @@ describe('TtsPronunciationDiagnosticsPage', () => {
     expect(wrapper.text()).not.toContain('X-Amz-Signature');
     expect(wrapper.text()).not.toContain('provider-secret');
     expect(wrapper.text()).not.toContain('signed-secret');
+    expect(wrapper.text()).not.toContain('sentinel-user-id');
+    expect(wrapper.text()).not.toContain('sentinel-vocabulary-id');
   });
 
   it('never renders raw failure details, credentials, tokens, payloads, or signed query strings', () => {
@@ -387,7 +389,7 @@ describe('TtsPronunciationDiagnosticsPage', () => {
     const controller = controllerFixture(unsafeState);
     const wrapper = mountPageWithController(controller);
 
-    expect(wrapper.text()).toContain('audio.example.test/pronunciations/mizu.mp3');
+    expect(wrapper.text()).toContain('audio.example.test/…/abcdef89');
     for (const forbidden of [
       'provider credential rejected',
       'provider-key-secret',
@@ -397,10 +399,23 @@ describe('TtsPronunciationDiagnosticsPage', () => {
       'X-Amz-Signature',
       'provider-secret',
       'signed-secret',
+      'sentinel-user-id',
+      'sentinel-vocabulary-id',
     ]) {
       expect(wrapper.text()).not.toContain(forbidden);
       expect(wrapper.html()).not.toContain(forbidden);
     }
+  });
+
+  it('directs not-configured users to Vela web settings', () => {
+    const controller = controllerFixture({
+      kind: 'error',
+      error: 'not_configured',
+      pronunciation: null,
+    });
+    const wrapper = mountPageWithController(controller);
+
+    expect(statusRegion(wrapper).text()).toContain('Configure TTS in Vela web settings');
   });
 
   it('wires replay and development actions to the controller with mobile touch targets', async () => {

--- a/apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts
+++ b/apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts
@@ -201,12 +201,8 @@ describe('TtsPronunciationDiagnosticsPage', () => {
     }
   });
 
-  it('renders playing and completed states with restart and replay labels', async () => {
-    const counters = counterFixture();
-    const controller = controllerFixture(
-      { kind: 'playing', pronunciation: PREPARED },
-      { counters },
-    );
+  it('renders playing and prepared states with accurate restart and play labels', async () => {
+    const controller = controllerFixture({ kind: 'playing', pronunciation: PREPARED });
     const wrapper = mountPageWithController(controller);
 
     expect(statusRegion(wrapper).text()).toContain('Playing pronunciation');
@@ -214,12 +210,55 @@ describe('TtsPronunciationDiagnosticsPage', () => {
       'Restart pronunciation',
     );
 
-    counters.completedPlays.value = 1;
     controller.state.value = { kind: 'ready', pronunciation: PREPARED, notice: null };
     await nextTick();
-    expect(statusRegion(wrapper).text()).toContain('Playback completed');
+    expect(statusRegion(wrapper).text()).toContain('prepared and ready to play');
     expect(wrapper.get('[data-testid="tts-play-button"]').attributes('aria-label')).toBe(
-      'Play pronunciation again',
+      'Play pronunciation',
+    );
+  });
+
+  it('keeps ready-state wording neutral when cumulative counters are cleared', async () => {
+    const counters = counterFixture({ completedPlays: 4 });
+    const controller = controllerFixture(
+      { kind: 'ready', pronunciation: PREPARED, notice: null },
+      { counters },
+    );
+    const wrapper = mountPageWithController(controller);
+
+    expect(statusRegion(wrapper).text()).toContain('prepared and ready to play');
+    expect(statusRegion(wrapper).text()).not.toContain('completed');
+    expect(wrapper.get('[data-testid="tts-play-button"]').attributes('aria-label')).toBe(
+      'Play pronunciation',
+    );
+
+    counters.completedPlays.value = 0;
+    await nextTick();
+
+    expect(statusRegion(wrapper).text()).toContain('prepared and ready to play');
+    expect(statusRegion(wrapper).text()).not.toContain('completed');
+    expect(wrapper.get('[data-testid="tts-play-button"]').attributes('aria-label')).toBe(
+      'Play pronunciation',
+    );
+  });
+
+  it('does not claim completion after a previous completion is followed by prepare without play', async () => {
+    const counters = counterFixture({ completedPlays: 1 });
+    const controller = controllerFixture(
+      { kind: 'ready', pronunciation: PREPARED, notice: null },
+      { counters },
+    );
+    const wrapper = mountPageWithController(controller);
+
+    controller.state.value = { kind: 'preparing', attempt: 2, recoveringSession: false };
+    await nextTick();
+    controller.state.value = { kind: 'ready', pronunciation: PREPARED, notice: null };
+    await nextTick();
+
+    expect(statusRegion(wrapper).text()).toContain('prepared and ready to play');
+    expect(statusRegion(wrapper).text()).not.toContain('completed');
+    expect(wrapper.get('[data-testid="tts-play-button"]').attributes('aria-label')).toBe(
+      'Play pronunciation',
     );
   });
 
@@ -243,9 +282,12 @@ describe('TtsPronunciationDiagnosticsPage', () => {
     };
     await nextTick();
     expect(statusRegion(wrapper).text()).toContain('app moved to the background');
+    expect(statusRegion(wrapper).text()).toContain('replay from the beginning');
+    expect(statusRegion(wrapper).text().toLowerCase()).not.toContain('resume');
     expect(wrapper.get('[data-testid="tts-play-button"]').attributes('aria-label')).toBe(
-      'Resume pronunciation',
+      'Replay pronunciation',
     );
+    expect(wrapper.get('[data-testid="tts-play-button"]').text()).toContain('Replay');
 
     controller.state.value = {
       kind: 'interrupted',
@@ -254,6 +296,8 @@ describe('TtsPronunciationDiagnosticsPage', () => {
     };
     await nextTick();
     expect(statusRegion(wrapper).text()).toContain('another audio source');
+    expect(statusRegion(wrapper).text()).toContain('replay from the beginning');
+    expect(statusRegion(wrapper).text().toLowerCase()).not.toContain('resume');
 
     controller.state.value = {
       kind: 'ready',

--- a/apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts
+++ b/apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts
@@ -367,7 +367,7 @@ describe('TtsPronunciationDiagnosticsPage', () => {
     expect(wrapper.text()).toContain('Gesture rejections 1');
     expect(wrapper.text()).toContain('Interruptions 2');
     expect(wrapper.text()).toContain('URL refreshes 1');
-    expect(wrapper.text()).not.toContain('?');
+    expect(wrapper.get('[data-testid="tts-audio-location"]').text()).not.toContain('?');
     expect(wrapper.text()).not.toContain('X-Amz-Credential');
     expect(wrapper.text()).not.toContain('X-Amz-Signature');
     expect(wrapper.text()).not.toContain('provider-secret');

--- a/apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts
+++ b/apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts
@@ -1,0 +1,410 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { QLayout, QPageContainer, Quasar } from 'quasar';
+import { defineComponent, nextTick, reactive, ref, type Ref } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MobileAuthCoordinator } from 'src/auth/mobile-auth-contract';
+import type { MobileFeatureSessionStatus } from 'src/auth/mobile-feature-session-status';
+import type {
+  PronunciationDiagnosticController,
+  PronunciationDiagnosticCounters,
+  PronunciationDiagnosticState,
+} from 'src/composables/usePronunciationDiagnostic';
+import { DIAGNOSTIC_WORD } from 'src/diagnostics/tts-pronunciation-contract';
+import { MOBILE_AUTH_KEY } from 'src/services/mobile-auth';
+import { MOBILE_TTS_SERVICE_KEY } from 'src/services/mobile-services';
+import type { MobileTtsService, PreparedPronunciation } from 'src/services/mobile-tts';
+import TtsPronunciationDiagnosticsPage from './TtsPronunciationDiagnosticsPage.vue';
+
+const composableMocks = vi.hoisted(() => ({
+  usePronunciationDiagnostic: vi.fn(),
+}));
+
+vi.mock('src/composables/usePronunciationDiagnostic', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('src/composables/usePronunciationDiagnostic')>()),
+  usePronunciationDiagnostic: composableMocks.usePronunciationDiagnostic,
+}));
+
+const PageHost = defineComponent({
+  components: { QLayout, QPageContainer, TtsPronunciationDiagnosticsPage },
+  template:
+    '<q-layout view="hHh Lpr fFf"><q-page-container><tts-pronunciation-diagnostics-page /></q-page-container></q-layout>',
+});
+
+const SIGNED_URL =
+  'https://audio.example.test/pronunciations/mizu.mp3?X-Amz-Credential=provider-secret&X-Amz-Signature=signed-secret';
+
+const PREPARED: PreparedPronunciation = {
+  audioUrl: SIGNED_URL,
+  source: 'generated',
+  expiresAt: 20_000,
+  timings: { settingsMs: 12, generateMs: 345 },
+};
+
+type MutableController = Omit<PronunciationDiagnosticController, 'state' | 'sessionStatus'> & {
+  state: Ref<PronunciationDiagnosticState>;
+  sessionStatus: Ref<MobileFeatureSessionStatus>;
+  playOrRetry: ReturnType<typeof vi.fn<PronunciationDiagnosticController['playOrRetry']>>;
+  invalidatePronunciation: ReturnType<
+    typeof vi.fn<PronunciationDiagnosticController['invalidatePronunciation']>
+  >;
+  simulateInvalidUrl: ReturnType<
+    typeof vi.fn<PronunciationDiagnosticController['simulateInvalidUrl']>
+  >;
+  clearCounters: ReturnType<typeof vi.fn<PronunciationDiagnosticController['clearCounters']>>;
+  dispose: ReturnType<typeof vi.fn<PronunciationDiagnosticController['dispose']>>;
+};
+
+type MutableCounters = {
+  [Key in keyof PronunciationDiagnosticCounters]: Ref<
+    PronunciationDiagnosticCounters[Key]['value']
+  >;
+};
+
+function counterFixture(overrides: Partial<{ [Key in keyof MutableCounters]: unknown }> = {}) {
+  return {
+    preparations: ref(overrides.preparations ?? 0),
+    playbackAttempts: ref(overrides.playbackAttempts ?? 0),
+    completedPlays: ref(overrides.completedPlays ?? 0),
+    gestureRejections: ref(overrides.gestureRejections ?? 0),
+    interruptions: ref(overrides.interruptions ?? 0),
+    urlRefreshes: ref(overrides.urlRefreshes ?? 0),
+    tapToPlayAttemptMs: ref(overrides.tapToPlayAttemptMs ?? null),
+    lastError: ref(overrides.lastError ?? null),
+  } as MutableCounters;
+}
+
+function controllerFixture(
+  state: PronunciationDiagnosticState = { kind: 'idle' },
+  options: {
+    counters?: MutableCounters;
+    sessionStatus?: MobileFeatureSessionStatus;
+  } = {},
+): MutableController {
+  return {
+    state: ref(state),
+    sessionStatus: ref(options.sessionStatus ?? { kind: 'usable', userId: 'user-1' }),
+    counters: options.counters ?? counterFixture(),
+    playOrRetry: vi.fn().mockResolvedValue(undefined),
+    invalidatePronunciation: vi.fn(),
+    simulateInvalidUrl: vi.fn(),
+    clearCounters: vi.fn(),
+    dispose: vi.fn(),
+  };
+}
+
+function authCoordinatorFixture(): MobileAuthCoordinator {
+  return {
+    state: reactive({
+      phase: 'authenticated',
+      operation: 'idle',
+      sessionUsable: true,
+      errorCode: null,
+      retryAction: null,
+      notice: null,
+      user: { userId: 'user-1', email: null },
+    }),
+  } as MobileAuthCoordinator;
+}
+
+function ttsServiceFixture(): MobileTtsService {
+  return {
+    preparePronunciation: vi.fn(),
+    invalidatePronunciation: vi.fn(),
+    clearUser: vi.fn(),
+    clearAll: vi.fn(),
+  };
+}
+
+function mountPageWithController(
+  controller: MutableController,
+  dependencies: {
+    coordinator?: MobileAuthCoordinator;
+    ttsService?: MobileTtsService;
+  } = {},
+): VueWrapper {
+  const coordinator = dependencies.coordinator ?? authCoordinatorFixture();
+  const ttsService = dependencies.ttsService ?? ttsServiceFixture();
+  composableMocks.usePronunciationDiagnostic.mockReturnValue(controller);
+
+  return mount(PageHost, {
+    global: {
+      plugins: [Quasar],
+      provide: {
+        [MOBILE_AUTH_KEY as symbol]: coordinator,
+        [MOBILE_TTS_SERVICE_KEY as symbol]: ttsService,
+      },
+    },
+  });
+}
+
+function statusRegion(wrapper: VueWrapper) {
+  return wrapper.get('[data-testid="tts-state-message"]');
+}
+
+beforeEach(() => {
+  composableMocks.usePronunciationDiagnostic.mockReset();
+});
+
+describe('TtsPronunciationDiagnosticsPage', () => {
+  it('renders the fixed pronunciation and wires only the injected controller dependencies', () => {
+    const controller = controllerFixture();
+    const coordinator = authCoordinatorFixture();
+    const ttsService = ttsServiceFixture();
+    const wrapper = mountPageWithController(controller, { coordinator, ttsService });
+
+    expect(wrapper.get('h1').text()).toBe(DIAGNOSTIC_WORD.text);
+    expect(wrapper.get('[data-testid="tts-reading"]').text()).toContain(DIAGNOSTIC_WORD.reading);
+    expect(wrapper.get('[data-testid="tts-translation"]').text()).toContain(
+      DIAGNOSTIC_WORD.translation,
+    );
+    expect(wrapper.get('[data-testid="tts-play-button"]').attributes('aria-label')).toBe(
+      'Prepare and play pronunciation',
+    );
+    expect(statusRegion(wrapper).attributes()).toMatchObject({
+      role: 'status',
+      'aria-live': 'polite',
+      'aria-atomic': 'true',
+    });
+    expect(composableMocks.usePronunciationDiagnostic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: { vocabularyId: '水:ミズ', text: '水' },
+        authState: coordinator.state,
+        ttsService,
+        audioPlayer: expect.objectContaining({
+          play: expect.any(Function),
+          interruptActive: expect.any(Function),
+          dispose: expect.any(Function),
+        }),
+      }),
+    );
+  });
+
+  it('renders ordinary and session-recovery preparation accessibly and disables every action', async () => {
+    const controller = controllerFixture();
+    const wrapper = mountPageWithController(controller);
+
+    controller.state.value = { kind: 'preparing', attempt: 1, recoveringSession: false };
+    await nextTick();
+    expect(statusRegion(wrapper).text()).toContain('Preparing pronunciation');
+    expect(wrapper.get('[data-testid="tts-play-button"]').attributes('disabled')).toBeDefined();
+
+    controller.state.value = { kind: 'preparing', attempt: 2, recoveringSession: true };
+    await nextTick();
+    expect(statusRegion(wrapper).text()).toContain('Recovering your session');
+    for (const selector of [
+      '[data-testid="tts-play-button"]',
+      '[data-testid="tts-invalidate-button"]',
+      '[data-testid="tts-invalid-url-button"]',
+      '[data-testid="tts-clear-counters-button"]',
+    ]) {
+      expect(wrapper.get(selector).attributes('disabled')).toBeDefined();
+    }
+  });
+
+  it('renders playing and completed states with restart and replay labels', async () => {
+    const counters = counterFixture();
+    const controller = controllerFixture(
+      { kind: 'playing', pronunciation: PREPARED },
+      { counters },
+    );
+    const wrapper = mountPageWithController(controller);
+
+    expect(statusRegion(wrapper).text()).toContain('Playing pronunciation');
+    expect(wrapper.get('[data-testid="tts-play-button"]').attributes('aria-label')).toBe(
+      'Restart pronunciation',
+    );
+
+    counters.completedPlays.value = 1;
+    controller.state.value = { kind: 'ready', pronunciation: PREPARED, notice: null };
+    await nextTick();
+    expect(statusRegion(wrapper).text()).toContain('Playback completed');
+    expect(wrapper.get('[data-testid="tts-play-button"]').attributes('aria-label')).toBe(
+      'Play pronunciation again',
+    );
+  });
+
+  it('renders gesture-required, interrupted, and refreshed-audio states with safe recovery labels', async () => {
+    const controller = controllerFixture({
+      kind: 'ready',
+      pronunciation: PREPARED,
+      notice: 'gesture_required',
+    });
+    const wrapper = mountPageWithController(controller);
+
+    expect(statusRegion(wrapper).text()).toContain('direct tap');
+    expect(wrapper.get('[data-testid="tts-play-button"]').attributes('aria-label')).toBe(
+      'Tap to play pronunciation',
+    );
+
+    controller.state.value = {
+      kind: 'interrupted',
+      pronunciation: PREPARED,
+      reason: 'background',
+    };
+    await nextTick();
+    expect(statusRegion(wrapper).text()).toContain('app moved to the background');
+    expect(wrapper.get('[data-testid="tts-play-button"]').attributes('aria-label')).toBe(
+      'Resume pronunciation',
+    );
+
+    controller.state.value = {
+      kind: 'interrupted',
+      pronunciation: PREPARED,
+      reason: 'external',
+    };
+    await nextTick();
+    expect(statusRegion(wrapper).text()).toContain('another audio source');
+
+    controller.state.value = {
+      kind: 'ready',
+      pronunciation: PREPARED,
+      notice: 'audio_refreshed',
+    };
+    await nextTick();
+    expect(statusRegion(wrapper).text()).toContain('audio link was refreshed');
+    expect(wrapper.get('[data-testid="tts-play-button"]').attributes('aria-label')).toBe(
+      'Play refreshed pronunciation',
+    );
+  });
+
+  it.each([
+    ['invalid_input', 'fixed pronunciation request is invalid'],
+    ['network', 'network or request deadline'],
+    ['generation_timeout', 'pronunciation provider timed out'],
+    ['service_unavailable', 'pronunciation service is temporarily unavailable'],
+    ['generation_failed', 'pronunciation provider could not generate audio'],
+    ['playback_failed', 'pronunciation playback failed'],
+  ] as const)('renders %s as an assertive, stable retry state', (error, message) => {
+    const controller = controllerFixture({ kind: 'error', error, pronunciation: null });
+    const wrapper = mountPageWithController(controller);
+
+    expect(statusRegion(wrapper).attributes()).toMatchObject({
+      role: 'alert',
+      'aria-live': 'assertive',
+      'aria-atomic': 'true',
+    });
+    expect(statusRegion(wrapper).text().toLowerCase()).toContain(message);
+    expect(wrapper.get('[data-testid="tts-play-button"]').attributes('aria-label')).toBe(
+      'Retry pronunciation',
+    );
+  });
+
+  it('renders safe counters, source, timings, and only a redacted audio host and path', () => {
+    const controller = controllerFixture(
+      { kind: 'ready', pronunciation: PREPARED, notice: 'audio_refreshed' },
+      {
+        counters: counterFixture({
+          preparations: 2,
+          playbackAttempts: 3,
+          completedPlays: 1,
+          gestureRejections: 1,
+          interruptions: 2,
+          urlRefreshes: 1,
+          tapToPlayAttemptMs: 48,
+          lastError: 'media_unavailable',
+        }),
+      },
+    );
+    const wrapper = mountPageWithController(controller);
+
+    expect(wrapper.get('[data-testid="tts-source"]').text()).toContain('Generated');
+    expect(wrapper.get('[data-testid="tts-settings-timing"]').text()).toContain('12 ms');
+    expect(wrapper.get('[data-testid="tts-generation-timing"]').text()).toContain('345 ms');
+    expect(wrapper.get('[data-testid="tts-audio-location"]').text()).toContain(
+      'audio.example.test/pronunciations/mizu.mp3',
+    );
+    expect(wrapper.get('[data-testid="tts-tap-timing"]').text()).toContain('48 ms');
+    expect(wrapper.get('[data-testid="tts-last-error"]').text()).toContain(
+      'Prepared audio unavailable',
+    );
+    expect(wrapper.text()).toContain('Preparations 2');
+    expect(wrapper.text()).toContain('Playback attempts 3');
+    expect(wrapper.text()).toContain('Completed plays 1');
+    expect(wrapper.text()).toContain('Gesture rejections 1');
+    expect(wrapper.text()).toContain('Interruptions 2');
+    expect(wrapper.text()).toContain('URL refreshes 1');
+    expect(wrapper.text()).not.toContain('?');
+    expect(wrapper.text()).not.toContain('X-Amz-Credential');
+    expect(wrapper.text()).not.toContain('X-Amz-Signature');
+    expect(wrapper.text()).not.toContain('provider-secret');
+    expect(wrapper.text()).not.toContain('signed-secret');
+  });
+
+  it('never renders raw failure details, credentials, tokens, payloads, or signed query strings', () => {
+    const unsafeState = {
+      kind: 'error',
+      error: 'generation_failed',
+      pronunciation: PREPARED,
+      serverMessage: 'provider credential rejected',
+      providerCredential: 'provider-key-secret',
+      token: 'cognito-token-secret',
+      requestPayload: { vocabularyId: 'secret-request-payload' },
+    } as PronunciationDiagnosticState;
+    const controller = controllerFixture(unsafeState);
+    const wrapper = mountPageWithController(controller);
+
+    expect(wrapper.text()).toContain('audio.example.test/pronunciations/mizu.mp3');
+    for (const forbidden of [
+      'provider credential rejected',
+      'provider-key-secret',
+      'cognito-token-secret',
+      'secret-request-payload',
+      'X-Amz-Credential',
+      'X-Amz-Signature',
+      'provider-secret',
+      'signed-secret',
+    ]) {
+      expect(wrapper.text()).not.toContain(forbidden);
+      expect(wrapper.html()).not.toContain(forbidden);
+    }
+  });
+
+  it('wires replay and development actions to the controller with mobile touch targets', async () => {
+    const controller = controllerFixture({ kind: 'ready', pronunciation: PREPARED, notice: null });
+    const wrapper = mountPageWithController(controller);
+
+    const actions = [
+      ['[data-testid="tts-play-button"]', controller.playOrRetry],
+      ['[data-testid="tts-invalidate-button"]', controller.invalidatePronunciation],
+      ['[data-testid="tts-invalid-url-button"]', controller.simulateInvalidUrl],
+      ['[data-testid="tts-clear-counters-button"]', controller.clearCounters],
+    ] as const;
+
+    for (const [selector, action] of actions) {
+      const button = wrapper.get(selector);
+      expect(button.classes()).toContain('mobile-touch-target');
+      await button.trigger('click');
+      expect(action).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('disables playback when the authenticated feature session is not usable', async () => {
+    const controller = controllerFixture(
+      { kind: 'idle' },
+      { sessionStatus: { kind: 'recovering', userId: 'user-1', sessionUsable: false } },
+    );
+    const wrapper = mountPageWithController(controller);
+
+    expect(wrapper.get('[data-testid="tts-session-status"]').text()).toContain(
+      'Session recovering',
+    );
+    expect(wrapper.get('[data-testid="tts-play-button"]').attributes('disabled')).toBeDefined();
+    await wrapper.get('[data-testid="tts-play-button"]').trigger('click');
+    expect(controller.playOrRetry).not.toHaveBeenCalled();
+
+    controller.sessionStatus.value = { kind: 'unavailable' };
+    await nextTick();
+    expect(wrapper.get('[data-testid="tts-session-status"]').text()).toContain(
+      'Session unavailable',
+    );
+  });
+
+  it('disposes the controller when the diagnostic page unmounts', () => {
+    const controller = controllerFixture();
+    const wrapper = mountPageWithController(controller);
+
+    wrapper.unmount();
+
+    expect(controller.dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.vue
+++ b/apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.vue
@@ -230,13 +230,11 @@ function messageForState(current: PronunciationDiagnosticState): string {
       if (current.notice === 'audio_refreshed') {
         return 'The audio link was refreshed. Tap to play the refreshed pronunciation.';
       }
-      return controller.counters.completedPlays.value > 0
-        ? 'Playback completed. Ready to play again.'
-        : 'Pronunciation is prepared and ready to play.';
+      return 'Pronunciation is prepared and ready to play.';
     case 'interrupted':
       return current.reason === 'background'
-        ? 'Playback was interrupted when the app moved to the background. Tap to resume.'
-        : 'Playback was interrupted by another audio source. Tap to resume.';
+        ? 'Playback was interrupted when the app moved to the background. Tap to replay from the beginning.'
+        : 'Playback was interrupted by another audio source. Tap to replay from the beginning.';
     case 'error':
       return errorMessages[current.error];
   }
@@ -281,11 +279,9 @@ const playButtonAriaLabel = computed(() => {
     case 'ready':
       if (state.value.notice === 'gesture_required') return 'Tap to play pronunciation';
       if (state.value.notice === 'audio_refreshed') return 'Play refreshed pronunciation';
-      return controller.counters.completedPlays.value > 0
-        ? 'Play pronunciation again'
-        : 'Play pronunciation';
+      return 'Play pronunciation';
     case 'interrupted':
-      return 'Resume pronunciation';
+      return 'Replay pronunciation';
     case 'error':
       return state.value.pronunciation ? 'Retry playback' : 'Retry pronunciation';
   }
@@ -302,7 +298,7 @@ const playButtonLabel = computed(() => {
     case 'ready':
       return state.value.notice === 'gesture_required' ? 'Tap to play' : 'Play';
     case 'interrupted':
-      return 'Resume';
+      return 'Replay';
     case 'error':
       return state.value.pronunciation ? 'Retry playback' : 'Retry';
   }

--- a/apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.vue
+++ b/apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.vue
@@ -1,0 +1,376 @@
+<template>
+  <q-page
+    padding
+    class="tts-pronunciation-page"
+    :data-testid="TTS_PRONUNCIATION_DIAGNOSTICS_MARKER"
+  >
+    <main class="column q-gutter-lg" aria-labelledby="tts-diagnostic-word">
+      <section class="pronunciation-card column items-center q-gutter-xs text-center">
+        <h1 id="tts-diagnostic-word" class="text-h2 q-my-none" lang="ja">
+          {{ DIAGNOSTIC_WORD.text }}
+        </h1>
+        <p data-testid="tts-reading" class="text-h6 q-my-none" lang="ja">
+          Reading: {{ DIAGNOSTIC_WORD.reading }}
+        </p>
+        <p data-testid="tts-translation" class="text-body1 text-grey-7 q-my-none">
+          Translation: {{ DIAGNOSTIC_WORD.translation }}
+        </p>
+      </section>
+
+      <section class="column q-gutter-sm" aria-labelledby="tts-playback-heading">
+        <h2 id="tts-playback-heading" class="text-h6 q-my-none">Playback</h2>
+        <p data-testid="tts-session-status" class="text-caption q-my-none">
+          {{ sessionStatusLabel }}
+        </p>
+        <p
+          data-testid="tts-state-message"
+          class="state-message q-my-none"
+          :role="stateMessageRole"
+          :aria-live="stateMessageLive"
+          aria-atomic="true"
+        >
+          {{ stateMessage }}
+        </p>
+        <q-btn
+          data-testid="tts-play-button"
+          class="mobile-touch-target full-width"
+          color="primary"
+          :label="playButtonLabel"
+          :aria-label="playButtonAriaLabel"
+          :loading="state.kind === 'preparing'"
+          :disable="playbackDisabled"
+          @click="playOrRetry"
+        />
+      </section>
+
+      <section v-if="pronunciation" class="column q-gutter-xs" aria-labelledby="tts-audio-heading">
+        <h2 id="tts-audio-heading" class="text-h6 q-my-none">Prepared audio</h2>
+        <p data-testid="tts-source" class="q-my-none">Source: {{ sourceLabel }}</p>
+        <p data-testid="tts-settings-timing" class="q-my-none">
+          Settings: {{ formatMilliseconds(pronunciation.timings.settingsMs) }}
+        </p>
+        <p data-testid="tts-generation-timing" class="q-my-none">
+          Generation: {{ formatMilliseconds(pronunciation.timings.generateMs) }}
+        </p>
+        <p v-if="safeAudioLocation" data-testid="tts-audio-location" class="q-my-none">
+          Audio location: {{ safeAudioLocation }}
+        </p>
+      </section>
+
+      <section class="column q-gutter-xs" aria-labelledby="tts-counters-heading">
+        <h2 id="tts-counters-heading" class="text-h6 q-my-none">Diagnostic counters</h2>
+        <p class="q-my-none">
+          Preparations {{ formatCount(controller.counters.preparations.value) }}
+        </p>
+        <p class="q-my-none">
+          Playback attempts {{ formatCount(controller.counters.playbackAttempts.value) }}
+        </p>
+        <p class="q-my-none">
+          Completed plays {{ formatCount(controller.counters.completedPlays.value) }}
+        </p>
+        <p class="q-my-none">
+          Gesture rejections {{ formatCount(controller.counters.gestureRejections.value) }}
+        </p>
+        <p class="q-my-none">
+          Interruptions {{ formatCount(controller.counters.interruptions.value) }}
+        </p>
+        <p class="q-my-none">
+          URL refreshes {{ formatCount(controller.counters.urlRefreshes.value) }}
+        </p>
+        <p data-testid="tts-tap-timing" class="q-my-none">
+          Tap to playback attempt:
+          {{ formatOptionalMilliseconds(controller.counters.tapToPlayAttemptMs.value) }}
+        </p>
+        <p data-testid="tts-last-error" class="q-my-none">Last error: {{ lastErrorLabel }}</p>
+      </section>
+
+      <section class="column q-gutter-sm" aria-labelledby="tts-actions-heading">
+        <h2 id="tts-actions-heading" class="text-h6 q-my-none">Development actions</h2>
+        <q-btn
+          data-testid="tts-invalidate-button"
+          class="mobile-touch-target full-width"
+          outline
+          label="Invalidate cached pronunciation"
+          aria-label="Invalidate cached pronunciation"
+          :disable="diagnosticActionsDisabled"
+          @click="controller.invalidatePronunciation"
+        />
+        <q-btn
+          data-testid="tts-invalid-url-button"
+          class="mobile-touch-target full-width"
+          outline
+          label="Simulate invalid audio URL"
+          aria-label="Simulate invalid audio URL"
+          :disable="diagnosticActionsDisabled || !canSimulateInvalidUrl"
+          @click="controller.simulateInvalidUrl"
+        />
+        <q-btn
+          data-testid="tts-clear-counters-button"
+          class="mobile-touch-target full-width"
+          flat
+          label="Clear diagnostic counters"
+          aria-label="Clear diagnostic counters"
+          :disable="diagnosticActionsDisabled"
+          @click="controller.clearCounters"
+        />
+      </section>
+    </main>
+  </q-page>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, onBeforeUnmount } from 'vue';
+import { HtmlAudioPlayer } from 'src/audio/html-audio-player';
+import {
+  usePronunciationDiagnostic,
+  type PronunciationDiagnosticError,
+  type PronunciationDiagnosticState,
+} from 'src/composables/usePronunciationDiagnostic';
+import {
+  DIAGNOSTIC_WORD,
+  TTS_PRONUNCIATION_DIAGNOSTICS_MARKER,
+} from 'src/diagnostics/tts-pronunciation-contract';
+import { MOBILE_AUTH_KEY } from 'src/services/mobile-auth';
+import { MOBILE_TTS_SERVICE_KEY } from 'src/services/mobile-services';
+import type { PreparedPronunciation } from 'src/services/mobile-tts';
+
+const providedCoordinator = inject(MOBILE_AUTH_KEY);
+if (!providedCoordinator) {
+  throw new Error('Mobile auth coordinator was not provided');
+}
+
+const providedTtsService = inject(MOBILE_TTS_SERVICE_KEY);
+if (!providedTtsService) {
+  throw new Error('Mobile TTS service was not provided');
+}
+
+const controller = usePronunciationDiagnostic({
+  input: {
+    vocabularyId: DIAGNOSTIC_WORD.vocabularyId,
+    text: DIAGNOSTIC_WORD.text,
+  },
+  authState: providedCoordinator.state,
+  ttsService: providedTtsService,
+  audioPlayer: new HtmlAudioPlayer(),
+});
+
+const state = computed(() => controller.state.value);
+
+const pronunciation = computed<PreparedPronunciation | null>(() => {
+  switch (state.value.kind) {
+    case 'ready':
+    case 'playing':
+    case 'interrupted':
+      return state.value.pronunciation;
+    case 'error':
+      return state.value.pronunciation;
+    case 'idle':
+    case 'preparing':
+      return null;
+  }
+});
+
+const sourceLabels: Record<PreparedPronunciation['source'], string> = {
+  'memory-cache': 'Memory cache',
+  'server-cache': 'Server cache',
+  generated: 'Generated',
+};
+
+const errorMessages: Record<PronunciationDiagnosticError, string> = {
+  invalid_input: 'The fixed pronunciation request is invalid.',
+  not_configured: 'Text-to-speech is not configured.',
+  session_unavailable: 'Your session is unavailable. Sign in again before retrying.',
+  session_changed: 'Your session changed. Try the pronunciation again.',
+  session_recovery_pending: 'Your session is still recovering. Try again shortly.',
+  unauthorized: 'Your session cannot use pronunciation playback.',
+  forbidden: 'Your session cannot use pronunciation playback.',
+  network:
+    'The pronunciation request failed because of the network or request deadline. Try again.',
+  service_unavailable: 'The pronunciation service is temporarily unavailable. Try again later.',
+  generation_timeout: 'The pronunciation provider timed out. Try again.',
+  generation_failed: 'The pronunciation provider could not generate audio. Try again.',
+  invalid_response: 'The pronunciation service returned an invalid response. Try again.',
+  gesture_required: 'Playback needs another direct tap.',
+  media_unavailable: 'The prepared audio is unavailable. Try again.',
+  playback_failed: 'Pronunciation playback failed. Try again.',
+};
+
+const errorLabels: Record<PronunciationDiagnosticError, string> = {
+  invalid_input: 'Invalid fixed request',
+  not_configured: 'TTS not configured',
+  session_unavailable: 'Session unavailable',
+  session_changed: 'Session changed',
+  session_recovery_pending: 'Session recovery pending',
+  unauthorized: 'Unauthorized',
+  forbidden: 'Forbidden',
+  network: 'Network or request deadline',
+  service_unavailable: 'Service unavailable',
+  generation_timeout: 'Provider timeout',
+  generation_failed: 'Generation failed',
+  invalid_response: 'Invalid response',
+  gesture_required: 'Playback gesture required',
+  media_unavailable: 'Prepared audio unavailable',
+  playback_failed: 'Playback failed',
+};
+
+function messageForState(current: PronunciationDiagnosticState): string {
+  switch (current.kind) {
+    case 'idle':
+      return 'Ready to prepare the fixed pronunciation.';
+    case 'preparing':
+      return current.recoveringSession
+        ? `Recovering your session before preparing pronunciation (attempt ${current.attempt}).`
+        : `Preparing pronunciation (attempt ${current.attempt}).`;
+    case 'playing':
+      return 'Playing pronunciation.';
+    case 'ready':
+      if (current.notice === 'gesture_required') {
+        return 'Playback needs another direct tap.';
+      }
+      if (current.notice === 'audio_refreshed') {
+        return 'The audio link was refreshed. Tap to play the refreshed pronunciation.';
+      }
+      return controller.counters.completedPlays.value > 0
+        ? 'Playback completed. Ready to play again.'
+        : 'Pronunciation is prepared and ready to play.';
+    case 'interrupted':
+      return current.reason === 'background'
+        ? 'Playback was interrupted when the app moved to the background. Tap to resume.'
+        : 'Playback was interrupted by another audio source. Tap to resume.';
+    case 'error':
+      return errorMessages[current.error];
+  }
+}
+
+const stateMessage = computed(() => messageForState(state.value));
+const stateMessageRole = computed(() => (state.value.kind === 'error' ? 'alert' : 'status'));
+const stateMessageLive = computed(() =>
+  state.value.kind === 'error' ? ('assertive' as const) : ('polite' as const),
+);
+
+const sessionStatusLabel = computed(() => {
+  switch (controller.sessionStatus.value.kind) {
+    case 'usable':
+      return 'Session ready';
+    case 'recovering':
+      return 'Session recovering';
+    case 'unavailable':
+      return 'Session unavailable';
+  }
+});
+
+const playbackDisabled = computed(
+  () => state.value.kind === 'preparing' || controller.sessionStatus.value.kind !== 'usable',
+);
+const diagnosticActionsDisabled = computed(() => state.value.kind === 'preparing');
+const canSimulateInvalidUrl = computed(
+  () =>
+    state.value.kind === 'ready' ||
+    state.value.kind === 'interrupted' ||
+    (state.value.kind === 'error' && state.value.pronunciation !== null),
+);
+
+const playButtonAriaLabel = computed(() => {
+  switch (state.value.kind) {
+    case 'idle':
+      return 'Prepare and play pronunciation';
+    case 'preparing':
+      return 'Preparing pronunciation';
+    case 'playing':
+      return 'Restart pronunciation';
+    case 'ready':
+      if (state.value.notice === 'gesture_required') return 'Tap to play pronunciation';
+      if (state.value.notice === 'audio_refreshed') return 'Play refreshed pronunciation';
+      return controller.counters.completedPlays.value > 0
+        ? 'Play pronunciation again'
+        : 'Play pronunciation';
+    case 'interrupted':
+      return 'Resume pronunciation';
+    case 'error':
+      return state.value.pronunciation ? 'Retry playback' : 'Retry pronunciation';
+  }
+});
+
+const playButtonLabel = computed(() => {
+  switch (state.value.kind) {
+    case 'idle':
+      return 'Prepare and play';
+    case 'preparing':
+      return 'Preparing';
+    case 'playing':
+      return 'Restart';
+    case 'ready':
+      return state.value.notice === 'gesture_required' ? 'Tap to play' : 'Play';
+    case 'interrupted':
+      return 'Resume';
+    case 'error':
+      return state.value.pronunciation ? 'Retry playback' : 'Retry';
+  }
+});
+
+const sourceLabel = computed(() =>
+  pronunciation.value ? sourceLabels[pronunciation.value.source] : '',
+);
+
+const safeAudioLocation = computed(() => {
+  if (!pronunciation.value) return null;
+  try {
+    const parsed = new URL(pronunciation.value.audioUrl);
+    if (parsed.protocol !== 'https:' || !parsed.host) return null;
+    return `${parsed.host}${parsed.pathname}`;
+  } catch {
+    return null;
+  }
+});
+
+const lastErrorLabel = computed(() => {
+  const lastError = controller.counters.lastError.value;
+  return lastError ? errorLabels[lastError] : 'None';
+});
+
+function formatCount(value: number): string {
+  return Number.isFinite(value) && value >= 0 ? String(Math.floor(value)) : '0';
+}
+
+function formatMilliseconds(value: number): string {
+  return Number.isFinite(value) && value >= 0 ? `${Math.round(value)} ms` : 'Not recorded';
+}
+
+function formatOptionalMilliseconds(value: number | null): string {
+  return value === null ? 'Not recorded' : formatMilliseconds(value);
+}
+
+function playOrRetry(): void {
+  void controller.playOrRetry();
+}
+
+onBeforeUnmount(() => {
+  controller.dispose();
+});
+</script>
+
+<style scoped>
+.tts-pronunciation-page {
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.pronunciation-card,
+.state-message {
+  border-radius: 12px;
+}
+
+.pronunciation-card {
+  padding: 20px;
+  background: rgb(255 255 255 / 72%);
+}
+
+.state-message {
+  padding: 12px;
+  background: rgb(103 80 164 / 10%);
+}
+
+body.body--dark .pronunciation-card {
+  background: rgb(255 255 255 / 8%);
+}
+</style>

--- a/apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.vue
+++ b/apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.vue
@@ -178,7 +178,7 @@ const sourceLabels: Record<PreparedPronunciation['source'], string> = {
 
 const errorMessages: Record<PronunciationDiagnosticError, string> = {
   invalid_input: 'The fixed pronunciation request is invalid.',
-  not_configured: 'Text-to-speech is not configured.',
+  not_configured: 'Text-to-speech is not configured. Configure TTS in Vela web settings.',
   session_unavailable: 'Your session is unavailable. Sign in again before retrying.',
   session_changed: 'Your session changed. Try the pronunciation again.',
   session_recovery_pending: 'Your session is still recovering. Try again shortly.',
@@ -313,7 +313,12 @@ const safeAudioLocation = computed(() => {
   try {
     const parsed = new URL(pronunciation.value.audioUrl);
     if (parsed.protocol !== 'https:' || !parsed.host) return null;
-    return `${parsed.host}${parsed.pathname}`;
+    const pathSegments = parsed.pathname.split('/').filter(Boolean);
+    if (pathSegments.length !== 4 || pathSegments[0] !== 'tts') return parsed.host;
+
+    const settingsHash = pathSegments.at(-1);
+    if (!settingsHash || !/^[0-9a-f]{16}$/i.test(settingsHash)) return parsed.host;
+    return `${parsed.host}/…/${settingsHash.slice(-8)}`;
   } catch {
     return null;
   }

--- a/apps/vela-mobile/src/router/diagnostic-routes.test.ts
+++ b/apps/vela-mobile/src/router/diagnostic-routes.test.ts
@@ -4,13 +4,19 @@ import {
   IOS_DIAGNOSTIC_ROOT_PATH,
   IOS_INTERACTION_DIAGNOSTICS_LABEL,
 } from 'src/diagnostics/ios-interaction-contract';
-import { buildMobileChildRoutes, developmentDiagnosticRoutes } from './diagnostic-routes';
+import {
+  authenticatedDevelopmentDiagnosticRoutes,
+  buildMobileChildRoutes,
+  bypassDevelopmentDiagnosticRoutes,
+  developmentDiagnosticRoutes,
+} from './diagnostic-routes';
 
 describe('diagnostic route construction', () => {
-  it('adds the two diagnostic routes in development', () => {
+  it('adds the diagnostic routes in development', () => {
     const paths = buildMobileChildRoutes(developmentDiagnosticRoutes).map((route) => route.path);
     expect(paths).toContain(IOS_DIAGNOSTIC_ROOT_PATH.slice(1));
     expect(paths).toContain(IOS_DIAGNOSTIC_DETAIL_PATH.slice(1));
+    expect(paths).toContain('diagnostics/tts-pronunciation');
   });
 
   it('keeps production construction at the five shell routes', () => {
@@ -26,21 +32,32 @@ describe('diagnostic route construction', () => {
   });
 
   it('declares exact header metadata and fallbacks', () => {
-    expect(developmentDiagnosticRoutes[0]?.meta?.mobileHeader).toEqual({
+    expect(bypassDevelopmentDiagnosticRoutes[0]?.meta?.mobileHeader).toEqual({
       title: IOS_INTERACTION_DIAGNOSTICS_LABEL,
       fallback: '/more',
     });
-    expect(developmentDiagnosticRoutes[1]?.meta?.mobileHeader).toEqual({
+    expect(bypassDevelopmentDiagnosticRoutes[1]?.meta?.mobileHeader).toEqual({
       title: 'Navigation Detail',
       fallback: IOS_DIAGNOSTIC_ROOT_PATH,
     });
+    expect(authenticatedDevelopmentDiagnosticRoutes[0]?.meta?.mobileHeader).toEqual({
+      title: 'Pronunciation diagnostics',
+      fallback: '/more',
+    });
   });
 
-  it('marks every development diagnostic route as an explicit mobile auth bypass', () => {
-    expect(developmentDiagnosticRoutes.length).toBeGreaterThan(0);
+  it('partitions bypassed and authenticated development diagnostics', () => {
+    expect(bypassDevelopmentDiagnosticRoutes.length).toBeGreaterThan(0);
     expect(
-      developmentDiagnosticRoutes.every((route) => route.meta?.bypassMobileAuth === true),
+      bypassDevelopmentDiagnosticRoutes.every((route) => route.meta?.bypassMobileAuth === true),
     ).toBe(true);
+    expect(authenticatedDevelopmentDiagnosticRoutes).toHaveLength(1);
+    expect(authenticatedDevelopmentDiagnosticRoutes[0]?.path).toBe('diagnostics/tts-pronunciation');
+    expect(authenticatedDevelopmentDiagnosticRoutes[0]?.meta?.bypassMobileAuth).not.toBe(true);
+    expect(developmentDiagnosticRoutes).toEqual([
+      ...bypassDevelopmentDiagnosticRoutes,
+      ...authenticatedDevelopmentDiagnosticRoutes,
+    ]);
   });
 
   it('never marks core shell routes as mobile auth bypasses', () => {

--- a/apps/vela-mobile/src/router/diagnostic-routes.ts
+++ b/apps/vela-mobile/src/router/diagnostic-routes.ts
@@ -17,9 +17,6 @@ const coreRoutes: RouteRecordRaw[] = [
   { path: 'more', name: 'more', component: () => import('pages/MorePage.vue') },
 ];
 
-const TTS_PRONUNCIATION_DIAGNOSTICS_PAGE =
-  '/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.vue';
-
 export const bypassDevelopmentDiagnosticRoutes: RouteRecordRaw[] = import.meta.env.DEV
   ? [
       {
@@ -54,7 +51,7 @@ export const authenticatedDevelopmentDiagnosticRoutes: RouteRecordRaw[] = import
       {
         path: TTS_PRONUNCIATION_DIAGNOSTIC_PATH.slice(1),
         name: 'ttsPronunciationDiagnostics',
-        component: () => import(/* @vite-ignore */ TTS_PRONUNCIATION_DIAGNOSTICS_PAGE),
+        component: () => import('pages/diagnostics/TtsPronunciationDiagnosticsPage.vue'),
         meta: {
           mobileHeader: {
             title: TTS_PRONUNCIATION_DIAGNOSTIC_LABEL,

--- a/apps/vela-mobile/src/router/diagnostic-routes.ts
+++ b/apps/vela-mobile/src/router/diagnostic-routes.ts
@@ -4,6 +4,10 @@ import {
   IOS_DIAGNOSTIC_ROOT_PATH,
   IOS_INTERACTION_DIAGNOSTICS_LABEL,
 } from 'src/diagnostics/ios-interaction-contract';
+import {
+  TTS_PRONUNCIATION_DIAGNOSTIC_LABEL,
+  TTS_PRONUNCIATION_DIAGNOSTIC_PATH,
+} from 'src/diagnostics/tts-pronunciation-contract';
 
 const coreRoutes: RouteRecordRaw[] = [
   { path: '', name: 'home', component: () => import('pages/HomePage.vue') },
@@ -13,7 +17,10 @@ const coreRoutes: RouteRecordRaw[] = [
   { path: 'more', name: 'more', component: () => import('pages/MorePage.vue') },
 ];
 
-export const developmentDiagnosticRoutes: RouteRecordRaw[] = import.meta.env.DEV
+const TTS_PRONUNCIATION_DIAGNOSTICS_PAGE =
+  '/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.vue';
+
+export const bypassDevelopmentDiagnosticRoutes: RouteRecordRaw[] = import.meta.env.DEV
   ? [
       {
         path: IOS_DIAGNOSTIC_ROOT_PATH.slice(1),
@@ -41,6 +48,27 @@ export const developmentDiagnosticRoutes: RouteRecordRaw[] = import.meta.env.DEV
       },
     ]
   : [];
+
+export const authenticatedDevelopmentDiagnosticRoutes: RouteRecordRaw[] = import.meta.env.DEV
+  ? [
+      {
+        path: TTS_PRONUNCIATION_DIAGNOSTIC_PATH.slice(1),
+        name: 'ttsPronunciationDiagnostics',
+        component: () => import(/* @vite-ignore */ TTS_PRONUNCIATION_DIAGNOSTICS_PAGE),
+        meta: {
+          mobileHeader: {
+            title: TTS_PRONUNCIATION_DIAGNOSTIC_LABEL,
+            fallback: '/more',
+          },
+        },
+      },
+    ]
+  : [];
+
+export const developmentDiagnosticRoutes: RouteRecordRaw[] = [
+  ...bypassDevelopmentDiagnosticRoutes,
+  ...authenticatedDevelopmentDiagnosticRoutes,
+];
 
 export function buildMobileChildRoutes(
   diagnosticRoutes: RouteRecordRaw[] = developmentDiagnosticRoutes,

--- a/apps/vela-mobile/src/router/routes.test.ts
+++ b/apps/vela-mobile/src/router/routes.test.ts
@@ -31,9 +31,9 @@ describe('routes', () => {
     expect(await loadDefault(root?.component)).toBeDefined();
   });
 
-  it('has five core routes plus two development routes under the root layout', () => {
+  it('has five core routes plus three development routes under the root layout', () => {
     const root = routes.find((r) => r.path === '/');
-    expect(root?.children).toHaveLength(7);
+    expect(root?.children).toHaveLength(8);
   });
 
   it('constructs production routes with only the five core children', () => {
@@ -50,6 +50,7 @@ describe('routes', () => {
     expect(paths).toContain('more');
     expect(paths).toContain(IOS_DIAGNOSTIC_ROOT_PATH.slice(1));
     expect(paths).toContain(IOS_DIAGNOSTIC_DETAIL_PATH.slice(1));
+    expect(paths).toContain('diagnostics/tts-pronunciation');
     // Await every child component so a deleted page fails here, not at runtime.
     await Promise.all(
       (root?.children ?? []).map(async (c) => {

--- a/apps/vela-mobile/src/services/mobile-api-client.test.ts
+++ b/apps/vela-mobile/src/services/mobile-api-client.test.ts
@@ -4,7 +4,14 @@ import {
   type MobileAuthCoordinator,
   type MobileAuthState,
 } from '../auth/mobile-auth-contract';
-import { createMobileApiClient, MOBILE_API_DEFAULT_TIMEOUT_MS } from './mobile-api-client';
+import {
+  createMobileApiClient,
+  MobileApiError,
+  MOBILE_API_DEFAULT_TIMEOUT_MS,
+  MOBILE_API_MAX_ERROR_BODY_BYTES,
+} from './mobile-api-client';
+
+/* global BodyInit, HeadersInit */
 
 const usableState: MobileAuthState = {
   phase: 'authenticated',
@@ -16,7 +23,15 @@ const usableState: MobileAuthState = {
   user: { userId: 'user-1', email: null },
 };
 
-type AuthenticatedRequest = { init?: { signal?: AbortSignal | null } };
+type AuthenticatedRequest = {
+  transportTimeoutMs?: number;
+  init?: {
+    body?: BodyInit | null;
+    headers?: HeadersInit;
+    method?: string;
+    signal?: AbortSignal | null;
+  };
+};
 
 function response(status: number, value: unknown): Response {
   return {
@@ -45,6 +60,16 @@ function expectCallerCleanup(caller: AbortController, remove: ReturnType<typeof 
   expect(remove).toHaveBeenCalledWith('abort', expect.any(Function));
 }
 
+async function captureError(promise: Promise<unknown>): Promise<MobileApiError> {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error).toBeInstanceOf(MobileApiError);
+    return error as MobileApiError;
+  }
+  throw new Error('expected_mobile_api_error');
+}
+
 describe('mobile API client', () => {
   it('returns a successful JSON response', async () => {
     const auth = coordinator();
@@ -53,11 +78,55 @@ describe('mobile API client', () => {
     await expect(client.getJson('srs/stats')).resolves.toEqual({ due_today: 4 });
     expect(auth.requestAuthenticatedApi).toHaveBeenCalledWith({
       path: 'srs/stats',
+      transportTimeoutMs: MOBILE_API_DEFAULT_TIMEOUT_MS,
       init: { signal: expect.any(AbortSignal) },
     });
   });
 
+  it('serializes JSON before coordinator dispatch', async () => {
+    const auth = coordinator({
+      requestAuthenticatedApi: vi
+        .fn()
+        .mockResolvedValue(
+          new Response(
+            JSON.stringify({ audioUrl: 'https://audio.example.test/mizu.mp3', cached: false }),
+          ),
+        ),
+    });
+    const client = createMobileApiClient(auth);
+
+    await client.postJson(
+      'tts/generate',
+      { vocabularyId: '水:ミズ', text: '水' },
+      { timeoutMs: 45_000 },
+    );
+
+    const request = vi.mocked(auth.requestAuthenticatedApi).mock.calls[0]?.[0];
+    expect(request).toMatchObject({
+      path: 'tts/generate',
+      transportTimeoutMs: 45_000,
+      init: {
+        method: 'POST',
+        body: JSON.stringify({ vocabularyId: '水:ミズ', text: '水' }),
+      },
+    });
+    expect(new Headers(request?.init?.headers).get('Content-Type')).toBe('application/json');
+  });
+
+  it('rejects circular JSON before coordinator dispatch', async () => {
+    const body: Record<string, unknown> = {};
+    body.self = body;
+    const auth = coordinator();
+    const client = createMobileApiClient(auth);
+
+    await expect(client.postJson('tts/generate', body)).rejects.toMatchObject({
+      code: 'invalid_request',
+    });
+    expect(auth.requestAuthenticatedApi).not.toHaveBeenCalled();
+  });
+
   it.each([
+    [400, 'client'],
     [401, 'unauthorized'],
     [403, 'forbidden'],
     [404, 'server'],
@@ -74,6 +143,7 @@ describe('mobile API client', () => {
   it.each([
     ['invalid_request_path', 'invalid_request'],
     ['invalid_request_headers', 'invalid_request'],
+    ['invalid_request_timeout', 'invalid_request'],
     ['session_unavailable', 'session_unavailable'],
     ['session_changed', 'session_changed'],
     ['session_recovery_pending', 'session_recovery_pending'],
@@ -88,6 +158,70 @@ describe('mobile API client', () => {
     );
 
     await expect(client.getJson('srs/stats')).rejects.toMatchObject({ code });
+  });
+
+  it('classifies 400 as a non-enumerable client error', async () => {
+    const client = createMobileApiClient(
+      coordinator({
+        requestAuthenticatedApi: vi.fn().mockResolvedValue(
+          new Response(JSON.stringify({ success: false, error: { issues: [] } }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+      }),
+    );
+
+    const error = await captureError(client.getJson('invalid'));
+    expect(error).toMatchObject({ code: 'client' });
+    expect(error.details.status).toBe(400);
+    expect(Object.keys(error)).not.toContain('details');
+  });
+
+  it('retains no more than 16 KiB of JSON error body details', async () => {
+    const client = createMobileApiClient(
+      coordinator({
+        requestAuthenticatedApi: vi.fn().mockResolvedValue(
+          new Response(JSON.stringify({ issue: 'x'.repeat(MOBILE_API_MAX_ERROR_BODY_BYTES * 2) }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+      }),
+    );
+
+    const error = await captureError(client.getJson('invalid'));
+    expect(error.details.status).toBe(400);
+    expect(typeof error.details.serverBody).toBe('string');
+    expect((error.details.serverBody as string).length).toBeLessThanOrEqual(
+      MOBILE_API_MAX_ERROR_BODY_BYTES,
+    );
+    expect(JSON.stringify(error)).toBe(JSON.stringify({ code: 'client' }));
+  });
+
+  it('retains no more than 16 KiB of text error body details', async () => {
+    const client = createMobileApiClient(
+      coordinator({
+        requestAuthenticatedApi: vi.fn().mockResolvedValue(
+          new Response('x'.repeat(MOBILE_API_MAX_ERROR_BODY_BYTES * 2), {
+            status: 500,
+            headers: { 'Content-Type': 'text/plain' },
+          }),
+        ),
+      }),
+    );
+
+    const error = await captureError(client.getJson('unavailable'));
+    expect(error.details.status).toBe(500);
+    expect(typeof error.details.serverBody).toBe('string');
+    expect((error.details.serverBody as string).length).toBeLessThanOrEqual(
+      MOBILE_API_MAX_ERROR_BODY_BYTES,
+    );
+    expect(JSON.stringify(error)).toBe(JSON.stringify({ code: 'server' }));
+  });
+
+  it('preserves absence of cause when none is provided', () => {
+    expect('cause' in new MobileApiError('network')).toBe(false);
   });
 
   it('maps a raw transport TypeError to network', async () => {

--- a/apps/vela-mobile/src/services/mobile-api-client.test.ts
+++ b/apps/vela-mobile/src/services/mobile-api-client.test.ts
@@ -125,6 +125,19 @@ describe('mobile API client', () => {
     expect(auth.requestAuthenticatedApi).not.toHaveBeenCalled();
   });
 
+  it('short-circuits a pre-aborted caller without coordinator dispatch', async () => {
+    const caller = new AbortController();
+    caller.abort();
+    const auth = coordinator();
+
+    await expect(
+      createMobileApiClient(auth).getJson('srs/stats', { signal: caller.signal }),
+    ).rejects.toMatchObject({
+      name: 'AbortError',
+    });
+    expect(auth.requestAuthenticatedApi).not.toHaveBeenCalled();
+  });
+
   it.each([
     [400, 'client'],
     [401, 'unauthorized'],
@@ -218,6 +231,33 @@ describe('mobile API client', () => {
       MOBILE_API_MAX_ERROR_BODY_BYTES,
     );
     expect(JSON.stringify(error)).toBe(JSON.stringify({ code: 'server' }));
+  });
+
+  it('cancels an error stream when a non-final chunk exactly fills the retention cap', async () => {
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    const releaseLock = vi.fn();
+    const reader = {
+      read: vi.fn().mockResolvedValue({
+        done: false,
+        value: new Uint8Array(MOBILE_API_MAX_ERROR_BODY_BYTES),
+      }),
+      cancel,
+      releaseLock,
+    };
+    const boundedResponse = {
+      status: 500,
+      ok: false,
+      body: { getReader: vi.fn().mockReturnValue(reader) },
+      headers: new Headers({ 'Content-Type': 'text/plain' }),
+    } as unknown as Response;
+    const client = createMobileApiClient(
+      coordinator({ requestAuthenticatedApi: vi.fn().mockResolvedValue(boundedResponse) }),
+    );
+
+    const error = await captureError(client.getJson('unavailable'));
+    expect((error.details.serverBody as string).length).toBe(MOBILE_API_MAX_ERROR_BODY_BYTES);
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(releaseLock).toHaveBeenCalledOnce();
   });
 
   it('preserves absence of cause when none is provided', () => {

--- a/apps/vela-mobile/src/services/mobile-api-client.test.ts
+++ b/apps/vela-mobile/src/services/mobile-api-client.test.ts
@@ -142,8 +142,10 @@ describe('mobile API client', () => {
     [400, 'client'],
     [401, 'unauthorized'],
     [403, 'forbidden'],
-    [404, 'server'],
-    [409, 'server'],
+    [404, 'client'],
+    [409, 'client'],
+    [422, 'client'],
+    [429, 'client'],
     [500, 'server'],
   ] as const)('maps HTTP %i to %s', async (status, code) => {
     const client = createMobileApiClient(

--- a/apps/vela-mobile/src/services/mobile-api-client.ts
+++ b/apps/vela-mobile/src/services/mobile-api-client.ts
@@ -175,7 +175,9 @@ async function responseError(response: Response): Promise<MobileApiError> {
   const details = await errorDetails(response);
   if (response.status === 401) return new MobileApiError('unauthorized', details);
   if (response.status === 403) return new MobileApiError('forbidden', details);
-  if (response.status === 400) return new MobileApiError('client', details);
+  if (response.status >= 400 && response.status < 500) {
+    return new MobileApiError('client', details);
+  }
   return new MobileApiError('server', details);
 }
 

--- a/apps/vela-mobile/src/services/mobile-api-client.ts
+++ b/apps/vela-mobile/src/services/mobile-api-client.ts
@@ -134,7 +134,7 @@ async function readBoundedErrorText(response: Response): Promise<string | undefi
       chunks.push(retained);
       retainedBytes += retained.byteLength;
 
-      if (retained.byteLength < value.byteLength) {
+      if (retainedBytes === MOBILE_API_MAX_ERROR_BODY_BYTES) {
         await reader.cancel();
         break;
       }
@@ -208,6 +208,10 @@ export function createMobileApiClient(
     }, selectedTimeoutMs);
 
     try {
+      if (callerAborted) {
+        throw new DOMException('The operation was aborted.', 'AbortError');
+      }
+
       let response: Response;
       try {
         response = await coordinator.requestAuthenticatedApi({

--- a/apps/vela-mobile/src/services/mobile-api-client.ts
+++ b/apps/vela-mobile/src/services/mobile-api-client.ts
@@ -4,6 +4,8 @@ import {
 } from '../auth/mobile-auth-contract';
 import { selectMobileFeatureSessionStatus } from '../auth/mobile-feature-session-status';
 
+/* global RequestInit */
+
 export type MobileApiErrorCode =
   | 'invalid_request'
   | 'session_unavailable'
@@ -13,22 +15,49 @@ export type MobileApiErrorCode =
   | 'forbidden'
   | 'network'
   | 'server'
+  | 'client'
   | 'invalid_response';
 
+export type MobileApiErrorDetails = {
+  cause?: unknown;
+  serverBody?: unknown;
+  status?: number;
+};
+
 export class MobileApiError extends Error {
+  declare readonly details: MobileApiErrorDetails;
+
   constructor(
     readonly code: MobileApiErrorCode,
-    options?: { cause?: unknown },
+    details: MobileApiErrorDetails = {},
   ) {
-    super(code, options);
-    this.name = 'MobileApiError';
+    super(code, details.cause === undefined ? undefined : { cause: details.cause });
+    Object.defineProperty(this, 'name', {
+      value: 'MobileApiError',
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(this, 'details', {
+      value: details,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
   }
 }
 
 export const MOBILE_API_DEFAULT_TIMEOUT_MS = 8_000;
+export const MOBILE_API_MAX_ERROR_BODY_BYTES = 16_384;
+
+export type MobileApiRequestOptions = {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+};
 
 export type MobileApiClient = {
-  getJson(path: string, options?: { signal?: AbortSignal }): Promise<unknown>;
+  getJson(path: string, options?: MobileApiRequestOptions): Promise<unknown>;
+  postJson(path: string, body: unknown, options?: MobileApiRequestOptions): Promise<unknown>;
 };
 
 function mapCoordinatorError(
@@ -42,7 +71,11 @@ function mapCoordinatorError(
   const { callerAborted, deadlineExpired, coordinator } = context;
 
   if (error instanceof MobileAuthenticatedApiRequestError) {
-    if (error.code === 'invalid_request_path' || error.code === 'invalid_request_headers') {
+    if (
+      error.code === 'invalid_request_path' ||
+      error.code === 'invalid_request_headers' ||
+      error.code === 'invalid_request_timeout'
+    ) {
       throw new MobileApiError('invalid_request', { cause: error });
     }
     if (error.code === 'request_timeout') {
@@ -84,54 +117,151 @@ function mapResponseBodyError(
   return mapCoordinatorError(error, context);
 }
 
+async function readBoundedErrorText(response: Response): Promise<string | undefined> {
+  if (!response.body) return undefined;
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let retainedBytes = 0;
+
+  try {
+    while (retainedBytes < MOBILE_API_MAX_ERROR_BODY_BYTES) {
+      const { done, value } = await reader.read();
+      if (done || !value) break;
+
+      const availableBytes = MOBILE_API_MAX_ERROR_BODY_BYTES - retainedBytes;
+      const retained = value.byteLength <= availableBytes ? value : value.slice(0, availableBytes);
+      chunks.push(retained);
+      retainedBytes += retained.byteLength;
+
+      if (retained.byteLength < value.byteLength) {
+        await reader.cancel();
+        break;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(retainedBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+async function errorDetails(response: Response): Promise<MobileApiErrorDetails> {
+  const details: MobileApiErrorDetails = { status: response.status };
+  const bodyText = await readBoundedErrorText(response);
+  if (bodyText === undefined) return details;
+
+  if (response.headers.get('Content-Type')?.toLowerCase().includes('application/json')) {
+    try {
+      details.serverBody = JSON.parse(bodyText);
+      return details;
+    } catch {
+      // A truncated or malformed error body remains a bounded string; never
+      // replace the HTTP failure with an invalid-response error.
+    }
+  }
+
+  details.serverBody = bodyText;
+  return details;
+}
+
+async function responseError(response: Response): Promise<MobileApiError> {
+  const details = await errorDetails(response);
+  if (response.status === 401) return new MobileApiError('unauthorized', details);
+  if (response.status === 403) return new MobileApiError('forbidden', details);
+  if (response.status === 400) return new MobileApiError('client', details);
+  return new MobileApiError('server', details);
+}
+
 export function createMobileApiClient(
   coordinator: MobileAuthCoordinator,
   timeoutMs = MOBILE_API_DEFAULT_TIMEOUT_MS,
 ): MobileApiClient {
-  return {
-    async getJson(path, options = {}) {
-      const controller = new AbortController();
-      let callerAborted = false;
-      let deadlineExpired = false;
-      const onCallerAbort = () => {
-        callerAborted = true;
-        controller.abort();
-      };
+  async function requestJson(
+    path: string,
+    init: RequestInit,
+    options: MobileApiRequestOptions = {},
+  ): Promise<unknown> {
+    const controller = new AbortController();
+    let callerAborted = false;
+    let deadlineExpired = false;
+    const onCallerAbort = () => {
+      callerAborted = true;
+      controller.abort();
+    };
 
-      options.signal?.addEventListener('abort', onCallerAbort, { once: true });
-      if (options.signal?.aborted) {
-        onCallerAbort();
+    options.signal?.addEventListener('abort', onCallerAbort, { once: true });
+    if (options.signal?.aborted) {
+      onCallerAbort();
+    }
+
+    const selectedTimeoutMs = options.timeoutMs ?? timeoutMs;
+    const deadline = setTimeout(() => {
+      deadlineExpired = true;
+      controller.abort();
+    }, selectedTimeoutMs);
+
+    try {
+      let response: Response;
+      try {
+        response = await coordinator.requestAuthenticatedApi({
+          path,
+          transportTimeoutMs: selectedTimeoutMs,
+          init: { ...init, signal: controller.signal },
+        });
+      } catch (error) {
+        return mapCoordinatorError(error, { callerAborted, deadlineExpired, coordinator });
       }
 
-      const deadline = setTimeout(() => {
-        deadlineExpired = true;
-        controller.abort();
-      }, timeoutMs);
-
-      try {
-        let response: Response;
+      if (!response.ok) {
         try {
-          response = await coordinator.requestAuthenticatedApi({
-            path,
-            init: { signal: controller.signal },
-          });
+          throw await responseError(response);
         } catch (error) {
-          return mapCoordinatorError(error, { callerAborted, deadlineExpired, coordinator });
-        }
-
-        if (response.status === 401) throw new MobileApiError('unauthorized');
-        if (response.status === 403) throw new MobileApiError('forbidden');
-        if (!response.ok) throw new MobileApiError('server');
-
-        try {
-          return await response.json();
-        } catch (error) {
+          if (error instanceof MobileApiError) throw error;
           return mapResponseBodyError(error, { callerAborted, deadlineExpired, coordinator });
         }
-      } finally {
-        clearTimeout(deadline);
-        options.signal?.removeEventListener('abort', onCallerAbort);
       }
+
+      try {
+        return await response.json();
+      } catch (error) {
+        return mapResponseBodyError(error, { callerAborted, deadlineExpired, coordinator });
+      }
+    } finally {
+      clearTimeout(deadline);
+      options.signal?.removeEventListener('abort', onCallerAbort);
+    }
+  }
+
+  return {
+    getJson(path, options) {
+      return requestJson(path, {}, options);
+    },
+    async postJson(path, body, options) {
+      let serializedBody: string;
+      try {
+        const serialized = JSON.stringify(body);
+        if (typeof serialized !== 'string') throw new TypeError('invalid_json_body');
+        serializedBody = serialized;
+      } catch (error) {
+        throw new MobileApiError('invalid_request', { cause: error });
+      }
+
+      return requestJson(
+        path,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: serializedBody,
+        },
+        options,
+      );
     },
   };
 }

--- a/apps/vela-mobile/src/services/mobile-api-client.ts
+++ b/apps/vela-mobile/src/services/mobile-api-client.ts
@@ -226,12 +226,13 @@ export function createMobileApiClient(
       }
 
       if (!response.ok) {
+        let responseApiError: MobileApiError;
         try {
-          throw await responseError(response);
+          responseApiError = await responseError(response);
         } catch (error) {
-          if (error instanceof MobileApiError) throw error;
           return mapResponseBodyError(error, { callerAborted, deadlineExpired, coordinator });
         }
+        throw responseApiError;
       }
 
       try {

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -3620,6 +3620,24 @@ describe('session verification', () => {
 });
 
 describe('authenticated feature transport', () => {
+  it.each([0, -1, 1.5, Number.NaN, 50_001])(
+    'rejects invalid transport timeout %s',
+    async (transportTimeoutMs) => {
+      const harness = makeHarness();
+      await authenticate(harness);
+      const before = harness.sessionFetch.mock.calls.length;
+
+      await expect(
+        harness.coordinator.requestAuthenticatedApi({
+          path: 'tts/generate',
+          transportTimeoutMs,
+        }),
+      ).rejects.toMatchObject({ code: 'invalid_request_timeout' });
+
+      expect(harness.sessionFetch).toHaveBeenCalledTimes(before);
+    },
+  );
+
   it('rejects path escapes before network activity', async () => {
     const harness = makeHarness();
     await authenticate(harness);
@@ -3800,21 +3818,54 @@ describe('authenticated feature transport', () => {
     await expect(request).rejects.toMatchObject({ name: 'AbortError' });
   });
 
-  it('maps the bounded feature timeout to request_timeout', async () => {
+  it('aborts an omitted feature transport timeout after 15 seconds', async () => {
     const harness = makeHarness();
     await authenticate(harness);
     vi.useFakeTimers();
     try {
+      let featureSignal: AbortSignal | undefined;
       harness.sessionFetch.mockImplementationOnce(
         (_url, init) =>
           new Promise<Response>((_resolve, reject) => {
+            featureSignal = init?.signal ?? undefined;
             init?.signal?.addEventListener('abort', () => reject(new Error('timeout')));
           }),
       );
 
       const request = harness.coordinator.requestAuthenticatedApi({ path: 'srs/stats' });
       const expected = expect(request).rejects.toMatchObject({ code: 'request_timeout' });
-      await vi.advanceTimersByTimeAsync(MOBILE_AUTH_NETWORK_TIMEOUT_MS);
+      await vi.advanceTimersByTimeAsync(MOBILE_AUTH_NETWORK_TIMEOUT_MS - 1);
+      expect(featureSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+
+      await expected;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps a 45-second feature transport timeout active beyond 15 seconds', async () => {
+    const harness = makeHarness();
+    await authenticate(harness);
+    vi.useFakeTimers();
+    try {
+      let featureSignal: AbortSignal | undefined;
+      harness.sessionFetch.mockImplementationOnce(
+        (_url, init) =>
+          new Promise<Response>((_resolve, reject) => {
+            featureSignal = init?.signal ?? undefined;
+            init?.signal?.addEventListener('abort', () => reject(new Error('timeout')));
+          }),
+      );
+
+      const request = harness.coordinator.requestAuthenticatedApi({
+        path: 'tts/generate',
+        transportTimeoutMs: 45_000,
+      });
+      const expected = expect(request).rejects.toMatchObject({ code: 'request_timeout' });
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(featureSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(30_000);
 
       await expected;
     } finally {
@@ -3942,6 +3993,51 @@ describe('authenticated feature transport', () => {
     ]);
     expect(refreshRequests(harness)).toHaveLength(1);
     expect(featureCalls).toBe(4);
+  });
+
+  it('replays a JSON POST once with the identical body after refresh', async () => {
+    let currentNow = NOW;
+    const harness = makeHarness({ now: () => currentNow });
+    await authenticateWithExpiry(harness, currentNow + 1_000, currentNow);
+    prepareSuccessfulRefresh(harness, {
+      claimExpirySeconds: Math.ceil((currentNow + 3_600_000) / 1_000),
+    });
+    harness.sessionFetch.mockClear();
+    const initialResponse = deferred<Response>();
+    let featureCalls = 0;
+    harness.sessionFetch.mockImplementation(async (target) => {
+      if (String(target).endsWith('/tts/generate')) {
+        featureCalls += 1;
+        return featureCalls === 1 ? initialResponse.promise : response(200, { cached: true });
+      }
+      return response(200, {
+        authenticated: true,
+        user: { userId: 'user-123', email: 'person@example.com' },
+      });
+    });
+    const body = JSON.stringify({ vocabularyId: '水:ミズ', text: '水' });
+
+    const request = harness.coordinator.requestAuthenticatedApi({
+      path: 'tts/generate',
+      transportTimeoutMs: 45_000,
+      init: {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      },
+    });
+    await vi.waitFor(() => expect(featureCalls).toBe(1));
+    currentNow += 2_000;
+    initialResponse.resolve(response(401, {}));
+
+    await expect(request).resolves.toMatchObject({ status: 200 });
+    const attempts = harness.sessionFetch.mock.calls.filter(([url]) =>
+      String(url).includes('tts/generate'),
+    );
+    expect(attempts).toHaveLength(2);
+    expect(attempts[0]?.[1]?.body).toBe(body);
+    expect(attempts[1]?.[1]?.body).toBe(body);
+    expect(attempts[1]?.[1]?.method).toBe('POST');
   });
 
   it('queues one terminal cleanup for concurrent still-valid-token 401s', async () => {

--- a/apps/vela-mobile/src/services/mobile-auth.test.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -4037,6 +4037,8 @@ describe('authenticated feature transport', () => {
     expect(attempts).toHaveLength(2);
     expect(attempts[0]?.[1]?.body).toBe(body);
     expect(attempts[1]?.[1]?.body).toBe(body);
+    expect(new Headers(attempts[0]?.[1]?.headers).get('Content-Type')).toBe('application/json');
+    expect(new Headers(attempts[1]?.[1]?.headers).get('Content-Type')).toBe('application/json');
     expect(attempts[1]?.[1]?.method).toBe('POST');
   });
 

--- a/apps/vela-mobile/src/services/mobile-auth.ts
+++ b/apps/vela-mobile/src/services/mobile-auth.ts
@@ -138,6 +138,7 @@ export const MOBILE_AUTH_KEY: InjectionKey<MobileAuthCoordinator> = Symbol('mobi
  * back through their existing failure paths so the user can retry.
  */
 export const MOBILE_AUTH_NETWORK_TIMEOUT_MS = 15_000;
+export const MOBILE_AUTH_MAX_FEATURE_NETWORK_TIMEOUT_MS = 50_000;
 export const MOBILE_AUTH_REFRESH_LEAD_MS = 60_000;
 export const MOBILE_AUTH_SOFT_RETRY_DELAY_MS = 5_000;
 
@@ -290,6 +291,19 @@ function normalizeAuthenticatedRequestHeaders(headersInit?: HeadersInit): Header
   return headers;
 }
 
+function featureTransportTimeout(request: MobileAuthenticatedApiRequest): number {
+  const value = request.transportTimeoutMs;
+  if (value === undefined) return MOBILE_AUTH_NETWORK_TIMEOUT_MS;
+  if (
+    !Number.isInteger(value) ||
+    value <= 0 ||
+    value > MOBILE_AUTH_MAX_FEATURE_NETWORK_TIMEOUT_MS
+  ) {
+    throw new MobileAuthenticatedApiRequestError('invalid_request_timeout');
+  }
+  return value;
+}
+
 export function createMobileAuthCoordinator(
   dependencies: MobileAuthCoordinatorDependencies,
 ): MobileAuthCoordinator {
@@ -357,6 +371,7 @@ export function createMobileAuthCoordinator(
     snapshot: AuthenticatedFeatureSnapshot,
     target: URL,
     headers: Headers,
+    transportTimeoutMs: number,
   ): Promise<Response> {
     headers.set('Accept', headers.get('Accept') ?? 'application/json');
     headers.set('Authorization', `Bearer ${snapshot.idToken}`);
@@ -372,7 +387,7 @@ export function createMobileAuthCoordinator(
     const timeout = setTimeout(() => {
       timeoutExpired = true;
       controller.abort();
-    }, MOBILE_AUTH_NETWORK_TIMEOUT_MS);
+    }, transportTimeoutMs);
 
     try {
       return await dependencies.fetch(target, {
@@ -586,6 +601,7 @@ export function createMobileAuthCoordinator(
       request.path,
     );
     const baseHeaders = normalizeAuthenticatedRequestHeaders(request.init?.headers);
+    const transportTimeoutMs = featureTransportTimeout(request);
 
     const owner = active;
     if (unavailable() || !owner || !activeSessionIsUsable() || !state.sessionUsable) {
@@ -607,6 +623,7 @@ export function createMobileAuthCoordinator(
       snapshot,
       target,
       new Headers(baseHeaders),
+      transportTimeoutMs,
     );
     if (response.status !== 401) {
       return response;

--- a/apps/vela-mobile/src/services/mobile-lifecycle.test.ts
+++ b/apps/vela-mobile/src/services/mobile-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   mobileLifecycleState,
+  recordAppStateChange,
   recordAppResume,
   resetMobileLifecycleForTests,
 } from './mobile-lifecycle';
@@ -11,5 +12,19 @@ describe('mobile lifecycle', () => {
     recordAppResume(1234);
     expect(mobileLifecycleState.resumeCount.value).toBe(1);
     expect(mobileLifecycleState.lastResumeAt.value).toBe(1234);
+  });
+
+  it('records app-state transitions without incrementing resume count', () => {
+    resetMobileLifecycleForTests();
+    recordAppStateChange(false, 100);
+    expect(mobileLifecycleState.isActive.value).toBe(false);
+    expect(mobileLifecycleState.lastStateChangeAt.value).toBe(100);
+    expect(mobileLifecycleState.lastBecameInactiveAt.value).toBe(100);
+    expect(mobileLifecycleState.resumeCount.value).toBe(0);
+
+    recordAppStateChange(true, 200);
+    expect(mobileLifecycleState.lastStateChangeAt.value).toBe(200);
+    expect(mobileLifecycleState.lastBecameActiveAt.value).toBe(200);
+    expect(mobileLifecycleState.resumeCount.value).toBe(0);
   });
 });

--- a/apps/vela-mobile/src/services/mobile-lifecycle.test.ts
+++ b/apps/vela-mobile/src/services/mobile-lifecycle.test.ts
@@ -27,4 +27,31 @@ describe('mobile lifecycle', () => {
     expect(mobileLifecycleState.lastBecameActiveAt.value).toBe(200);
     expect(mobileLifecycleState.resumeCount.value).toBe(0);
   });
+
+  it('only updates became-timestamps on an actual transition', () => {
+    resetMobileLifecycleForTests();
+    // reset leaves isActive=true; transition to inactive first.
+    recordAppStateChange(false, 100);
+    expect(mobileLifecycleState.lastBecameInactiveAt.value).toBe(100);
+    expect(mobileLifecycleState.lastBecameActiveAt.value).toBe(null);
+
+    recordAppStateChange(true, 200);
+    expect(mobileLifecycleState.lastBecameActiveAt.value).toBe(200);
+
+    // Repeated active notification: not a transition, became-timestamp unchanged.
+    recordAppStateChange(true, 300);
+    expect(mobileLifecycleState.isActive.value).toBe(true);
+    expect(mobileLifecycleState.lastStateChangeAt.value).toBe(300);
+    expect(mobileLifecycleState.lastBecameActiveAt.value).toBe(200);
+    expect(mobileLifecycleState.lastBecameInactiveAt.value).toBe(100);
+
+    // Transition back to inactive, then a repeated inactive notification.
+    recordAppStateChange(false, 400);
+    expect(mobileLifecycleState.lastBecameInactiveAt.value).toBe(400);
+
+    recordAppStateChange(false, 500);
+    expect(mobileLifecycleState.lastStateChangeAt.value).toBe(500);
+    expect(mobileLifecycleState.lastBecameInactiveAt.value).toBe(400);
+    expect(mobileLifecycleState.lastBecameActiveAt.value).toBe(200);
+  });
 });

--- a/apps/vela-mobile/src/services/mobile-lifecycle.ts
+++ b/apps/vela-mobile/src/services/mobile-lifecycle.ts
@@ -22,10 +22,13 @@ export function recordAppResume(at = Date.now()): void {
 }
 
 export function recordAppStateChange(next: boolean, at = Date.now()): void {
+  const previous = isActive.value;
   isActive.value = next;
   lastStateChangeAt.value = at;
-  if (next) lastBecameActiveAt.value = at;
-  else lastBecameInactiveAt.value = at;
+  if (next !== previous) {
+    if (next) lastBecameActiveAt.value = at;
+    else lastBecameInactiveAt.value = at;
+  }
 }
 
 export function resetMobileLifecycleForTests(): void {

--- a/apps/vela-mobile/src/services/mobile-lifecycle.ts
+++ b/apps/vela-mobile/src/services/mobile-lifecycle.ts
@@ -2,10 +2,18 @@ import { readonly, ref } from 'vue';
 
 const resumeCount = ref(0);
 const lastResumeAt = ref<number | null>(null);
+const isActive = ref(true);
+const lastStateChangeAt = ref<number | null>(null);
+const lastBecameActiveAt = ref<number | null>(null);
+const lastBecameInactiveAt = ref<number | null>(null);
 
 export const mobileLifecycleState = {
   resumeCount: readonly(resumeCount),
   lastResumeAt: readonly(lastResumeAt),
+  isActive: readonly(isActive),
+  lastStateChangeAt: readonly(lastStateChangeAt),
+  lastBecameActiveAt: readonly(lastBecameActiveAt),
+  lastBecameInactiveAt: readonly(lastBecameInactiveAt),
 };
 
 export function recordAppResume(at = Date.now()): void {
@@ -13,7 +21,18 @@ export function recordAppResume(at = Date.now()): void {
   lastResumeAt.value = at;
 }
 
+export function recordAppStateChange(next: boolean, at = Date.now()): void {
+  isActive.value = next;
+  lastStateChangeAt.value = at;
+  if (next) lastBecameActiveAt.value = at;
+  else lastBecameInactiveAt.value = at;
+}
+
 export function resetMobileLifecycleForTests(): void {
   resumeCount.value = 0;
   lastResumeAt.value = null;
+  isActive.value = true;
+  lastStateChangeAt.value = null;
+  lastBecameActiveAt.value = null;
+  lastBecameInactiveAt.value = null;
 }

--- a/apps/vela-mobile/src/services/mobile-services.test.ts
+++ b/apps/vela-mobile/src/services/mobile-services.test.ts
@@ -4,11 +4,12 @@ import type { MobileAuthCoordinator } from '../auth/mobile-auth-contract';
 import {
   MOBILE_API_CLIENT_KEY,
   MOBILE_SRS_SERVICE_KEY,
+  MOBILE_TTS_SERVICE_KEY,
   provideMobileServices,
 } from './mobile-services';
 
 describe('mobile service provisioning', () => {
-  it('directly provides SRS services that delegate through the supplied coordinator', async () => {
+  it('provides SRS and TTS services from one API client', async () => {
     const coordinator = {
       state: {},
       requestAuthenticatedApi: vi.fn().mockResolvedValue({
@@ -34,8 +35,12 @@ describe('mobile service provisioning', () => {
     const srsService = (app.provide as ReturnType<typeof vi.fn>).mock.calls.find(
       ([key]) => key === MOBILE_SRS_SERVICE_KEY,
     )?.[1];
+    const ttsService = (app.provide as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([key]) => key === MOBILE_TTS_SERVICE_KEY,
+    )?.[1];
     await expect(srsService.getStats()).resolves.toMatchObject({ due_today: 0 });
     expect(apiClient).toBeDefined();
+    expect(ttsService).toBeDefined();
     expect(coordinator.requestAuthenticatedApi).toHaveBeenCalledOnce();
   });
 });

--- a/apps/vela-mobile/src/services/mobile-services.test.ts
+++ b/apps/vela-mobile/src/services/mobile-services.test.ts
@@ -78,11 +78,11 @@ describe('mobile service provisioning', () => {
     });
 
     expect(getJson).toHaveBeenCalledWith('srs/stats', {});
-    expect(getJson).toHaveBeenCalledWith('tts/settings', { signal: expect.any(AbortSignal) });
+    expect(getJson).toHaveBeenCalledWith('tts/settings');
     expect(postJson).toHaveBeenCalledWith(
       'tts/generate',
       { vocabularyId: '水:ミズ', text: '水' },
-      { signal: expect.any(AbortSignal), timeoutMs: 45_000 },
+      { timeoutMs: 45_000 },
     );
     expect(coordinator.requestAuthenticatedApi).not.toHaveBeenCalled();
   });

--- a/apps/vela-mobile/src/services/mobile-services.test.ts
+++ b/apps/vela-mobile/src/services/mobile-services.test.ts
@@ -43,4 +43,47 @@ describe('mobile service provisioning', () => {
     expect(ttsService).toBeDefined();
     expect(coordinator.requestAuthenticatedApi).toHaveBeenCalledOnce();
   });
+
+  it('gives SRS and TTS the exact API client instance returned by the registry', async () => {
+    const coordinator = {
+      state: {},
+      requestAuthenticatedApi: vi.fn(),
+    } as unknown as MobileAuthCoordinator;
+    const app = { provide: vi.fn() } as unknown as App;
+    const services = provideMobileServices(app, coordinator);
+    const getJson = vi.fn().mockImplementation(async (path: string) =>
+      path === 'srs/stats'
+        ? {
+            total_items: 0,
+            due_today: 0,
+            mastery_breakdown: { new: 0, learning: 0, reviewing: 0, mastered: 0 },
+            average_ease_factor: 0,
+            total_reviews: 0,
+            accuracy_rate: 0,
+          }
+        : { provider: 'openai', voiceId: 'alloy', model: 'tts-1', hasApiKey: true },
+    );
+    const postJson = vi.fn().mockResolvedValue({
+      audioUrl: 'https://audio.example.test/tts/user/vocabulary/settings-hash',
+      cached: false,
+    });
+    services.apiClient.getJson = getJson;
+    services.apiClient.postJson = postJson;
+
+    await services.srsService.getStats();
+    await services.ttsService.preparePronunciation({
+      userId: 'user-1',
+      vocabularyId: '水:ミズ',
+      text: '水',
+    });
+
+    expect(getJson).toHaveBeenCalledWith('srs/stats', {});
+    expect(getJson).toHaveBeenCalledWith('tts/settings', { signal: expect.any(AbortSignal) });
+    expect(postJson).toHaveBeenCalledWith(
+      'tts/generate',
+      { vocabularyId: '水:ミズ', text: '水' },
+      { signal: expect.any(AbortSignal), timeoutMs: 45_000 },
+    );
+    expect(coordinator.requestAuthenticatedApi).not.toHaveBeenCalled();
+  });
 });

--- a/apps/vela-mobile/src/services/mobile-services.ts
+++ b/apps/vela-mobile/src/services/mobile-services.ts
@@ -2,14 +2,29 @@ import type { App, InjectionKey } from 'vue';
 import type { MobileAuthCoordinator } from '../auth/mobile-auth-contract';
 import { createMobileApiClient, type MobileApiClient } from './mobile-api-client';
 import { createMobileSrsService, type MobileSrsService } from './mobile-srs';
+import { createMobileTtsService, type MobileTtsService } from './mobile-tts';
 
 export const MOBILE_API_CLIENT_KEY: InjectionKey<MobileApiClient> = Symbol('mobile-api-client');
 export const MOBILE_SRS_SERVICE_KEY: InjectionKey<MobileSrsService> = Symbol('mobile-srs-service');
+export const MOBILE_TTS_SERVICE_KEY: InjectionKey<MobileTtsService> = Symbol('mobile-tts-service');
 
-export function provideMobileServices(app: App, coordinator: MobileAuthCoordinator): void {
+export type MobileServices = {
+  apiClient: MobileApiClient;
+  srsService: MobileSrsService;
+  ttsService: MobileTtsService;
+};
+
+export function provideMobileServices(
+  app: App,
+  coordinator: MobileAuthCoordinator,
+): MobileServices {
   const apiClient = createMobileApiClient(coordinator);
   const srsService = createMobileSrsService(apiClient);
+  const ttsService = createMobileTtsService(apiClient);
 
   app.provide(MOBILE_API_CLIENT_KEY, apiClient);
   app.provide(MOBILE_SRS_SERVICE_KEY, srsService);
+  app.provide(MOBILE_TTS_SERVICE_KEY, ttsService);
+
+  return { apiClient, srsService, ttsService };
 }

--- a/apps/vela-mobile/src/services/mobile-srs.test.ts
+++ b/apps/vela-mobile/src/services/mobile-srs.test.ts
@@ -14,14 +14,20 @@ const stats = {
 describe('mobile SRS service', () => {
   it('loads stats through the exact authenticated SRS path and caller signal', async () => {
     const signal = new AbortController().signal;
-    const apiClient: MobileApiClient = { getJson: vi.fn().mockResolvedValue(stats) };
+    const apiClient: MobileApiClient = {
+      getJson: vi.fn().mockResolvedValue(stats),
+      postJson: vi.fn(),
+    };
 
     await expect(createMobileSrsService(apiClient).getStats({ signal })).resolves.toEqual(stats);
     expect(apiClient.getJson).toHaveBeenCalledWith('srs/stats', { signal });
   });
 
   it('maps malformed stats to invalid_response', async () => {
-    const apiClient: MobileApiClient = { getJson: vi.fn().mockResolvedValue({ due_today: -1 }) };
+    const apiClient: MobileApiClient = {
+      getJson: vi.fn().mockResolvedValue({ due_today: -1 }),
+      postJson: vi.fn(),
+    };
 
     await expect(createMobileSrsService(apiClient).getStats()).rejects.toMatchObject({
       code: 'invalid_response',

--- a/apps/vela-mobile/src/services/mobile-tts-auth-isolation.test.ts
+++ b/apps/vela-mobile/src/services/mobile-tts-auth-isolation.test.ts
@@ -1,0 +1,150 @@
+import { nextTick, reactive } from 'vue';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { MobileAuthState } from '../auth/mobile-auth-contract';
+import type { MobileTtsService } from './mobile-tts';
+import { installMobileTtsAuthIsolation } from './mobile-tts-auth-isolation';
+
+function authenticatedState(userId: string): MobileAuthState {
+  return {
+    phase: 'authenticated',
+    operation: 'idle',
+    sessionUsable: true,
+    errorCode: null,
+    retryAction: null,
+    notice: null,
+    user: { userId, email: null },
+  };
+}
+
+function signedOutState(): MobileAuthState {
+  return {
+    phase: 'signedOut',
+    operation: 'idle',
+    sessionUsable: false,
+    errorCode: null,
+    retryAction: null,
+    notice: null,
+    user: null,
+  };
+}
+
+async function settle(): Promise<void> {
+  await nextTick();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('mobile TTS auth isolation', () => {
+  const stops: (() => void)[] = [];
+
+  afterEach(() => {
+    stops.splice(0).forEach((stop) => stop());
+  });
+
+  it('clears only the previous user on identity replacement', async () => {
+    const state = reactive(authenticatedState('user-a'));
+    const tts = { clearUser: vi.fn() } as unknown as MobileTtsService;
+    stops.push(installMobileTtsAuthIsolation({ state, ttsService: tts }));
+
+    Object.assign(state, authenticatedState('user-b'));
+    await settle();
+
+    expect(tts.clearUser).toHaveBeenCalledWith('user-a');
+    expect(tts.clearUser).not.toHaveBeenCalledWith('user-b');
+  });
+
+  it('does nothing for a null-to-user transition', async () => {
+    const state = reactive(signedOutState());
+    const tts = { clearUser: vi.fn() } as unknown as MobileTtsService;
+    stops.push(installMobileTtsAuthIsolation({ state, ttsService: tts }));
+
+    Object.assign(state, authenticatedState('user-a'));
+    await settle();
+
+    expect(tts.clearUser).not.toHaveBeenCalled();
+  });
+
+  it('clears the signing-out user without clearing a successor', async () => {
+    const state = reactive(authenticatedState('user-a'));
+    const tts = { clearUser: vi.fn() } as unknown as MobileTtsService;
+    stops.push(installMobileTtsAuthIsolation({ state, ttsService: tts }));
+
+    Object.assign(state, { operation: 'signingOut', sessionUsable: false });
+    await settle();
+    Object.assign(state, signedOutState());
+    await settle();
+    Object.assign(state, authenticatedState('user-b'));
+    await settle();
+
+    expect(tts.clearUser).toHaveBeenCalledWith('user-a');
+    expect(tts.clearUser).not.toHaveBeenCalledWith('user-b');
+  });
+
+  it('clears the prior user when terminal cleanup starts', async () => {
+    const state = reactive(authenticatedState('user-a'));
+    const tts = { clearUser: vi.fn() } as unknown as MobileTtsService;
+    stops.push(installMobileTtsAuthIsolation({ state, ttsService: tts }));
+
+    Object.assign(state, {
+      ...signedOutState(),
+      operation: 'cleaningUp',
+    });
+    await settle();
+
+    expect(tts.clearUser).toHaveBeenCalledWith('user-a');
+  });
+
+  it('clears the recovering user when their session becomes unusable', async () => {
+    const state = reactive(authenticatedState('user-a'));
+    const tts = { clearUser: vi.fn() } as unknown as MobileTtsService;
+    stops.push(installMobileTtsAuthIsolation({ state, ttsService: tts }));
+
+    Object.assign(state, { operation: 'refreshing', sessionUsable: false });
+    await settle();
+
+    expect(tts.clearUser).toHaveBeenCalledWith('user-a');
+  });
+
+  it('does not clear a successor after a no-prior-user cleanup retry', async () => {
+    const state = reactive<MobileAuthState>({
+      ...signedOutState(),
+      errorCode: 'session_cleanup_failed',
+      retryAction: 'cleanup',
+      notice: 'cleanup_incomplete',
+    });
+    const tts = { clearUser: vi.fn() } as unknown as MobileTtsService;
+    stops.push(installMobileTtsAuthIsolation({ state, ttsService: tts }));
+
+    Object.assign(state, {
+      operation: 'cleaningUp',
+      errorCode: null,
+      retryAction: null,
+      notice: null,
+    });
+    await settle();
+    Object.assign(state, signedOutState());
+    await settle();
+    Object.assign(state, authenticatedState('user-b'));
+    await settle();
+
+    expect(tts.clearUser).not.toHaveBeenCalled();
+  });
+
+  it('continues scoped cleanup after a prior clear failure during successor races', async () => {
+    const state = reactive(authenticatedState('user-a'));
+    const clearUser = vi.fn((userId: string) => {
+      if (userId === 'user-a') throw new Error('cache unavailable');
+    });
+    const tts = { clearUser } as unknown as MobileTtsService;
+    stops.push(installMobileTtsAuthIsolation({ state, ttsService: tts }));
+
+    Object.assign(state, authenticatedState('user-b'));
+    await settle();
+    Object.assign(state, authenticatedState('user-c'));
+    await settle();
+
+    expect(clearUser).toHaveBeenNthCalledWith(1, 'user-a');
+    expect(clearUser).toHaveBeenNthCalledWith(2, 'user-b');
+    expect(clearUser).not.toHaveBeenCalledWith('user-c');
+  });
+});

--- a/apps/vela-mobile/src/services/mobile-tts-auth-isolation.test.ts
+++ b/apps/vela-mobile/src/services/mobile-tts-auth-isolation.test.ts
@@ -147,4 +147,27 @@ describe('mobile TTS auth isolation', () => {
     expect(clearUser).toHaveBeenNthCalledWith(2, 'user-b');
     expect(clearUser).not.toHaveBeenCalledWith('user-c');
   });
+
+  it('consumes a terminal clear failure without surfacing an unhandled rejection', async () => {
+    const state = reactive(authenticatedState('user-a'));
+    const clearUser = vi.fn(() => {
+      throw new Error('cache unavailable');
+    });
+    const tts = { clearUser } as unknown as MobileTtsService;
+    const unhandledRejections: unknown[] = [];
+    const captureUnhandledRejection = (reason: unknown) => unhandledRejections.push(reason);
+    process.on('unhandledRejection', captureUnhandledRejection);
+    stops.push(installMobileTtsAuthIsolation({ state, ttsService: tts }));
+
+    try {
+      Object.assign(state, authenticatedState('user-b'));
+      await settle();
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      expect(clearUser).toHaveBeenCalledWith('user-a');
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', captureUnhandledRejection);
+    }
+  });
 });

--- a/apps/vela-mobile/src/services/mobile-tts-auth-isolation.ts
+++ b/apps/vela-mobile/src/services/mobile-tts-auth-isolation.ts
@@ -57,7 +57,8 @@ export function installMobileTtsAuthIsolation(options: {
           if (unusableRecovery && next.featureStatus.kind === 'recovering') {
             options.ttsService.clearUser(next.featureStatus.userId);
           }
-        });
+        })
+        .catch(() => undefined);
     },
   );
 }

--- a/apps/vela-mobile/src/services/mobile-tts-auth-isolation.ts
+++ b/apps/vela-mobile/src/services/mobile-tts-auth-isolation.ts
@@ -1,0 +1,63 @@
+import { watch, type WatchStopHandle } from 'vue';
+import type { MobileAuthState } from '../auth/mobile-auth-contract';
+import {
+  selectMobileFeatureSessionStatus,
+  type MobileFeatureSessionStatus,
+} from '../auth/mobile-feature-session-status';
+import type { MobileTtsService } from './mobile-tts';
+
+type AuthTtsSnapshot = {
+  phase: MobileAuthState['phase'];
+  operation: MobileAuthState['operation'];
+  userId: string | null;
+  featureStatus: MobileFeatureSessionStatus;
+};
+
+function selectAuthTtsSnapshot(state: Readonly<MobileAuthState>): AuthTtsSnapshot {
+  return {
+    phase: state.phase,
+    operation: state.operation,
+    userId: state.user?.userId ?? null,
+    featureStatus: selectMobileFeatureSessionStatus(state),
+  };
+}
+
+/**
+ * Removes cache and pending-work indexes for the identity that just lost its
+ * session. Audio ownership remains with the mounted pronunciation controller.
+ */
+export function installMobileTtsAuthIsolation(options: {
+  state: Readonly<MobileAuthState>;
+  ttsService: MobileTtsService;
+}): WatchStopHandle {
+  let cleanupTail = Promise.resolve();
+
+  return watch(
+    () => selectAuthTtsSnapshot(options.state),
+    (next, previous) => {
+      const previousUserId = previous.userId;
+      const identityChanged = previousUserId !== next.userId;
+      const signOutTransition =
+        next.phase === 'signedOut' ||
+        next.operation === 'signingOut' ||
+        next.operation === 'cleaningUp';
+      const unusableRecovery =
+        next.featureStatus.kind === 'recovering' && !next.featureStatus.sessionUsable;
+
+      if (!identityChanged && !signOutTransition && !unusableRecovery) return;
+
+      cleanupTail = cleanupTail
+        .catch(() => undefined)
+        .then(() => {
+          if (signOutTransition || identityChanged) {
+            if (previousUserId !== null) options.ttsService.clearUser(previousUserId);
+            return;
+          }
+
+          if (unusableRecovery && next.featureStatus.kind === 'recovering') {
+            options.ttsService.clearUser(next.featureStatus.userId);
+          }
+        });
+    },
+  );
+}

--- a/apps/vela-mobile/src/services/mobile-tts.test.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.test.ts
@@ -55,7 +55,15 @@ async function captureError(promise: Promise<unknown>): Promise<MobileTtsError> 
 }
 
 function generated(audioUrl = HTTPS_AUDIO, cached = false) {
-  return { audioUrl, cached };
+  return {
+    audioUrl,
+    cached,
+    effectiveSettings: {
+      provider: CONFIGURED_SETTINGS.provider,
+      voiceId: CONFIGURED_SETTINGS.voiceId,
+      model: CONFIGURED_SETTINGS.model,
+    },
+  };
 }
 
 describe('MobileTtsService', () => {
@@ -364,16 +372,22 @@ describe('MobileTtsService', () => {
     expect(api.postJson).toHaveBeenCalledTimes(1);
   });
 
-  it('caches normally when the backend omits effective settings (older deployment)', async () => {
-    api.postJson.mockResolvedValueOnce(generated(HTTPS_AUDIO, false));
+  it('does not cache when the backend omits effective settings (older deployment)', async () => {
+    // An older backend that omits effectiveSettings cannot confirm the
+    // settings identity, so the client must not cache under the GET-derived
+    // key. Playback still succeeds, but the second request re-generates
+    // rather than returning a potentially stale memory-cache entry.
+    const responseWithoutEffective = { audioUrl: HTTPS_AUDIO, cached: false };
+    api.postJson.mockResolvedValueOnce(responseWithoutEffective);
+    api.postJson.mockResolvedValueOnce(responseWithoutEffective);
     const service = createMobileTtsService(api);
 
     const first = await service.preparePronunciation(INPUT);
     expect(first).toMatchObject({ source: 'generated' });
 
     const second = await service.preparePronunciation(INPUT);
-    expect(second).toMatchObject({ source: 'memory-cache' });
-    expect(api.postJson).toHaveBeenCalledTimes(1);
+    expect(second).toMatchObject({ source: 'generated' });
+    expect(api.postJson).toHaveBeenCalledTimes(2);
   });
 
   it('uses distinct keys when user, vocabulary, provider, voice, or model changes', async () => {

--- a/apps/vela-mobile/src/services/mobile-tts.test.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.test.ts
@@ -110,13 +110,11 @@ describe('MobileTtsService', () => {
     await service.preparePronunciation(INPUT);
 
     expect(MOBILE_TTS_GENERATE_TIMEOUT_MS).toBe(45_000);
-    expect(api.getJson).toHaveBeenCalledWith('tts/settings', {
-      signal: expect.any(AbortSignal),
-    });
+    expect(api.getJson).toHaveBeenCalledWith('tts/settings');
     expect(api.postJson).toHaveBeenCalledWith(
       'tts/generate',
       { vocabularyId: '水:ミズ', text: '水' },
-      { signal: expect.any(AbortSignal), timeoutMs: 45_000 },
+      { timeoutMs: 45_000 },
     );
   });
 

--- a/apps/vela-mobile/src/services/mobile-tts.test.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.test.ts
@@ -523,6 +523,49 @@ describe('MobileTtsService', () => {
     });
   });
 
+  it.each(['invalidatePronunciation', 'clearUser', 'clearAll'] as const)(
+    'does not publish pre-boundary settings work into the current join index after %s',
+    async (boundary) => {
+      const oldSettings = deferred<unknown>();
+      const freshSettings = deferred<unknown>();
+      const oldGeneration = deferred<unknown>();
+      const freshGeneration = deferred<unknown>();
+      api.getJson
+        .mockReturnValueOnce(oldSettings.promise)
+        .mockReturnValueOnce(freshSettings.promise);
+      api.postJson
+        .mockReturnValueOnce(oldGeneration.promise)
+        .mockReturnValueOnce(freshGeneration.promise);
+      const service = createMobileTtsService(api);
+
+      const oldCaller = service.preparePronunciation(INPUT);
+      await vi.waitFor(() => expect(api.getJson).toHaveBeenCalledTimes(1));
+      if (boundary === 'invalidatePronunciation') {
+        service.invalidatePronunciation(INPUT.userId, INPUT.vocabularyId);
+      } else if (boundary === 'clearUser') {
+        service.clearUser(INPUT.userId);
+      } else {
+        service.clearAll();
+      }
+
+      const freshCaller = service.preparePronunciation(INPUT);
+      await vi.waitFor(() => expect(api.getJson).toHaveBeenCalledTimes(2));
+      oldSettings.resolve(CONFIGURED_SETTINGS);
+      await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(1));
+      freshSettings.resolve(CONFIGURED_SETTINGS);
+      await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(2));
+
+      oldGeneration.resolve(generated('https://audio.example.test/pre-boundary.mp3'));
+      freshGeneration.resolve(generated('https://audio.example.test/post-boundary.mp3'));
+      await expect(oldCaller).resolves.toMatchObject({
+        audioUrl: 'https://audio.example.test/pre-boundary.mp3',
+      });
+      await expect(freshCaller).resolves.toMatchObject({
+        audioUrl: 'https://audio.example.test/post-boundary.mp3',
+      });
+    },
+  );
+
   it('does not cache a stale completion after clearUser', async () => {
     const generation = deferred<unknown>();
     api.postJson.mockReturnValueOnce(generation.promise);

--- a/apps/vela-mobile/src/services/mobile-tts.test.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.test.ts
@@ -58,39 +58,6 @@ function generated(audioUrl = HTTPS_AUDIO, cached = false) {
   return { audioUrl, cached };
 }
 
-function captureVocabularyGenerationMap(
-  service: ReturnType<typeof createMobileTtsService>,
-): Map<string, number> {
-  const setSpy = vi.spyOn(Map.prototype, 'set');
-  try {
-    service.invalidatePronunciation('metadata-probe-user', 'metadata-probe-vocabulary');
-    const callIndex = setSpy.mock.calls.findIndex(
-      ([key]) => key === 'metadata-probe-user|metadata-probe-vocabulary',
-    );
-    const generationMap = setSpy.mock.contexts[callIndex];
-    expect(generationMap).toBeInstanceOf(Map);
-    return generationMap as Map<string, number>;
-  } finally {
-    setSpy.mockRestore();
-  }
-}
-
-function captureUserGenerationMap(
-  service: ReturnType<typeof createMobileTtsService>,
-): Map<string, number> {
-  const setSpy = vi.spyOn(Map.prototype, 'set');
-  try {
-    service.clearUser('metadata-probe-user');
-    const callIndex = setSpy.mock.calls.findIndex(([key]) => key === 'metadata-probe-user');
-    const generationMap = setSpy.mock.contexts[callIndex];
-    expect(generationMap).toBeInstanceOf(Map);
-    service.clearAll();
-    return generationMap as Map<string, number>;
-  } finally {
-    setSpy.mockRestore();
-  }
-}
-
 describe('MobileTtsService', () => {
   let api: MockApiClient;
 
@@ -440,6 +407,8 @@ describe('MobileTtsService', () => {
     await service.preparePronunciation({ ...INPUT, vocabularyId: 'vocab-0' });
     await service.preparePronunciation({ ...INPUT, vocabularyId: 'vocab-1' });
 
+    // 300 initial misses + vocab-new evicts vocab-1 (miss) + vocab-0 still live
+    // (hit) + vocab-1 was evicted so it misses again = 302 calls.
     expect(api.postJson).toHaveBeenCalledTimes(302);
   });
 
@@ -451,29 +420,29 @@ describe('MobileTtsService', () => {
     }
     await service.preparePronunciation({ ...INPUT, vocabularyId: 'vocab-0' });
 
+    // 301 initial misses fill the cache and evict vocab-0; re-reading vocab-0
+    // is a miss because it was evicted as the least recently used entry = 302.
     expect(api.postJson).toHaveBeenCalledTimes(302);
   });
 
   it('releases vocabulary generation metadata after more completed vocabularies than the cache cap', async () => {
     const service = createMobileTtsService(api);
-    const generationMap = captureVocabularyGenerationMap(service);
 
     for (let index = 0; index < 301; index += 1) {
       await service.preparePronunciation({ ...INPUT, vocabularyId: `metadata-${index}` });
     }
 
-    expect(generationMap.size).toBe(0);
+    expect(service._testGetGenerationMetadata!().vocabularyGenerationCount).toBe(0);
   });
 
   it('releases user generation metadata after more completed users than the cache cap', async () => {
     const service = createMobileTtsService(api);
-    const generationMap = captureUserGenerationMap(service);
 
     for (let index = 0; index < 301; index += 1) {
       await service.preparePronunciation({ ...INPUT, userId: `metadata-user-${index}` });
     }
 
-    expect(generationMap.size).toBe(0);
+    expect(service._testGetGenerationMetadata!().userGenerationCount).toBe(0);
   });
 
   it('sweeps expired entries at five-minute activity boundaries before LRU eviction', async () => {
@@ -492,6 +461,9 @@ describe('MobileTtsService', () => {
     await service.preparePronunciation({ ...INPUT, vocabularyId: 'new-after-sweep' });
     await service.preparePronunciation({ ...INPUT, vocabularyId: 'live-0' });
 
+    // 300 initial misses; at 14 min the sweep deletes the expired entry, so
+    // new-after-sweep is a miss (301) while expired-but-recent (re-read before
+    // expiry) and live-0 (still live) are cache hits = 301 calls.
     expect(api.postJson).toHaveBeenCalledTimes(301);
   });
 
@@ -583,7 +555,6 @@ describe('MobileTtsService', () => {
       .mockReturnValueOnce(oldGeneration.promise)
       .mockReturnValueOnce(freshGeneration.promise);
     const service = createMobileTtsService(api);
-    const generationMap = captureVocabularyGenerationMap(service);
 
     const staleCaller = service.preparePronunciation(INPUT);
     await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(1));
@@ -595,13 +566,13 @@ describe('MobileTtsService', () => {
     await expect(freshCaller).resolves.toMatchObject({
       audioUrl: 'https://audio.example.test/fresh.mp3',
     });
-    expect(generationMap.size).toBe(1);
+    expect(service._testGetGenerationMetadata!().vocabularyGenerationCount).toBe(1);
 
     oldGeneration.resolve(generated('https://audio.example.test/stale.mp3'));
     await expect(staleCaller).resolves.toMatchObject({
       audioUrl: 'https://audio.example.test/stale.mp3',
     });
-    expect(generationMap.size).toBe(0);
+    expect(service._testGetGenerationMetadata!().vocabularyGenerationCount).toBe(0);
     await expect(service.preparePronunciation(INPUT)).resolves.toMatchObject({
       audioUrl: 'https://audio.example.test/fresh.mp3',
       source: 'memory-cache',
@@ -671,16 +642,15 @@ describe('MobileTtsService', () => {
     const generation = deferred<unknown>();
     api.postJson.mockReturnValueOnce(generation.promise);
     const service = createMobileTtsService(api);
-    const generationMap = captureUserGenerationMap(service);
 
     const staleCaller = service.preparePronunciation(INPUT);
     await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(1));
     service.clearUser(INPUT.userId);
-    expect(generationMap.get(INPUT.userId)).toBe(1);
+    expect(service._testGetGenerationMetadata!().userGenerationFor(INPUT.userId)).toBe(1);
 
     generation.resolve(generated('https://audio.example.test/stale-user.mp3'));
     await staleCaller;
-    expect(generationMap.size).toBe(0);
+    expect(service._testGetGenerationMetadata!().userGenerationCount).toBe(0);
 
     api.postJson.mockResolvedValueOnce(generated());
     await service.preparePronunciation(INPUT);
@@ -707,16 +677,15 @@ describe('MobileTtsService', () => {
     const generation = deferred<unknown>();
     api.postJson.mockReturnValueOnce(generation.promise);
     const service = createMobileTtsService(api);
-    const generationMap = captureUserGenerationMap(service);
 
     const staleCaller = service.preparePronunciation(INPUT);
     await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(1));
     service.clearAll();
-    expect(generationMap.size).toBe(0);
+    expect(service._testGetGenerationMetadata!().userGenerationCount).toBe(0);
 
     generation.resolve(generated('https://audio.example.test/stale-global.mp3'));
     await staleCaller;
-    expect(generationMap.size).toBe(0);
+    expect(service._testGetGenerationMetadata!().userGenerationCount).toBe(0);
 
     api.postJson.mockResolvedValueOnce(generated());
     await service.preparePronunciation(INPUT);

--- a/apps/vela-mobile/src/services/mobile-tts.test.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.test.ts
@@ -58,6 +58,23 @@ function generated(audioUrl = HTTPS_AUDIO, cached = false) {
   return { audioUrl, cached };
 }
 
+function captureVocabularyGenerationMap(
+  service: ReturnType<typeof createMobileTtsService>,
+): Map<string, number> {
+  const setSpy = vi.spyOn(Map.prototype, 'set');
+  try {
+    service.invalidatePronunciation('metadata-probe-user', 'metadata-probe-vocabulary');
+    const callIndex = setSpy.mock.calls.findIndex(
+      ([key]) => key === 'metadata-probe-user|metadata-probe-vocabulary',
+    );
+    const generationMap = setSpy.mock.contexts[callIndex];
+    expect(generationMap).toBeInstanceOf(Map);
+    return generationMap as Map<string, number>;
+  } finally {
+    setSpy.mockRestore();
+  }
+}
+
 describe('MobileTtsService', () => {
   let api: MockApiClient;
 
@@ -423,6 +440,17 @@ describe('MobileTtsService', () => {
     expect(api.postJson).toHaveBeenCalledTimes(302);
   });
 
+  it('releases vocabulary generation metadata after more completed vocabularies than the cache cap', async () => {
+    const service = createMobileTtsService(api);
+    const generationMap = captureVocabularyGenerationMap(service);
+
+    for (let index = 0; index < 301; index += 1) {
+      await service.preparePronunciation({ ...INPUT, vocabularyId: `metadata-${index}` });
+    }
+
+    expect(generationMap.size).toBe(0);
+  });
+
   it('sweeps expired entries at five-minute activity boundaries before LRU eviction', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
@@ -520,6 +548,38 @@ describe('MobileTtsService', () => {
     });
     await expect(newCaller).resolves.toMatchObject({
       audioUrl: 'https://audio.example.test/new.mp3',
+    });
+  });
+
+  it('releases invalidation metadata only after stale and fresh work finish', async () => {
+    const oldGeneration = deferred<unknown>();
+    const freshGeneration = deferred<unknown>();
+    api.postJson
+      .mockReturnValueOnce(oldGeneration.promise)
+      .mockReturnValueOnce(freshGeneration.promise);
+    const service = createMobileTtsService(api);
+    const generationMap = captureVocabularyGenerationMap(service);
+
+    const staleCaller = service.preparePronunciation(INPUT);
+    await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(1));
+    service.invalidatePronunciation(INPUT.userId, INPUT.vocabularyId);
+    const freshCaller = service.preparePronunciation(INPUT);
+    await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(2));
+
+    freshGeneration.resolve(generated('https://audio.example.test/fresh.mp3'));
+    await expect(freshCaller).resolves.toMatchObject({
+      audioUrl: 'https://audio.example.test/fresh.mp3',
+    });
+    expect(generationMap.size).toBe(1);
+
+    oldGeneration.resolve(generated('https://audio.example.test/stale.mp3'));
+    await expect(staleCaller).resolves.toMatchObject({
+      audioUrl: 'https://audio.example.test/stale.mp3',
+    });
+    expect(generationMap.size).toBe(0);
+    await expect(service.preparePronunciation(INPUT)).resolves.toMatchObject({
+      audioUrl: 'https://audio.example.test/fresh.mp3',
+      source: 'memory-cache',
     });
   });
 

--- a/apps/vela-mobile/src/services/mobile-tts.test.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.test.ts
@@ -7,6 +7,7 @@ import {
   createMobileTtsService,
   type MobilePronunciationInput,
   type MobileTtsErrorCode,
+  type MobileTtsServiceTestAccess,
 } from './mobile-tts';
 
 const HTTPS_AUDIO = 'https://audio.example.test/mizu.mp3?signature=temporary';
@@ -52,6 +53,15 @@ async function captureError(promise: Promise<unknown>): Promise<MobileTtsError> 
     return error as MobileTtsError;
   }
   throw new Error('Expected promise to reject');
+}
+
+// The test-only generation-metadata accessor is intentionally excluded from
+// the public MobileTtsService type. Cast through MobileTtsServiceTestAccess to
+// reach it without leaking it into the public contract.
+function generationMetadata(
+  service: ReturnType<typeof createMobileTtsService>,
+): ReturnType<MobileTtsServiceTestAccess['_testGetGenerationMetadata']> {
+  return (service as unknown as MobileTtsServiceTestAccess)._testGetGenerationMetadata();
 }
 
 function generated(audioUrl = HTTPS_AUDIO, cached = false) {
@@ -502,7 +512,7 @@ describe('MobileTtsService', () => {
       await service.preparePronunciation({ ...INPUT, vocabularyId: `metadata-${index}` });
     }
 
-    expect(service._testGetGenerationMetadata!().vocabularyGenerationCount).toBe(0);
+    expect(generationMetadata(service).vocabularyGenerationCount).toBe(0);
   });
 
   it('releases user generation metadata after more completed users than the cache cap', async () => {
@@ -512,7 +522,7 @@ describe('MobileTtsService', () => {
       await service.preparePronunciation({ ...INPUT, userId: `metadata-user-${index}` });
     }
 
-    expect(service._testGetGenerationMetadata!().userGenerationCount).toBe(0);
+    expect(generationMetadata(service).userGenerationCount).toBe(0);
   });
 
   it('sweeps expired entries at five-minute activity boundaries before LRU eviction', async () => {
@@ -636,13 +646,13 @@ describe('MobileTtsService', () => {
     await expect(freshCaller).resolves.toMatchObject({
       audioUrl: 'https://audio.example.test/fresh.mp3',
     });
-    expect(service._testGetGenerationMetadata!().vocabularyGenerationCount).toBe(1);
+    expect(generationMetadata(service).vocabularyGenerationCount).toBe(1);
 
     oldGeneration.resolve(generated('https://audio.example.test/stale.mp3'));
     await expect(staleCaller).resolves.toMatchObject({
       audioUrl: 'https://audio.example.test/stale.mp3',
     });
-    expect(service._testGetGenerationMetadata!().vocabularyGenerationCount).toBe(0);
+    expect(generationMetadata(service).vocabularyGenerationCount).toBe(0);
     await expect(service.preparePronunciation(INPUT)).resolves.toMatchObject({
       audioUrl: 'https://audio.example.test/fresh.mp3',
       source: 'memory-cache',
@@ -716,11 +726,11 @@ describe('MobileTtsService', () => {
     const staleCaller = service.preparePronunciation(INPUT);
     await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(1));
     service.clearUser(INPUT.userId);
-    expect(service._testGetGenerationMetadata!().userGenerationFor(INPUT.userId)).toBe(1);
+    expect(generationMetadata(service).userGenerationFor(INPUT.userId)).toBe(1);
 
     generation.resolve(generated('https://audio.example.test/stale-user.mp3'));
     await staleCaller;
-    expect(service._testGetGenerationMetadata!().userGenerationCount).toBe(0);
+    expect(generationMetadata(service).userGenerationCount).toBe(0);
 
     api.postJson.mockResolvedValueOnce(generated());
     await service.preparePronunciation(INPUT);
@@ -751,11 +761,11 @@ describe('MobileTtsService', () => {
     const staleCaller = service.preparePronunciation(INPUT);
     await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(1));
     service.clearAll();
-    expect(service._testGetGenerationMetadata!().userGenerationCount).toBe(0);
+    expect(generationMetadata(service).userGenerationCount).toBe(0);
 
     generation.resolve(generated('https://audio.example.test/stale-global.mp3'));
     await staleCaller;
-    expect(service._testGetGenerationMetadata!().userGenerationCount).toBe(0);
+    expect(generationMetadata(service).userGenerationCount).toBe(0);
 
     api.postJson.mockResolvedValueOnce(generated());
     await service.preparePronunciation(INPUT);

--- a/apps/vela-mobile/src/services/mobile-tts.test.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.test.ts
@@ -75,6 +75,22 @@ function captureVocabularyGenerationMap(
   }
 }
 
+function captureUserGenerationMap(
+  service: ReturnType<typeof createMobileTtsService>,
+): Map<string, number> {
+  const setSpy = vi.spyOn(Map.prototype, 'set');
+  try {
+    service.clearUser('metadata-probe-user');
+    const callIndex = setSpy.mock.calls.findIndex(([key]) => key === 'metadata-probe-user');
+    const generationMap = setSpy.mock.contexts[callIndex];
+    expect(generationMap).toBeInstanceOf(Map);
+    service.clearAll();
+    return generationMap as Map<string, number>;
+  } finally {
+    setSpy.mockRestore();
+  }
+}
+
 describe('MobileTtsService', () => {
   let api: MockApiClient;
 
@@ -451,6 +467,17 @@ describe('MobileTtsService', () => {
     expect(generationMap.size).toBe(0);
   });
 
+  it('releases user generation metadata after more completed users than the cache cap', async () => {
+    const service = createMobileTtsService(api);
+    const generationMap = captureUserGenerationMap(service);
+
+    for (let index = 0; index < 301; index += 1) {
+      await service.preparePronunciation({ ...INPUT, userId: `metadata-user-${index}` });
+    }
+
+    expect(generationMap.size).toBe(0);
+  });
+
   it('sweeps expired entries at five-minute activity boundaries before LRU eviction', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
@@ -642,6 +669,26 @@ describe('MobileTtsService', () => {
     expect(api.postJson).toHaveBeenCalledTimes(2);
   });
 
+  it('reclaims a user generation only after clearUser stale work settles', async () => {
+    const generation = deferred<unknown>();
+    api.postJson.mockReturnValueOnce(generation.promise);
+    const service = createMobileTtsService(api);
+    const generationMap = captureUserGenerationMap(service);
+
+    const staleCaller = service.preparePronunciation(INPUT);
+    await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(1));
+    service.clearUser(INPUT.userId);
+    expect(generationMap.get(INPUT.userId)).toBe(1);
+
+    generation.resolve(generated('https://audio.example.test/stale-user.mp3'));
+    await staleCaller;
+    expect(generationMap.size).toBe(0);
+
+    api.postJson.mockResolvedValueOnce(generated());
+    await service.preparePronunciation(INPUT);
+    expect(api.postJson).toHaveBeenCalledTimes(2);
+  });
+
   it('does not cache a stale completion after clearAll', async () => {
     const generation = deferred<unknown>();
     api.postJson.mockReturnValueOnce(generation.promise);
@@ -652,6 +699,26 @@ describe('MobileTtsService', () => {
     service.clearAll();
     generation.resolve(generated());
     await first;
+
+    api.postJson.mockResolvedValueOnce(generated());
+    await service.preparePronunciation(INPUT);
+    expect(api.postJson).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not recreate user generation metadata when clearAll stale work settles', async () => {
+    const generation = deferred<unknown>();
+    api.postJson.mockReturnValueOnce(generation.promise);
+    const service = createMobileTtsService(api);
+    const generationMap = captureUserGenerationMap(service);
+
+    const staleCaller = service.preparePronunciation(INPUT);
+    await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(1));
+    service.clearAll();
+    expect(generationMap.size).toBe(0);
+
+    generation.resolve(generated('https://audio.example.test/stale-global.mp3'));
+    await staleCaller;
+    expect(generationMap.size).toBe(0);
 
     api.postJson.mockResolvedValueOnce(generated());
     await service.preparePronunciation(INPUT);

--- a/apps/vela-mobile/src/services/mobile-tts.test.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.test.ts
@@ -320,6 +320,62 @@ describe('MobileTtsService', () => {
     expect(api.postJson).toHaveBeenCalledTimes(1);
   });
 
+  it('does not cache under the stale settings key when backend effective settings changed between GET and POST', async () => {
+    // Reproduces the race: the client reads settings A (openai/alloy), derives
+    // the cache key from A, then the backend re-reads settings during POST and
+    // generates with B (openai/echo). The response is still usable, but it must
+    // not be cached under the A-derived key, otherwise a later A-identity
+    // request would hit the cache and play echo-voiced audio as if it were
+    // alloy. A second call with the same A settings must therefore miss the
+    // memory cache and re-generate instead of returning source 'memory-cache'.
+    api.postJson.mockResolvedValueOnce({
+      audioUrl: HTTPS_AUDIO,
+      cached: false,
+      effectiveSettings: { provider: 'openai', voiceId: 'echo', model: 'tts-1' },
+    });
+    api.postJson.mockResolvedValueOnce(generated(HTTPS_AUDIO, false));
+    const service = createMobileTtsService(api);
+
+    const first = await service.preparePronunciation(INPUT);
+    expect(first).toMatchObject({ audioUrl: HTTPS_AUDIO, source: 'generated' });
+
+    const second = await service.preparePronunciation(INPUT);
+    expect(second).toMatchObject({ source: 'generated' });
+    expect(api.postJson).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches normally when backend effective settings match the GET snapshot', async () => {
+    api.postJson.mockResolvedValueOnce({
+      audioUrl: HTTPS_AUDIO,
+      cached: false,
+      effectiveSettings: {
+        provider: CONFIGURED_SETTINGS.provider,
+        voiceId: CONFIGURED_SETTINGS.voiceId,
+        model: CONFIGURED_SETTINGS.model,
+      },
+    });
+    const service = createMobileTtsService(api);
+
+    const first = await service.preparePronunciation(INPUT);
+    expect(first).toMatchObject({ source: 'generated' });
+
+    const second = await service.preparePronunciation(INPUT);
+    expect(second).toMatchObject({ source: 'memory-cache' });
+    expect(api.postJson).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches normally when the backend omits effective settings (older deployment)', async () => {
+    api.postJson.mockResolvedValueOnce(generated(HTTPS_AUDIO, false));
+    const service = createMobileTtsService(api);
+
+    const first = await service.preparePronunciation(INPUT);
+    expect(first).toMatchObject({ source: 'generated' });
+
+    const second = await service.preparePronunciation(INPUT);
+    expect(second).toMatchObject({ source: 'memory-cache' });
+    expect(api.postJson).toHaveBeenCalledTimes(1);
+  });
+
   it('uses distinct keys when user, vocabulary, provider, voice, or model changes', async () => {
     const service = createMobileTtsService(api);
     const settings = [

--- a/apps/vela-mobile/src/services/mobile-tts.test.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.test.ts
@@ -597,4 +597,38 @@ describe('MobileTtsService', () => {
     await service.preparePronunciation(INPUT);
     expect(api.postJson).toHaveBeenCalledTimes(2);
   });
+
+  it('keeps a user-generation guard after purging that user vocabulary generations', async () => {
+    const generation = deferred<unknown>();
+    api.postJson.mockReturnValueOnce(generation.promise);
+    const service = createMobileTtsService(api);
+
+    service.invalidatePronunciation(INPUT.userId, 'populated-generation-key');
+    const first = service.preparePronunciation(INPUT);
+    await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(1));
+    service.clearUser(INPUT.userId);
+    generation.resolve(generated());
+    await first;
+
+    api.postJson.mockResolvedValueOnce(generated());
+    await service.preparePronunciation(INPUT);
+    expect(api.postJson).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the global-generation guard after clearing generation metadata', async () => {
+    const generation = deferred<unknown>();
+    api.postJson.mockReturnValueOnce(generation.promise);
+    const service = createMobileTtsService(api);
+
+    service.invalidatePronunciation(INPUT.userId, 'populated-generation-key');
+    const first = service.preparePronunciation(INPUT);
+    await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(1));
+    service.clearAll();
+    generation.resolve(generated());
+    await first;
+
+    api.postJson.mockResolvedValueOnce(generated());
+    await service.preparePronunciation(INPUT);
+    expect(api.postJson).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/vela-mobile/src/services/mobile-tts.test.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.test.ts
@@ -1,0 +1,557 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TtsApiErrorCode, TtsSettings } from '@vela/common';
+import { MobileApiError, type MobileApiClient } from './mobile-api-client';
+import {
+  MOBILE_TTS_GENERATE_TIMEOUT_MS,
+  MobileTtsError,
+  createMobileTtsService,
+  type MobilePronunciationInput,
+  type MobileTtsErrorCode,
+} from './mobile-tts';
+
+const HTTPS_AUDIO = 'https://audio.example.test/mizu.mp3?signature=temporary';
+const INPUT: MobilePronunciationInput = {
+  userId: 'user-1',
+  vocabularyId: '水:ミズ',
+  text: '水',
+};
+const CONFIGURED_SETTINGS: TtsSettings = {
+  provider: 'openai',
+  voiceId: 'alloy',
+  model: 'tts-1',
+  hasApiKey: true,
+};
+
+type MockApiClient = {
+  getJson: ReturnType<typeof vi.fn<MobileApiClient['getJson']>>;
+  postJson: ReturnType<typeof vi.fn<MobileApiClient['postJson']>>;
+};
+
+function createApi(): MockApiClient {
+  return {
+    getJson: vi.fn<MobileApiClient['getJson']>(),
+    postJson: vi.fn<MobileApiClient['postJson']>(),
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function captureError(promise: Promise<unknown>): Promise<MobileTtsError> {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error).toBeInstanceOf(MobileTtsError);
+    return error as MobileTtsError;
+  }
+  throw new Error('Expected promise to reject');
+}
+
+function generated(audioUrl = HTTPS_AUDIO, cached = false) {
+  return { audioUrl, cached };
+}
+
+describe('MobileTtsService', () => {
+  let api: MockApiClient;
+
+  beforeEach(() => {
+    api = createApi();
+    api.getJson.mockResolvedValue(CONFIGURED_SETTINGS);
+    api.postJson.mockResolvedValue(generated());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('uses the default settings timeout and exactly 45 seconds for generation', async () => {
+    const service = createMobileTtsService(api);
+
+    await service.preparePronunciation(INPUT);
+
+    expect(MOBILE_TTS_GENERATE_TIMEOUT_MS).toBe(45_000);
+    expect(api.getJson).toHaveBeenCalledWith('tts/settings', {
+      signal: expect.any(AbortSignal),
+    });
+    expect(api.postJson).toHaveBeenCalledWith(
+      'tts/generate',
+      { vocabularyId: '水:ミズ', text: '水' },
+      { signal: expect.any(AbortSignal), timeoutMs: 45_000 },
+    );
+  });
+
+  it('validates and trims input without sending the cache-only user ID', async () => {
+    const service = createMobileTtsService(api);
+
+    await service.preparePronunciation({
+      userId: ' user-1 ',
+      vocabularyId: ' 水:ミズ ',
+      text: ' 水 ',
+    });
+
+    expect(api.postJson).toHaveBeenCalledWith(
+      'tts/generate',
+      { vocabularyId: '水:ミズ', text: '水' },
+      expect.any(Object),
+    );
+    expect(api.postJson.mock.calls[0]?.[1]).not.toHaveProperty('userId');
+  });
+
+  it.each([
+    ['userId', { ...INPUT, userId: ' ' }],
+    ['vocabularyId', { ...INPUT, vocabularyId: '' }],
+    ['text', { ...INPUT, text: '\t' }],
+  ])('rejects a blank %s before making a request', async (_field, input) => {
+    const service = createMobileTtsService(api);
+
+    await expect(service.preparePronunciation(input)).rejects.toMatchObject({
+      code: 'invalid_input',
+    });
+    expect(api.getJson).not.toHaveBeenCalled();
+  });
+
+  it('short-circuits generation when settings are not configured', async () => {
+    api.getJson.mockResolvedValue({ ...CONFIGURED_SETTINGS, hasApiKey: false });
+    const service = createMobileTtsService(api);
+
+    await expect(service.preparePronunciation(INPUT)).rejects.toMatchObject({
+      code: 'not_configured',
+    });
+    expect(api.postJson).not.toHaveBeenCalled();
+  });
+
+  it.each<[TtsApiErrorCode, MobileTtsErrorCode]>([
+    ['tts_not_configured', 'not_configured'],
+    ['tts_invalid_provider_configuration', 'generation_failed'],
+    ['tts_audio_service_unavailable', 'service_unavailable'],
+    ['tts_generation_timeout', 'generation_timeout'],
+    ['tts_generation_failed', 'generation_failed'],
+    ['tts_audio_storage_failed', 'generation_failed'],
+    ['tts_audio_access_failed', 'generation_failed'],
+  ])('maps stable backend code %s to %s before status fallback', async (backendCode, code) => {
+    api.postJson.mockRejectedValue(
+      new MobileApiError('client', {
+        status: 400,
+        serverBody: { error: 'opaque backend message', code: backendCode },
+      }),
+    );
+    const service = createMobileTtsService(api);
+
+    await expect(service.preparePronunciation(INPUT)).rejects.toMatchObject({ code });
+  });
+
+  it.each([
+    ['TTS API key not configured. Please configure in Settings.', 'not_configured'],
+    ['Invalid TTS provider configuration', 'generation_failed'],
+  ] as const)('maps the exact legacy 400 message %s to %s', async (legacyMessage, code) => {
+    api.postJson.mockRejectedValue(
+      new MobileApiError('client', {
+        status: 400,
+        serverBody: { error: legacyMessage },
+      }),
+    );
+    const service = createMobileTtsService(api);
+
+    await expect(service.preparePronunciation(INPUT)).rejects.toMatchObject({ code });
+  });
+
+  it('does not treat a legacy message as compatibility evidence outside status 400', async () => {
+    api.postJson.mockRejectedValue(
+      new MobileApiError('server', {
+        status: 500,
+        serverBody: { error: 'TTS API key not configured. Please configure in Settings.' },
+      }),
+    );
+    const service = createMobileTtsService(api);
+
+    await expect(service.preparePronunciation(INPUT)).rejects.toMatchObject({
+      code: 'generation_failed',
+    });
+  });
+
+  it('maps an uncoded validator 400 to invalid_input', async () => {
+    api.postJson.mockRejectedValue(
+      new MobileApiError('client', {
+        status: 400,
+        serverBody: { success: false, error: { issues: [] } },
+      }),
+    );
+    const service = createMobileTtsService(api);
+
+    await expect(service.preparePronunciation(INPUT)).rejects.toMatchObject({
+      code: 'invalid_input',
+    });
+  });
+
+  it.each([
+    [503, 'service_unavailable'],
+    [504, 'generation_timeout'],
+    [500, 'generation_failed'],
+  ] as const)('maps status-only HTTP %i to %s', async (status, code) => {
+    api.postJson.mockRejectedValue(new MobileApiError('server', { status }));
+    const service = createMobileTtsService(api);
+
+    await expect(service.preparePronunciation(INPUT)).rejects.toMatchObject({ code });
+  });
+
+  it.each([
+    ['session_unavailable', 'session_unavailable'],
+    ['session_changed', 'session_changed'],
+    ['session_recovery_pending', 'session_recovery_pending'],
+    ['unauthorized', 'unauthorized'],
+    ['forbidden', 'forbidden'],
+    ['network', 'network'],
+  ] as const)('preserves API classification %s as %s', async (apiCode, code) => {
+    api.postJson.mockRejectedValue(new MobileApiError(apiCode));
+    const service = createMobileTtsService(api);
+
+    await expect(service.preparePronunciation(INPUT)).rejects.toMatchObject({ code });
+  });
+
+  it('maps an API invalid-response failure to invalid_response', async () => {
+    api.getJson.mockRejectedValue(new MobileApiError('invalid_response'));
+    const service = createMobileTtsService(api);
+
+    await expect(service.preparePronunciation(INPUT)).rejects.toMatchObject({
+      code: 'invalid_response',
+    });
+  });
+
+  it.each([
+    ['settings', { provider: 'unsupported', voiceId: null, model: null, hasApiKey: true }],
+    ['generation', { audioUrl: 'http://audio.example.test/mizu.mp3', cached: false }],
+  ])(
+    'maps a structurally invalid successful %s response to invalid_response',
+    async (kind, value) => {
+      if (kind === 'settings') api.getJson.mockResolvedValue(value);
+      else api.postJson.mockResolvedValue(value);
+      const service = createMobileTtsService(api);
+
+      await expect(service.preparePronunciation(INPUT)).rejects.toMatchObject({
+        code: 'invalid_response',
+      });
+    },
+  );
+
+  it('keeps unknown and raw server details private', async () => {
+    const rawBody = { error: 'provider credential rejected', code: 'future_server_code' };
+    api.postJson.mockRejectedValue(
+      new MobileApiError('server', { status: 500, serverBody: rawBody }),
+    );
+    const service = createMobileTtsService(api);
+
+    const error = await captureError(service.preparePronunciation(INPUT));
+
+    expect(error).toMatchObject({ code: 'generation_failed', message: 'generation_failed' });
+    expect(error).not.toHaveProperty('details');
+    expect(error).not.toHaveProperty('serverBody');
+    expect(error.cause).toBeUndefined();
+    expect(JSON.stringify(error)).not.toContain('provider credential rejected');
+    expect(JSON.stringify(error)).not.toContain('future_server_code');
+  });
+
+  it('reports server-cache, generated, and memory-cache sources without exposing the URL in errors', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-31T12:00:00.000Z'));
+    api.postJson.mockResolvedValueOnce(generated(HTTPS_AUDIO, true));
+    const service = createMobileTtsService(api);
+
+    const serverCached = await service.preparePronunciation(INPUT);
+    const memoryCached = await service.preparePronunciation(INPUT);
+
+    expect(serverCached).toEqual({
+      audioUrl: HTTPS_AUDIO,
+      source: 'server-cache',
+      expiresAt: Date.now() + 14 * 60_000,
+      timings: { settingsMs: 0, generateMs: 0 },
+    });
+    expect(memoryCached).toMatchObject({
+      audioUrl: HTTPS_AUDIO,
+      source: 'memory-cache',
+      expiresAt: serverCached.expiresAt,
+      timings: { settingsMs: 0, generateMs: 0 },
+    });
+
+    service.invalidatePronunciation(INPUT.userId, INPUT.vocabularyId);
+    api.postJson.mockResolvedValueOnce(generated(HTTPS_AUDIO, false));
+    await expect(service.preparePronunciation(INPUT)).resolves.toMatchObject({
+      source: 'generated',
+    });
+  });
+
+  it('records settings and generation timings separately', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const settings = deferred<unknown>();
+    const generation = deferred<unknown>();
+    api.getJson.mockReturnValue(settings.promise);
+    api.postJson.mockReturnValue(generation.promise);
+    const service = createMobileTtsService(api);
+
+    const prepared = service.preparePronunciation(INPUT);
+    await vi.advanceTimersByTimeAsync(12);
+    settings.resolve(CONFIGURED_SETTINGS);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(34);
+    generation.resolve(generated());
+
+    await expect(prepared).resolves.toMatchObject({
+      timings: { settingsMs: 12, generateMs: 34 },
+    });
+  });
+
+  it('shares generation only after resolving the same settings-derived key', async () => {
+    const generation = deferred<unknown>();
+    api.postJson.mockReturnValue(generation.promise);
+    const service = createMobileTtsService(api);
+
+    const first = service.preparePronunciation(INPUT);
+    const second = service.preparePronunciation(INPUT);
+    await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(1));
+    generation.resolve(generated());
+
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+    expect(api.getJson).toHaveBeenCalledTimes(2);
+    expect(api.postJson).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses distinct keys when user, vocabulary, provider, voice, or model changes', async () => {
+    const service = createMobileTtsService(api);
+    const settings = [
+      CONFIGURED_SETTINGS,
+      CONFIGURED_SETTINGS,
+      CONFIGURED_SETTINGS,
+      { ...CONFIGURED_SETTINGS, provider: 'gemini' },
+      { ...CONFIGURED_SETTINGS, voiceId: 'nova' },
+      { ...CONFIGURED_SETTINGS, model: 'tts-2' },
+    ] satisfies TtsSettings[];
+    api.getJson.mockImplementation(async () => settings.shift() ?? CONFIGURED_SETTINGS);
+
+    await service.preparePronunciation(INPUT);
+    await service.preparePronunciation({ ...INPUT, userId: 'user-2' });
+    await service.preparePronunciation({ ...INPUT, vocabularyId: '火:ヒ', text: '火' });
+    await service.preparePronunciation(INPUT);
+    await service.preparePronunciation(INPUT);
+    await service.preparePronunciation(INPUT);
+
+    expect(api.postJson).toHaveBeenCalledTimes(6);
+  });
+
+  it('does not include text in the full cache key for a fixed vocabulary/text pair', async () => {
+    const service = createMobileTtsService(api);
+
+    await service.preparePronunciation(INPUT);
+    await service.preparePronunciation({ ...INPUT, text: '別の読み' });
+
+    expect(api.postJson).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up failed pending generation so an explicit retry starts new work', async () => {
+    api.postJson.mockRejectedValueOnce(new MobileApiError('network'));
+    const service = createMobileTtsService(api);
+
+    await expect(service.preparePronunciation(INPUT)).rejects.toMatchObject({ code: 'network' });
+    api.postJson.mockResolvedValueOnce(generated());
+    await expect(service.preparePronunciation(INPUT)).resolves.toMatchObject({
+      source: 'generated',
+    });
+
+    expect(api.postJson).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps underlying preparation useful when one caller aborts', async () => {
+    const generation = deferred<unknown>();
+    api.postJson.mockReturnValue(generation.promise);
+    const controller = new AbortController();
+    const service = createMobileTtsService(api);
+
+    const first = service.preparePronunciation(INPUT, { signal: controller.signal });
+    await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(1));
+    controller.abort();
+    await expect(first).rejects.toMatchObject({ name: 'AbortError' });
+    generation.resolve(generated());
+    await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(1));
+    await expect(service.preparePronunciation(INPUT)).resolves.toMatchObject({
+      source: 'memory-cache',
+    });
+  });
+
+  it('expires cache entries after exactly 14 minutes', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const service = createMobileTtsService(api);
+
+    await service.preparePronunciation(INPUT);
+    await vi.advanceTimersByTimeAsync(14 * 60_000 - 1);
+    await service.preparePronunciation(INPUT);
+    expect(api.postJson).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await service.preparePronunciation(INPUT);
+    expect(api.postJson).toHaveBeenCalledTimes(2);
+  });
+
+  it('refreshes LRU order when a live entry is read', async () => {
+    const service = createMobileTtsService(api);
+
+    for (let index = 0; index < 300; index += 1) {
+      await service.preparePronunciation({ ...INPUT, vocabularyId: `vocab-${index}` });
+    }
+    await service.preparePronunciation({ ...INPUT, vocabularyId: 'vocab-0' });
+    await service.preparePronunciation({ ...INPUT, vocabularyId: 'vocab-new' });
+    await service.preparePronunciation({ ...INPUT, vocabularyId: 'vocab-0' });
+    await service.preparePronunciation({ ...INPUT, vocabularyId: 'vocab-1' });
+
+    expect(api.postJson).toHaveBeenCalledTimes(302);
+  });
+
+  it('bounds the cache at 300 entries by evicting the least recently used entry', async () => {
+    const service = createMobileTtsService(api);
+
+    for (let index = 0; index < 301; index += 1) {
+      await service.preparePronunciation({ ...INPUT, vocabularyId: `vocab-${index}` });
+    }
+    await service.preparePronunciation({ ...INPUT, vocabularyId: 'vocab-0' });
+
+    expect(api.postJson).toHaveBeenCalledTimes(302);
+  });
+
+  it('sweeps expired entries at five-minute activity boundaries before LRU eviction', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const service = createMobileTtsService(api);
+
+    await service.preparePronunciation({ ...INPUT, vocabularyId: 'expired-but-recent' });
+    await vi.advanceTimersByTimeAsync(1);
+    for (let index = 0; index < 299; index += 1) {
+      await service.preparePronunciation({ ...INPUT, vocabularyId: `live-${index}` });
+    }
+    await service.preparePronunciation({ ...INPUT, vocabularyId: 'expired-but-recent' });
+
+    await vi.advanceTimersByTimeAsync(14 * 60_000 - 1);
+    await service.preparePronunciation({ ...INPUT, vocabularyId: 'new-after-sweep' });
+    await service.preparePronunciation({ ...INPUT, vocabularyId: 'live-0' });
+
+    expect(api.postJson).toHaveBeenCalledTimes(301);
+  });
+
+  it('removes every settings partition for one user and vocabulary', async () => {
+    const service = createMobileTtsService(api);
+    api.getJson
+      .mockResolvedValueOnce(CONFIGURED_SETTINGS)
+      .mockResolvedValueOnce({ ...CONFIGURED_SETTINGS, voiceId: 'nova' })
+      .mockResolvedValueOnce(CONFIGURED_SETTINGS)
+      .mockResolvedValueOnce({ ...CONFIGURED_SETTINGS, voiceId: 'nova' });
+
+    await service.preparePronunciation(INPUT);
+    await service.preparePronunciation(INPUT);
+    service.invalidatePronunciation('user-1', '水:ミズ');
+    await service.preparePronunciation(INPUT);
+    await service.preparePronunciation(INPUT);
+
+    expect(api.postJson).toHaveBeenCalledTimes(4);
+  });
+
+  it('clearUser removes only that user cache', async () => {
+    const service = createMobileTtsService(api);
+
+    await service.preparePronunciation(INPUT);
+    await service.preparePronunciation({ ...INPUT, userId: 'user-2' });
+    service.clearUser('user-1');
+    await service.preparePronunciation(INPUT);
+    await service.preparePronunciation({ ...INPUT, userId: 'user-2' });
+
+    expect(api.postJson).toHaveBeenCalledTimes(3);
+  });
+
+  it('clearAll removes all cached users', async () => {
+    const service = createMobileTtsService(api);
+
+    await service.preparePronunciation(INPUT);
+    await service.preparePronunciation({ ...INPUT, userId: 'user-2' });
+    service.clearAll();
+    await service.preparePronunciation(INPUT);
+    await service.preparePronunciation({ ...INPUT, userId: 'user-2' });
+
+    expect(api.postJson).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not cache a stale completion after vocabulary invalidation', async () => {
+    const generation = deferred<unknown>();
+    api.postJson.mockReturnValueOnce(generation.promise);
+    const service = createMobileTtsService(api);
+
+    const first = service.preparePronunciation(INPUT);
+    await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(1));
+    service.invalidatePronunciation('user-1', '水:ミズ');
+    generation.resolve(generated());
+    await expect(first).resolves.toMatchObject({ source: 'generated' });
+
+    api.postJson.mockResolvedValueOnce(generated(HTTPS_AUDIO, true));
+    await service.preparePronunciation(INPUT);
+    expect(api.postJson).toHaveBeenCalledTimes(2);
+  });
+
+  it('detaches invalidated pending work without aborting its existing awaiters', async () => {
+    const oldGeneration = deferred<unknown>();
+    const newGeneration = deferred<unknown>();
+    api.postJson
+      .mockReturnValueOnce(oldGeneration.promise)
+      .mockReturnValueOnce(newGeneration.promise);
+    const service = createMobileTtsService(api);
+
+    const oldCaller = service.preparePronunciation(INPUT);
+    await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(1));
+    service.invalidatePronunciation('user-1', '水:ミズ');
+    const newCaller = service.preparePronunciation(INPUT);
+    await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(2));
+
+    oldGeneration.resolve(generated('https://audio.example.test/old.mp3'));
+    newGeneration.resolve(generated('https://audio.example.test/new.mp3'));
+    await expect(oldCaller).resolves.toMatchObject({
+      audioUrl: 'https://audio.example.test/old.mp3',
+    });
+    await expect(newCaller).resolves.toMatchObject({
+      audioUrl: 'https://audio.example.test/new.mp3',
+    });
+  });
+
+  it('does not cache a stale completion after clearUser', async () => {
+    const generation = deferred<unknown>();
+    api.postJson.mockReturnValueOnce(generation.promise);
+    const service = createMobileTtsService(api);
+
+    const first = service.preparePronunciation(INPUT);
+    await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(1));
+    service.clearUser('user-1');
+    generation.resolve(generated());
+    await first;
+
+    api.postJson.mockResolvedValueOnce(generated());
+    await service.preparePronunciation(INPUT);
+    expect(api.postJson).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache a stale completion after clearAll', async () => {
+    const generation = deferred<unknown>();
+    api.postJson.mockReturnValueOnce(generation.promise);
+    const service = createMobileTtsService(api);
+
+    const first = service.preparePronunciation(INPUT);
+    await vi.waitFor(() => expect(api.postJson).toHaveBeenCalledTimes(1));
+    service.clearAll();
+    generation.resolve(generated());
+    await first;
+
+    api.postJson.mockResolvedValueOnce(generated());
+    await service.preparePronunciation(INPUT);
+    expect(api.postJson).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/vela-mobile/src/services/mobile-tts.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.ts
@@ -268,14 +268,14 @@ function cacheKey(input: NormalizedInput, settings: TtsSettings): string {
  * the old snapshot, so the entry must not be cached under that stale key.
  *
  * When the backend omits `effectiveSettings` (older deployment), this returns
- * true to preserve the pre-guard caching behavior rather than penalizing
- * up-to-date clients talking to a not-yet-updated backend.
+ * false to avoid caching under a settings identity the backend did not
+ * confirm. Playback still succeeds; only the memory cache is skipped.
  */
 function effectiveSettingsMatch(
   snapshot: TtsSettings,
   effective: TtsEffectiveSettings | undefined,
 ): boolean {
-  if (!effective) return true;
+  if (!effective) return false;
   return (
     effective.provider === snapshot.provider &&
     effective.voiceId === snapshot.voiceId &&

--- a/apps/vela-mobile/src/services/mobile-tts.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.ts
@@ -1,10 +1,10 @@
 import {
+  effectiveSettingsMatch,
   parseGeneratePronunciationRequest,
   parseGeneratePronunciationResponse,
   parseTtsApiErrorResponse,
   parseTtsSettings,
   type TtsApiErrorCode,
-  type TtsEffectiveSettings,
   type TtsSettings,
 } from '@vela/common';
 import { MobileApiError, type MobileApiClient } from './mobile-api-client';
@@ -70,8 +70,16 @@ export type MobileTtsService = {
   invalidatePronunciation(userId: string, vocabularyId: string): void;
   clearUser(userId: string): void;
   clearAll(): void;
-  // Test-only inspection accessor: not part of the public contract.
-  _testGetGenerationMetadata?: () => {
+};
+
+/**
+ * Test-only inspection accessor exposed by the service implementation but
+ * intentionally excluded from the public {@link MobileTtsService} contract.
+ * Tests cast the service to this type to reach the accessor without leaking
+ * it into the public API surface.
+ */
+export type MobileTtsServiceTestAccess = {
+  _testGetGenerationMetadata: () => {
     vocabularyGenerationCount: number;
     userGenerationCount: number;
     userGenerationFor(userId: string): number;
@@ -116,6 +124,7 @@ const STABLE_ERROR_CODE_MAP: Record<TtsApiErrorCode, MobileTtsErrorCode> = {
   tts_audio_storage_failed: 'generation_failed',
   tts_audio_access_failed: 'generation_failed',
   tts_audio_bucket_not_configured: 'service_unavailable',
+  tts_audio_not_found: 'generation_failed',
   tts_unexpected_error: 'generation_failed',
 };
 
@@ -257,30 +266,6 @@ function cacheKey(input: NormalizedInput, settings: TtsSettings): string {
   ]
     .map(encodeURIComponent)
     .join('|');
-}
-
-/**
- * Compare the GET /tts/settings snapshot (used to derive the client cache key)
- * against the effective settings the backend reports it actually used for the
- * generation. The backend re-reads settings during POST /tts/generate, so a
- * concurrent settings change can make these differ. When they differ, the
- * audio was produced under new settings but the client key was derived from
- * the old snapshot, so the entry must not be cached under that stale key.
- *
- * When the backend omits `effectiveSettings` (older deployment), this returns
- * false to avoid caching under a settings identity the backend did not
- * confirm. Playback still succeeds; only the memory cache is skipped.
- */
-function effectiveSettingsMatch(
-  snapshot: TtsSettings,
-  effective: TtsEffectiveSettings | undefined,
-): boolean {
-  if (!effective) return false;
-  return (
-    effective.provider === snapshot.provider &&
-    effective.voiceId === snapshot.voiceId &&
-    effective.model === snapshot.model
-  );
 }
 
 function vocabularyGenerationKey(userId: string, vocabularyId: string): string {
@@ -587,7 +572,8 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
 
     // Test-only inspection accessor: reports generation metadata counts so tests
     // can assert cleanup behavior without spying on Map internals or depending
-    // on private key encoding. Not part of the public MobileTtsService contract.
+    // on private key encoding. Not part of the public MobileTtsService contract;
+    // reach it via `MobileTtsServiceTestAccess` in tests.
     _testGetGenerationMetadata() {
       return {
         vocabularyGenerationCount: vocabularyGenerations.size,
@@ -597,5 +583,5 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
         },
       };
     },
-  };
+  } as MobileTtsService;
 }

--- a/apps/vela-mobile/src/services/mobile-tts.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.ts
@@ -4,6 +4,7 @@ import {
   parseTtsApiErrorResponse,
   parseTtsSettings,
   type TtsApiErrorCode,
+  type TtsEffectiveSettings,
   type TtsSettings,
 } from '@vela/common';
 import { MobileApiError, type MobileApiClient } from './mobile-api-client';
@@ -258,6 +259,30 @@ function cacheKey(input: NormalizedInput, settings: TtsSettings): string {
     .join('|');
 }
 
+/**
+ * Compare the GET /tts/settings snapshot (used to derive the client cache key)
+ * against the effective settings the backend reports it actually used for the
+ * generation. The backend re-reads settings during POST /tts/generate, so a
+ * concurrent settings change can make these differ. When they differ, the
+ * audio was produced under new settings but the client key was derived from
+ * the old snapshot, so the entry must not be cached under that stale key.
+ *
+ * When the backend omits `effectiveSettings` (older deployment), this returns
+ * true to preserve the pre-guard caching behavior rather than penalizing
+ * up-to-date clients talking to a not-yet-updated backend.
+ */
+function effectiveSettingsMatch(
+  snapshot: TtsSettings,
+  effective: TtsEffectiveSettings | undefined,
+): boolean {
+  if (!effective) return true;
+  return (
+    effective.provider === snapshot.provider &&
+    effective.voiceId === snapshot.voiceId &&
+    effective.model === snapshot.model
+  );
+}
+
 function vocabularyGenerationKey(userId: string, vocabularyId: string): string {
   return [userId, vocabularyId].map(encodeURIComponent).join('|');
 }
@@ -431,7 +456,12 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
 
         const completedAt = Date.now();
         const expiresAt = completedAt + MOBILE_TTS_CACHE_TTL_MS;
+        // Skip caching when the backend's effective settings differ from the
+        // GET snapshot used to derive `key`: the audio was produced under new
+        // settings and must not be served from a stale-settings cache entry.
+        const settingsAreConsistent = effectiveSettingsMatch(settings, response.effectiveSettings);
         if (
+          settingsAreConsistent &&
           userGeneration(input.userId) === capturedUserGeneration &&
           vocabularyGeneration(input.userId, input.vocabularyId) === capturedVocabularyGeneration &&
           clearGeneration === capturedClearGeneration

--- a/apps/vela-mobile/src/services/mobile-tts.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.ts
@@ -94,6 +94,9 @@ type PendingResult = {
 type PendingEntry = {
   userId: string;
   vocabularyId: string;
+  userGeneration: number;
+  vocabularyGeneration: number;
+  clearGeneration: number;
   promise: Promise<PendingResult>;
 };
 
@@ -256,6 +259,7 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
   const pending = new Map<string, PendingEntry>();
   const userGenerations = new Map<string, number>();
   const vocabularyGenerations = new Map<string, number>();
+  let clearGeneration = 0;
   let lastExpiredSweepAt = Date.now();
 
   function userGeneration(userId: string): number {
@@ -314,6 +318,7 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
     input: NormalizedInput,
     capturedUserGeneration: number,
     capturedVocabularyGeneration: number,
+    capturedClearGeneration: number,
   ): Promise<PreparedPronunciation> {
     const requestController = new AbortController();
     const settingsStartedAt = Date.now();
@@ -346,7 +351,17 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
       };
     }
 
-    let pendingEntry = pending.get(key);
+    const generationsAreCurrent =
+      userGeneration(input.userId) === capturedUserGeneration &&
+      vocabularyGeneration(input.userId, input.vocabularyId) === capturedVocabularyGeneration &&
+      clearGeneration === capturedClearGeneration;
+    const indexedPending = generationsAreCurrent ? pending.get(key) : undefined;
+    let pendingEntry =
+      indexedPending?.userGeneration === capturedUserGeneration &&
+      indexedPending.vocabularyGeneration === capturedVocabularyGeneration &&
+      indexedPending.clearGeneration === capturedClearGeneration
+        ? indexedPending
+        : undefined;
     if (!pendingEntry) {
       const generateStartedAt = Date.now();
       const generationPromise = (async (): Promise<PendingResult> => {
@@ -372,7 +387,8 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
         const expiresAt = completedAt + MOBILE_TTS_CACHE_TTL_MS;
         if (
           userGeneration(input.userId) === capturedUserGeneration &&
-          vocabularyGeneration(input.userId, input.vocabularyId) === capturedVocabularyGeneration
+          vocabularyGeneration(input.userId, input.vocabularyId) === capturedVocabularyGeneration &&
+          clearGeneration === capturedClearGeneration
         ) {
           setCached(key, {
             userId: input.userId,
@@ -392,14 +408,19 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
       pendingEntry = {
         userId: input.userId,
         vocabularyId: input.vocabularyId,
+        userGeneration: capturedUserGeneration,
+        vocabularyGeneration: capturedVocabularyGeneration,
+        clearGeneration: capturedClearGeneration,
         promise: generationPromise,
       };
-      pending.set(key, pendingEntry);
+      if (generationsAreCurrent) {
+        pending.set(key, pendingEntry);
 
-      const removeOwnedPending = () => {
-        if (pending.get(key) === pendingEntry) pending.delete(key);
-      };
-      void generationPromise.then(removeOwnedPending, removeOwnedPending);
+        const removeOwnedPending = () => {
+          if (pending.get(key) === pendingEntry) pending.delete(key);
+        };
+        void generationPromise.then(removeOwnedPending, removeOwnedPending);
+      }
     }
 
     const result = await pendingEntry.promise;
@@ -426,6 +447,7 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
         normalized,
         userGeneration(normalized.userId),
         vocabularyGeneration(normalized.userId, normalized.vocabularyId),
+        clearGeneration,
       );
       return detachOnAbort(work, options.signal);
     },
@@ -461,9 +483,7 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
     },
 
     clearAll() {
-      for (const userId of userGenerations.keys()) {
-        userGenerations.set(userId, userGeneration(userId) + 1);
-      }
+      clearGeneration += 1;
       cache.clear();
       pending.clear();
       lastExpiredSweepAt = Date.now();

--- a/apps/vela-mobile/src/services/mobile-tts.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.ts
@@ -259,6 +259,7 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
   const pending = new Map<string, PendingEntry>();
   const userGenerations = new Map<string, number>();
   const vocabularyGenerations = new Map<string, number>();
+  const activeVocabularyPreparations = new Map<string, number>();
   let clearGeneration = 0;
   let lastExpiredSweepAt = Date.now();
 
@@ -270,9 +271,29 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
 
   function vocabularyGeneration(userId: string, vocabularyId: string): number {
     const key = vocabularyGenerationKey(userId, vocabularyId);
-    const generation = vocabularyGenerations.get(key) ?? 0;
-    if (!vocabularyGenerations.has(key)) vocabularyGenerations.set(key, generation);
-    return generation;
+    return vocabularyGenerations.get(key) ?? 0;
+  }
+
+  function beginVocabularyPreparation(userId: string, vocabularyId: string) {
+    const key = vocabularyGenerationKey(userId, vocabularyId);
+    activeVocabularyPreparations.set(key, (activeVocabularyPreparations.get(key) ?? 0) + 1);
+    let released = false;
+
+    return {
+      generation: vocabularyGenerations.get(key) ?? 0,
+      release() {
+        if (released) return;
+        released = true;
+        const remaining = (activeVocabularyPreparations.get(key) ?? 1) - 1;
+        if (remaining > 0) {
+          activeVocabularyPreparations.set(key, remaining);
+          return;
+        }
+
+        activeVocabularyPreparations.delete(key);
+        vocabularyGenerations.delete(key);
+      },
+    };
   }
 
   function sweepExpired(now: number): void {
@@ -443,12 +464,16 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
         return Promise.reject(error);
       }
 
+      const vocabularyPreparation = beginVocabularyPreparation(
+        normalized.userId,
+        normalized.vocabularyId,
+      );
       const work = prepare(
         normalized,
         userGeneration(normalized.userId),
-        vocabularyGeneration(normalized.userId, normalized.vocabularyId),
+        vocabularyPreparation.generation,
         clearGeneration,
-      );
+      ).finally(vocabularyPreparation.release);
       return detachOnAbort(work, options.signal);
     },
 
@@ -467,6 +492,9 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
         if (entry.userId === normalizedUserId && entry.vocabularyId === normalizedVocabularyId) {
           pending.delete(key);
         }
+      }
+      if (!activeVocabularyPreparations.has(generationKey)) {
+        vocabularyGenerations.delete(generationKey);
       }
     },
 

--- a/apps/vela-mobile/src/services/mobile-tts.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.ts
@@ -1,0 +1,472 @@
+import {
+  parseGeneratePronunciationRequest,
+  parseGeneratePronunciationResponse,
+  parseTtsApiErrorResponse,
+  parseTtsSettings,
+  type TtsApiErrorCode,
+  type TtsSettings,
+} from '@vela/common';
+import { MobileApiError, type MobileApiClient } from './mobile-api-client';
+
+export const MOBILE_TTS_GENERATE_TIMEOUT_MS = 45_000;
+
+const MOBILE_TTS_CACHE_TTL_MS = 14 * 60_000;
+const MOBILE_TTS_CACHE_MAX_ENTRIES = 300;
+const MOBILE_TTS_CACHE_SWEEP_INTERVAL_MS = 5 * 60_000;
+
+export type MobilePronunciationInput = {
+  userId: string;
+  vocabularyId: string;
+  text: string;
+};
+
+export type PreparationTimings = {
+  settingsMs: number;
+  generateMs: number;
+};
+
+export type PreparedPronunciation = {
+  audioUrl: string;
+  source: 'memory-cache' | 'server-cache' | 'generated';
+  expiresAt: number;
+  timings: PreparationTimings;
+};
+
+export type MobileTtsErrorCode =
+  | 'invalid_input'
+  | 'not_configured'
+  | 'session_unavailable'
+  | 'session_changed'
+  | 'session_recovery_pending'
+  | 'unauthorized'
+  | 'forbidden'
+  | 'network'
+  | 'service_unavailable'
+  | 'generation_timeout'
+  | 'generation_failed'
+  | 'invalid_response';
+
+export class MobileTtsError extends Error {
+  constructor(
+    readonly code: MobileTtsErrorCode,
+    options?: { cause?: unknown },
+  ) {
+    super(code, options);
+    Object.defineProperty(this, 'name', {
+      value: 'MobileTtsError',
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+  }
+}
+
+export type MobileTtsService = {
+  preparePronunciation(
+    input: MobilePronunciationInput,
+    options?: { signal?: AbortSignal },
+  ): Promise<PreparedPronunciation>;
+  invalidatePronunciation(userId: string, vocabularyId: string): void;
+  clearUser(userId: string): void;
+  clearAll(): void;
+};
+
+type NormalizedInput = {
+  userId: string;
+  vocabularyId: string;
+  text: string;
+};
+
+type CacheEntry = {
+  userId: string;
+  vocabularyId: string;
+  audioUrl: string;
+  expiresAt: number;
+};
+
+type PendingResult = {
+  audioUrl: string;
+  source: 'server-cache' | 'generated';
+  expiresAt: number;
+  generateMs: number;
+};
+
+type PendingEntry = {
+  userId: string;
+  vocabularyId: string;
+  promise: Promise<PendingResult>;
+};
+
+const STABLE_ERROR_CODE_MAP: Record<TtsApiErrorCode, MobileTtsErrorCode> = {
+  tts_not_configured: 'not_configured',
+  tts_invalid_provider_configuration: 'generation_failed',
+  tts_audio_service_unavailable: 'service_unavailable',
+  tts_generation_timeout: 'generation_timeout',
+  tts_generation_failed: 'generation_failed',
+  tts_audio_storage_failed: 'generation_failed',
+  tts_audio_access_failed: 'generation_failed',
+};
+
+const LEGACY_NOT_CONFIGURED_MESSAGE = 'TTS API key not configured. Please configure in Settings.';
+const LEGACY_INVALID_PROVIDER_MESSAGE = 'Invalid TTS provider configuration';
+
+function normalizeInput(input: MobilePronunciationInput): NormalizedInput {
+  if (typeof input?.userId !== 'string' || !input.userId.trim()) {
+    throw new MobileTtsError('invalid_input');
+  }
+
+  let request: ReturnType<typeof parseGeneratePronunciationRequest>;
+  try {
+    request = parseGeneratePronunciationRequest(input);
+  } catch {
+    throw new MobileTtsError('invalid_input');
+  }
+
+  return {
+    userId: input.userId.trim(),
+    vocabularyId: request.vocabularyId,
+    text: request.text,
+  };
+}
+
+function recognizedServerCode(error: MobileApiError): TtsApiErrorCode | undefined {
+  try {
+    return parseTtsApiErrorResponse(error.details.serverBody).code;
+  } catch {
+    return undefined;
+  }
+}
+
+function exactServerMessage(serverBody: unknown): string | undefined {
+  if (typeof serverBody !== 'object' || serverBody === null || Array.isArray(serverBody)) {
+    return undefined;
+  }
+  const message = (serverBody as Record<string, unknown>).error;
+  return typeof message === 'string' ? message : undefined;
+}
+
+function mapApiError(error: unknown): MobileTtsError {
+  if (!(error instanceof MobileApiError)) {
+    return new MobileTtsError('generation_failed');
+  }
+
+  const stableCode = recognizedServerCode(error);
+  if (stableCode) {
+    return new MobileTtsError(STABLE_ERROR_CODE_MAP[stableCode]);
+  }
+
+  if (error.details.status === 400) {
+    const legacyMessage = exactServerMessage(error.details.serverBody);
+    if (legacyMessage === LEGACY_NOT_CONFIGURED_MESSAGE) {
+      return new MobileTtsError('not_configured');
+    }
+    if (legacyMessage === LEGACY_INVALID_PROVIDER_MESSAGE) {
+      return new MobileTtsError('generation_failed');
+    }
+  }
+
+  switch (error.code) {
+    case 'session_unavailable':
+    case 'session_changed':
+    case 'session_recovery_pending':
+    case 'unauthorized':
+    case 'forbidden':
+    case 'network':
+      return new MobileTtsError(error.code);
+  }
+
+  switch (error.details.status) {
+    case 400:
+      return new MobileTtsError('invalid_input');
+    case 401:
+      return new MobileTtsError('unauthorized');
+    case 403:
+      return new MobileTtsError('forbidden');
+    case 503:
+      return new MobileTtsError('service_unavailable');
+    case 504:
+      return new MobileTtsError('generation_timeout');
+  }
+
+  if (error.details.status !== undefined && error.details.status >= 500) {
+    return new MobileTtsError('generation_failed');
+  }
+  if (error.details.status !== undefined && error.details.status >= 400) {
+    return new MobileTtsError('invalid_input');
+  }
+  if (error.code === 'invalid_response') {
+    return new MobileTtsError('invalid_response');
+  }
+  if (error.code === 'invalid_request' || error.code === 'client') {
+    return new MobileTtsError('invalid_input');
+  }
+  return new MobileTtsError('generation_failed');
+}
+
+function abortError(): DOMException {
+  return new DOMException('The operation was aborted.', 'AbortError');
+}
+
+function detachOnAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(abortError());
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      cleanup();
+      reject(abortError());
+    };
+    const cleanup = () => signal.removeEventListener('abort', onAbort);
+
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error: unknown) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
+function cacheKey(input: NormalizedInput, settings: TtsSettings): string {
+  // `vocabularyId` and `text` are an immutable canonical pair in the backend.
+  // This service validates non-empty text but deliberately does not include it
+  // in the client cache identity or attempt to enforce that backend invariant.
+  return [
+    input.userId,
+    input.vocabularyId,
+    settings.provider,
+    settings.voiceId ?? '',
+    settings.model ?? '',
+  ]
+    .map(encodeURIComponent)
+    .join('|');
+}
+
+function vocabularyGenerationKey(userId: string, vocabularyId: string): string {
+  return [userId, vocabularyId].map(encodeURIComponent).join('|');
+}
+
+export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsService {
+  const cache = new Map<string, CacheEntry>();
+  const pending = new Map<string, PendingEntry>();
+  const userGenerations = new Map<string, number>();
+  const vocabularyGenerations = new Map<string, number>();
+  let lastExpiredSweepAt = Date.now();
+
+  function userGeneration(userId: string): number {
+    const generation = userGenerations.get(userId) ?? 0;
+    if (!userGenerations.has(userId)) userGenerations.set(userId, generation);
+    return generation;
+  }
+
+  function vocabularyGeneration(userId: string, vocabularyId: string): number {
+    const key = vocabularyGenerationKey(userId, vocabularyId);
+    const generation = vocabularyGenerations.get(key) ?? 0;
+    if (!vocabularyGenerations.has(key)) vocabularyGenerations.set(key, generation);
+    return generation;
+  }
+
+  function sweepExpired(now: number): void {
+    for (const [key, entry] of cache) {
+      if (entry.expiresAt <= now) cache.delete(key);
+    }
+    lastExpiredSweepAt = now;
+  }
+
+  function maybeSweepExpired(now: number): void {
+    if (now - lastExpiredSweepAt >= MOBILE_TTS_CACHE_SWEEP_INTERVAL_MS) {
+      sweepExpired(now);
+    }
+  }
+
+  function getCached(key: string): CacheEntry | undefined {
+    const now = Date.now();
+    maybeSweepExpired(now);
+    const entry = cache.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= now) {
+      cache.delete(key);
+      return undefined;
+    }
+
+    cache.delete(key);
+    cache.set(key, entry);
+    return entry;
+  }
+
+  function setCached(key: string, entry: CacheEntry): void {
+    maybeSweepExpired(Date.now());
+    cache.delete(key);
+    cache.set(key, entry);
+    while (cache.size > MOBILE_TTS_CACHE_MAX_ENTRIES) {
+      const oldestKey = cache.keys().next().value;
+      if (oldestKey === undefined) break;
+      cache.delete(oldestKey);
+    }
+  }
+
+  async function prepare(
+    input: NormalizedInput,
+    capturedUserGeneration: number,
+    capturedVocabularyGeneration: number,
+  ): Promise<PreparedPronunciation> {
+    const requestController = new AbortController();
+    const settingsStartedAt = Date.now();
+    let settingsValue: unknown;
+    try {
+      settingsValue = await apiClient.getJson('tts/settings', {
+        signal: requestController.signal,
+      });
+    } catch (error) {
+      throw mapApiError(error);
+    }
+    const settingsMs = Date.now() - settingsStartedAt;
+
+    let settings: TtsSettings;
+    try {
+      settings = parseTtsSettings(settingsValue);
+    } catch {
+      throw new MobileTtsError('invalid_response');
+    }
+    if (!settings.hasApiKey) throw new MobileTtsError('not_configured');
+
+    const key = cacheKey(input, settings);
+    const cached = getCached(key);
+    if (cached) {
+      return {
+        audioUrl: cached.audioUrl,
+        source: 'memory-cache',
+        expiresAt: cached.expiresAt,
+        timings: { settingsMs, generateMs: 0 },
+      };
+    }
+
+    let pendingEntry = pending.get(key);
+    if (!pendingEntry) {
+      const generateStartedAt = Date.now();
+      const generationPromise = (async (): Promise<PendingResult> => {
+        let responseValue: unknown;
+        try {
+          responseValue = await apiClient.postJson(
+            'tts/generate',
+            { vocabularyId: input.vocabularyId, text: input.text },
+            { signal: requestController.signal, timeoutMs: MOBILE_TTS_GENERATE_TIMEOUT_MS },
+          );
+        } catch (error) {
+          throw mapApiError(error);
+        }
+
+        let response: ReturnType<typeof parseGeneratePronunciationResponse>;
+        try {
+          response = parseGeneratePronunciationResponse(responseValue);
+        } catch {
+          throw new MobileTtsError('invalid_response');
+        }
+
+        const completedAt = Date.now();
+        const expiresAt = completedAt + MOBILE_TTS_CACHE_TTL_MS;
+        if (
+          userGeneration(input.userId) === capturedUserGeneration &&
+          vocabularyGeneration(input.userId, input.vocabularyId) === capturedVocabularyGeneration
+        ) {
+          setCached(key, {
+            userId: input.userId,
+            vocabularyId: input.vocabularyId,
+            audioUrl: response.audioUrl,
+            expiresAt,
+          });
+        }
+
+        return {
+          audioUrl: response.audioUrl,
+          source: response.cached ? 'server-cache' : 'generated',
+          expiresAt,
+          generateMs: completedAt - generateStartedAt,
+        };
+      })();
+      pendingEntry = {
+        userId: input.userId,
+        vocabularyId: input.vocabularyId,
+        promise: generationPromise,
+      };
+      pending.set(key, pendingEntry);
+
+      const removeOwnedPending = () => {
+        if (pending.get(key) === pendingEntry) pending.delete(key);
+      };
+      void generationPromise.then(removeOwnedPending, removeOwnedPending);
+    }
+
+    const result = await pendingEntry.promise;
+    return {
+      audioUrl: result.audioUrl,
+      source: result.source,
+      expiresAt: result.expiresAt,
+      timings: { settingsMs, generateMs: result.generateMs },
+    };
+  }
+
+  return {
+    preparePronunciation(input, options = {}) {
+      if (options.signal?.aborted) return Promise.reject(abortError());
+
+      let normalized: NormalizedInput;
+      try {
+        normalized = normalizeInput(input);
+      } catch (error) {
+        return Promise.reject(error);
+      }
+
+      const work = prepare(
+        normalized,
+        userGeneration(normalized.userId),
+        vocabularyGeneration(normalized.userId, normalized.vocabularyId),
+      );
+      return detachOnAbort(work, options.signal);
+    },
+
+    invalidatePronunciation(userId, vocabularyId) {
+      const normalizedUserId = userId.trim();
+      const normalizedVocabularyId = vocabularyId.trim();
+      const generationKey = vocabularyGenerationKey(normalizedUserId, normalizedVocabularyId);
+      vocabularyGenerations.set(generationKey, (vocabularyGenerations.get(generationKey) ?? 0) + 1);
+
+      for (const [key, entry] of cache) {
+        if (entry.userId === normalizedUserId && entry.vocabularyId === normalizedVocabularyId) {
+          cache.delete(key);
+        }
+      }
+      for (const [key, entry] of pending) {
+        if (entry.userId === normalizedUserId && entry.vocabularyId === normalizedVocabularyId) {
+          pending.delete(key);
+        }
+      }
+    },
+
+    clearUser(userId) {
+      const normalizedUserId = userId.trim();
+      userGenerations.set(normalizedUserId, userGeneration(normalizedUserId) + 1);
+
+      for (const [key, entry] of cache) {
+        if (entry.userId === normalizedUserId) cache.delete(key);
+      }
+      for (const [key, entry] of pending) {
+        if (entry.userId === normalizedUserId) pending.delete(key);
+      }
+    },
+
+    clearAll() {
+      for (const userId of userGenerations.keys()) {
+        userGenerations.set(userId, userGeneration(userId) + 1);
+      }
+      cache.clear();
+      pending.clear();
+      lastExpiredSweepAt = Date.now();
+    },
+  };
+}

--- a/apps/vela-mobile/src/services/mobile-tts.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.ts
@@ -473,6 +473,10 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
     clearUser(userId) {
       const normalizedUserId = userId.trim();
       userGenerations.set(normalizedUserId, userGeneration(normalizedUserId) + 1);
+      const vocabularyGenerationPrefix = `${encodeURIComponent(normalizedUserId)}|`;
+      for (const key of vocabularyGenerations.keys()) {
+        if (key.startsWith(vocabularyGenerationPrefix)) vocabularyGenerations.delete(key);
+      }
 
       for (const [key, entry] of cache) {
         if (entry.userId === normalizedUserId) cache.delete(key);
@@ -484,6 +488,8 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
 
     clearAll() {
       clearGeneration += 1;
+      userGenerations.clear();
+      vocabularyGenerations.clear();
       cache.clear();
       pending.clear();
       lastExpiredSweepAt = Date.now();

--- a/apps/vela-mobile/src/services/mobile-tts.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.ts
@@ -259,14 +259,34 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
   const pending = new Map<string, PendingEntry>();
   const userGenerations = new Map<string, number>();
   const vocabularyGenerations = new Map<string, number>();
+  const activeUserPreparations = new Map<string, number>();
   const activeVocabularyPreparations = new Map<string, number>();
   let clearGeneration = 0;
   let lastExpiredSweepAt = Date.now();
 
   function userGeneration(userId: string): number {
-    const generation = userGenerations.get(userId) ?? 0;
-    if (!userGenerations.has(userId)) userGenerations.set(userId, generation);
-    return generation;
+    return userGenerations.get(userId) ?? 0;
+  }
+
+  function beginUserPreparation(userId: string) {
+    activeUserPreparations.set(userId, (activeUserPreparations.get(userId) ?? 0) + 1);
+    let released = false;
+
+    return {
+      generation: userGenerations.get(userId) ?? 0,
+      release() {
+        if (released) return;
+        released = true;
+        const remaining = (activeUserPreparations.get(userId) ?? 1) - 1;
+        if (remaining > 0) {
+          activeUserPreparations.set(userId, remaining);
+          return;
+        }
+
+        activeUserPreparations.delete(userId);
+        userGenerations.delete(userId);
+      },
+    };
   }
 
   function vocabularyGeneration(userId: string, vocabularyId: string): number {
@@ -464,16 +484,20 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
         return Promise.reject(error);
       }
 
+      const userPreparation = beginUserPreparation(normalized.userId);
       const vocabularyPreparation = beginVocabularyPreparation(
         normalized.userId,
         normalized.vocabularyId,
       );
       const work = prepare(
         normalized,
-        userGeneration(normalized.userId),
+        userPreparation.generation,
         vocabularyPreparation.generation,
         clearGeneration,
-      ).finally(vocabularyPreparation.release);
+      ).finally(() => {
+        vocabularyPreparation.release();
+        userPreparation.release();
+      });
       return detachOnAbort(work, options.signal);
     },
 
@@ -511,6 +535,9 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
       }
       for (const [key, entry] of pending) {
         if (entry.userId === normalizedUserId) pending.delete(key);
+      }
+      if (!activeUserPreparations.has(normalizedUserId)) {
+        userGenerations.delete(normalizedUserId);
       }
     },
 

--- a/apps/vela-mobile/src/services/mobile-tts.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.ts
@@ -361,13 +361,10 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
     capturedVocabularyGeneration: number,
     capturedClearGeneration: number,
   ): Promise<PreparedPronunciation> {
-    const requestController = new AbortController();
     const settingsStartedAt = Date.now();
     let settingsValue: unknown;
     try {
-      settingsValue = await apiClient.getJson('tts/settings', {
-        signal: requestController.signal,
-      });
+      settingsValue = await apiClient.getJson('tts/settings');
     } catch (error) {
       throw mapApiError(error);
     }
@@ -411,7 +408,7 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
           responseValue = await apiClient.postJson(
             'tts/generate',
             { vocabularyId: input.vocabularyId, text: input.text },
-            { signal: requestController.signal, timeoutMs: MOBILE_TTS_GENERATE_TIMEOUT_MS },
+            { timeoutMs: MOBILE_TTS_GENERATE_TIMEOUT_MS },
           );
         } catch (error) {
           throw mapApiError(error);

--- a/apps/vela-mobile/src/services/mobile-tts.ts
+++ b/apps/vela-mobile/src/services/mobile-tts.ts
@@ -69,6 +69,12 @@ export type MobileTtsService = {
   invalidatePronunciation(userId: string, vocabularyId: string): void;
   clearUser(userId: string): void;
   clearAll(): void;
+  // Test-only inspection accessor: not part of the public contract.
+  _testGetGenerationMetadata?: () => {
+    vocabularyGenerationCount: number;
+    userGenerationCount: number;
+    userGenerationFor(userId: string): number;
+  };
 };
 
 type NormalizedInput = {
@@ -108,6 +114,8 @@ const STABLE_ERROR_CODE_MAP: Record<TtsApiErrorCode, MobileTtsErrorCode> = {
   tts_generation_failed: 'generation_failed',
   tts_audio_storage_failed: 'generation_failed',
   tts_audio_access_failed: 'generation_failed',
+  tts_audio_bucket_not_configured: 'service_unavailable',
+  tts_unexpected_error: 'generation_failed',
 };
 
 const LEGACY_NOT_CONFIGURED_MESSAGE = 'TTS API key not configured. Please configure in Settings.';
@@ -545,6 +553,19 @@ export function createMobileTtsService(apiClient: MobileApiClient): MobileTtsSer
       cache.clear();
       pending.clear();
       lastExpiredSweepAt = Date.now();
+    },
+
+    // Test-only inspection accessor: reports generation metadata counts so tests
+    // can assert cleanup behavior without spying on Map internals or depending
+    // on private key encoding. Not part of the public MobileTtsService contract.
+    _testGetGenerationMetadata() {
+      return {
+        vocabularyGenerationCount: vocabularyGenerations.size,
+        userGenerationCount: userGenerations.size,
+        userGenerationFor(userId: string): number {
+          return userGeneration(userId);
+        },
+      };
     },
   };
 }

--- a/apps/vela/src/services/ttsService.test.ts
+++ b/apps/vela/src/services/ttsService.test.ts
@@ -88,14 +88,18 @@ describe('ttsService', () => {
     vi.restoreAllMocks();
   });
 
+  function mockSuccessfulTtsResponse(responseBody: unknown): void {
+    mockFetch.mockImplementation((url: string) =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(url === '/api/tts/settings' ? mockTTSSettings : responseBody),
+      }),
+    );
+  }
+
   describe('getAuthHeader', () => {
     it('should return auth header with JWT token', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: vi
-          .fn()
-          .mockResolvedValue({ audioUrl: 'https://example.com/audio.mp3', cached: false }),
-      });
+      mockSuccessfulTtsResponse({ audioUrl: 'https://example.com/audio.mp3', cached: false });
 
       await generatePronunciation('vocab-1', '猫', 'user-123');
 
@@ -142,16 +146,14 @@ describe('ttsService', () => {
   });
 
   describe('generatePronunciation', () => {
+    const HTTPS_AUDIO = 'https://audio.example.test/mizu.mp3';
     const mockTTSResponse: TTSResponse = {
       audioUrl: 'https://example.com/audio/neko.mp3',
       cached: false,
     };
 
     it('should generate pronunciation successfully', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: vi.fn().mockResolvedValue(mockTTSResponse),
-      });
+      mockSuccessfulTtsResponse(mockTTSResponse);
 
       const result = await generatePronunciation('vocab-1', '猫', 'user-123');
 
@@ -168,6 +170,36 @@ describe('ttsService', () => {
         }),
       });
       expect(result).toEqual(mockTTSResponse);
+    });
+
+    it('keeps a valid generated response unchanged', async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (url === '/api/tts/settings') {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTTSSettings) });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ audioUrl: HTTPS_AUDIO, cached: false }),
+        });
+      });
+
+      await expect(generatePronunciation('水:ミズ', '水', 'user-1')).resolves.toEqual({
+        audioUrl: HTTPS_AUDIO,
+        cached: false,
+      });
+    });
+
+    it('rejects a malformed successful generate response', async () => {
+      mockFetch.mockImplementation((url: string) => {
+        if (url === '/api/tts/settings') {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTTSSettings) });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ cached: false }) });
+      });
+
+      await expect(generatePronunciation('水:ミズ', '水', 'user-1')).rejects.toThrow(
+        'invalid_tts_generate_response:audioUrl',
+      );
     });
 
     it('should return cached audio URL when available', async () => {
@@ -254,10 +286,7 @@ describe('ttsService', () => {
     });
 
     it('should accept deprecated userId parameter without using it', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: vi.fn().mockResolvedValue(mockTTSResponse),
-      });
+      mockSuccessfulTtsResponse(mockTTSResponse);
 
       const result = await generatePronunciation('vocab-1', '猫', 'user-123');
 
@@ -329,10 +358,7 @@ describe('ttsService', () => {
     });
 
     it('should use POST method', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: vi.fn().mockResolvedValue(mockTTSResponse),
-      });
+      mockSuccessfulTtsResponse(mockTTSResponse);
 
       await generatePronunciation('vocab-1', '猫', 'user-123');
 
@@ -345,10 +371,7 @@ describe('ttsService', () => {
     });
 
     it('should handle Japanese characters correctly', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: vi.fn().mockResolvedValue(mockTTSResponse),
-      });
+      mockSuccessfulTtsResponse(mockTTSResponse);
 
       await generatePronunciation('vocab-3', 'こんにちは', 'user-123');
 
@@ -384,10 +407,7 @@ describe('ttsService', () => {
 
   describe('getAudioUrl', () => {
     it('should fetch audio URL successfully', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: vi.fn().mockResolvedValue({ audioUrl: 'https://example.com/audio/word.mp3' }),
-      });
+      mockSuccessfulTtsResponse({ audioUrl: 'https://example.com/audio/word.mp3' });
 
       const result = await getAudioUrl('vocab-1', 'user-123');
 
@@ -463,10 +483,7 @@ describe('ttsService', () => {
     });
 
     it('should URL encode vocabulary IDs with special characters', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: vi.fn().mockResolvedValue({ audioUrl: 'https://example.com/audio.mp3' }),
-      });
+      mockSuccessfulTtsResponse({ audioUrl: 'https://example.com/audio.mp3' });
 
       await getAudioUrl('vocab/1', 'user-123');
 
@@ -474,10 +491,7 @@ describe('ttsService', () => {
     });
 
     it('should use GET method (default)', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: vi.fn().mockResolvedValue({ audioUrl: 'https://example.com/audio.mp3' }),
-      });
+      mockSuccessfulTtsResponse({ audioUrl: 'https://example.com/audio.mp3' });
 
       await getAudioUrl('vocab-1', 'user-123');
 
@@ -1031,10 +1045,7 @@ describe('ttsService', () => {
         cached: false,
       };
 
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: vi.fn().mockResolvedValue(mockTTSResponse),
-      });
+      mockSuccessfulTtsResponse(mockTTSResponse);
 
       const CustomMockAudio = class extends MockAudio {
         override play() {
@@ -1055,12 +1066,9 @@ describe('ttsService', () => {
         created_at: '2024-01-01T00:00:00Z',
       };
 
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: vi.fn().mockResolvedValue({
-          audioUrl: 'https://example.com/audio/hello.mp3',
-          cached: false,
-        }),
+      mockSuccessfulTtsResponse({
+        audioUrl: 'https://example.com/audio/hello.mp3',
+        cached: false,
       });
 
       const CustomMockAudio = class extends MockAudio {

--- a/apps/vela/src/services/ttsService.test.ts
+++ b/apps/vela/src/services/ttsService.test.ts
@@ -603,7 +603,15 @@ describe('ttsService', () => {
         }
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve({ audioUrl: 'https://example.com/audio/cached-get.mp3' }),
+          json: () =>
+            Promise.resolve({
+              audioUrl: 'https://example.com/audio/cached-get.mp3',
+              effectiveSettings: {
+                provider: mockTTSSettings.provider,
+                voiceId: mockTTSSettings.voiceId,
+                model: mockTTSSettings.model,
+              },
+            }),
         });
       });
 
@@ -616,6 +624,101 @@ describe('ttsService', () => {
         (c) => typeof c[0] === 'string' && (c[0] as string).includes('tts/audio/'),
       );
       expect(audioCalls).toHaveLength(1);
+    });
+
+    it('does not cache under the stale settings key when backend effective settings changed between GET and audio lookup', async () => {
+      // Reproduces the race: the client reads settings A (elevenlabs/voice-123),
+      // derives the cache key from A, then the backend re-reads settings during
+      // GET /tts/audio and resolves the S3 key under B (elevenlabs/voice-999).
+      // The URL is still returned for immediate playback, but it must not be
+      // cached under the A-derived key, otherwise a later A-identity request
+      // would hit the cache and serve voice-999 audio as if it were voice-123.
+      // A second call with the same A settings must therefore miss the memory
+      // cache and re-fetch the audio endpoint.
+      const mismatchedResponse = {
+        audioUrl: 'https://example.com/audio/race.mp3',
+        effectiveSettings: {
+          provider: 'elevenlabs',
+          voiceId: 'voice-999',
+          model: 'model-456',
+        },
+      };
+      const matchingResponse = {
+        audioUrl: 'https://example.com/audio/race.mp3',
+        effectiveSettings: {
+          provider: 'elevenlabs',
+          voiceId: 'voice-123',
+          model: 'model-456',
+        },
+      };
+
+      let audioCallCount = 0;
+      mockFetch.mockImplementation((url: string) => {
+        if (url === '/api/tts/settings') {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockTTSSettings),
+          });
+        }
+        if (typeof url === 'string' && url.includes('tts/audio/')) {
+          audioCallCount += 1;
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve(audioCallCount === 1 ? mismatchedResponse : matchingResponse),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({}),
+        });
+      });
+
+      const firstResult = await getAudioUrl('vocab-race', 'user-123');
+      expect(firstResult).toBe('https://example.com/audio/race.mp3');
+
+      const secondResult = await getAudioUrl('vocab-race', 'user-123');
+      expect(secondResult).toBe('https://example.com/audio/race.mp3');
+
+      // The second call must re-fetch (not served from memory cache) because
+      // the first response's effective settings did not match the GET snapshot.
+      const audioCalls = mockFetch.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && (c[0] as string).includes('tts/audio/'),
+      );
+      expect(audioCalls).toHaveLength(2);
+    });
+
+    it('does not cache when the audio endpoint omits effective settings (older deployment)', async () => {
+      // An older backend that omits effectiveSettings cannot confirm the
+      // settings identity, so the client must not cache under the GET-derived
+      // key. The URL is still returned, but the second request re-fetches.
+      const responseWithoutEffective = {
+        audioUrl: 'https://example.com/audio/legacy.mp3',
+      };
+
+      mockFetch.mockImplementation((url: string) => {
+        if (url === '/api/tts/settings') {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockTTSSettings),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(responseWithoutEffective),
+        });
+      });
+
+      const firstResult = await getAudioUrl('vocab-legacy', 'user-123');
+      expect(firstResult).toBe('https://example.com/audio/legacy.mp3');
+
+      const secondResult = await getAudioUrl('vocab-legacy', 'user-123');
+      expect(secondResult).toBe('https://example.com/audio/legacy.mp3');
+
+      const audioCalls = mockFetch.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && (c[0] as string).includes('tts/audio/'),
+      );
+      expect(audioCalls).toHaveLength(2);
     });
   });
 
@@ -779,7 +882,15 @@ describe('ttsService', () => {
         }
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve({ audioUrl: 'https://example.com/audio/item.mp3' }),
+          json: () =>
+            Promise.resolve({
+              audioUrl: 'https://example.com/audio/item.mp3',
+              effectiveSettings: {
+                provider: mockTTSSettings.provider,
+                voiceId: mockTTSSettings.voiceId,
+                model: mockTTSSettings.model,
+              },
+            }),
         });
       });
     });

--- a/apps/vela/src/services/ttsService.test.ts
+++ b/apps/vela/src/services/ttsService.test.ts
@@ -193,6 +193,11 @@ describe('ttsService', () => {
       const cachedResponse: TTSResponse = {
         audioUrl: 'https://example.com/audio/cached.mp3',
         cached: true,
+        effectiveSettings: {
+          provider: mockTTSSettings.provider,
+          voiceId: mockTTSSettings.voiceId,
+          model: mockTTSSettings.model,
+        },
       };
 
       mockFetch.mockImplementation((url: string) => {
@@ -217,6 +222,99 @@ describe('ttsService', () => {
       expect(secondResult.audioUrl).toBe('https://example.com/audio/cached.mp3');
       // Called for settings + generate on first call, settings only on second (cached)
       expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not cache under the stale settings key when backend effective settings changed between GET and POST', async () => {
+      // Reproduces the race: the client reads settings A (elevenlabs/voice-123),
+      // derives the cache key from A, then the backend re-reads settings during
+      // POST and generates with B (elevenlabs/voice-999). The response is still
+      // usable, but it must not be cached under the A-derived key, otherwise a
+      // later A-identity request would hit the cache and play voice-999 audio
+      // as if it were voice-123. A second call with the same A settings must
+      // therefore miss the memory cache and re-generate.
+      const mismatchedResponse = {
+        audioUrl: 'https://example.com/audio/race.mp3',
+        cached: false,
+        effectiveSettings: {
+          provider: 'elevenlabs',
+          voiceId: 'voice-999',
+          model: 'model-456',
+        },
+      };
+      const matchingResponse = {
+        audioUrl: 'https://example.com/audio/race.mp3',
+        cached: false,
+        effectiveSettings: {
+          provider: 'elevenlabs',
+          voiceId: 'voice-123',
+          model: 'model-456',
+        },
+      };
+
+      let generateCallCount = 0;
+      mockFetch.mockImplementation((url: string) => {
+        if (url === '/api/tts/settings') {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockTTSSettings),
+          });
+        }
+        if (url === '/api/tts/generate') {
+          generateCallCount += 1;
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve(generateCallCount === 1 ? mismatchedResponse : matchingResponse),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({}),
+        });
+      });
+
+      const firstResult = await generatePronunciation('vocab-race', '語', 'user-123');
+      expect(firstResult.audioUrl).toBe('https://example.com/audio/race.mp3');
+
+      const secondResult = await generatePronunciation('vocab-race', '語', 'user-123');
+      expect(secondResult.audioUrl).toBe('https://example.com/audio/race.mp3');
+
+      // The second call must re-generate (not served from memory cache) because
+      // the first response's effective settings did not match the GET snapshot.
+      const generateCalls = mockFetch.mock.calls.filter((call) => call[0] === '/api/tts/generate');
+      expect(generateCalls).toHaveLength(2);
+    });
+
+    it('does not cache when the backend omits effective settings (older deployment)', async () => {
+      // An older backend that omits effectiveSettings cannot confirm the
+      // settings identity, so the client must not cache under the GET-derived
+      // key. Playback still succeeds, but the second request re-generates.
+      const responseWithoutEffective = {
+        audioUrl: 'https://example.com/audio/legacy.mp3',
+        cached: false,
+      };
+
+      mockFetch.mockImplementation((url: string) => {
+        if (url === '/api/tts/settings') {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockTTSSettings),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(responseWithoutEffective),
+        });
+      });
+
+      const firstResult = await generatePronunciation('vocab-legacy', '語', 'user-123');
+      expect(firstResult.audioUrl).toBe('https://example.com/audio/legacy.mp3');
+
+      const secondResult = await generatePronunciation('vocab-legacy', '語', 'user-123');
+      expect(secondResult.audioUrl).toBe('https://example.com/audio/legacy.mp3');
+
+      const generateCalls = mockFetch.mock.calls.filter((call) => call[0] === '/api/tts/generate');
+      expect(generateCalls).toHaveLength(2);
     });
 
     it('should reuse the same in-flight generate request for concurrent callers', async () => {

--- a/apps/vela/src/services/ttsService.test.ts
+++ b/apps/vela/src/services/ttsService.test.ts
@@ -421,6 +421,14 @@ describe('ttsService', () => {
       expect(result).toBe('https://example.com/audio/word.mp3');
     });
 
+    it('rejects a non-HTTPS audio URL from the GET audio endpoint', async () => {
+      mockSuccessfulTtsResponse({ audioUrl: 'http://insecure.example.test/audio.mp3' });
+
+      await expect(getAudioUrl('vocab-1', 'user-123')).rejects.toThrow(
+        'invalid_tts_audio_response:audioUrl',
+      );
+    });
+
     it('should return null when audio does not exist (404)', async () => {
       mockFetch.mockImplementation((url: string) => {
         if (url === '/api/tts/settings') {

--- a/apps/vela/src/services/ttsService.test.ts
+++ b/apps/vela/src/services/ttsService.test.ts
@@ -173,15 +173,7 @@ describe('ttsService', () => {
     });
 
     it('keeps a valid generated response unchanged', async () => {
-      mockFetch.mockImplementation((url: string) => {
-        if (url === '/api/tts/settings') {
-          return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTTSSettings) });
-        }
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({ audioUrl: HTTPS_AUDIO, cached: false }),
-        });
-      });
+      mockSuccessfulTtsResponse({ audioUrl: HTTPS_AUDIO, cached: false });
 
       await expect(generatePronunciation('水:ミズ', '水', 'user-1')).resolves.toEqual({
         audioUrl: HTTPS_AUDIO,
@@ -190,12 +182,7 @@ describe('ttsService', () => {
     });
 
     it('rejects a malformed successful generate response', async () => {
-      mockFetch.mockImplementation((url: string) => {
-        if (url === '/api/tts/settings') {
-          return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTTSSettings) });
-        }
-        return Promise.resolve({ ok: true, json: () => Promise.resolve({ cached: false }) });
-      });
+      mockSuccessfulTtsResponse({ cached: false });
 
       await expect(generatePronunciation('水:ミズ', '水', 'user-1')).rejects.toThrow(
         'invalid_tts_generate_response:audioUrl',

--- a/apps/vela/src/services/ttsService.ts
+++ b/apps/vela/src/services/ttsService.ts
@@ -3,6 +3,7 @@ import { getApiUrl } from '../utils/api';
 import { fetchAuthSession } from 'aws-amplify/auth';
 import {
   parseGeneratePronunciationResponse,
+  parseTtsAudioUrlResponse,
   parseTtsSettings,
   type GeneratePronunciationResponse,
   type TtsSettings,
@@ -245,8 +246,9 @@ export async function getAudioUrl(vocabularyId: string, userId: string): Promise
   }
 
   const data = await response.json();
-  setCachedAudioUrl(cacheKey, data.audioUrl);
-  return data.audioUrl;
+  const audioUrl = parseTtsAudioUrlResponse(data).audioUrl;
+  setCachedAudioUrl(cacheKey, audioUrl);
+  return audioUrl;
 }
 
 /**

--- a/apps/vela/src/services/ttsService.ts
+++ b/apps/vela/src/services/ttsService.ts
@@ -1,18 +1,15 @@
 import type { Vocabulary } from '../types/database';
 import { getApiUrl } from '../utils/api';
 import { fetchAuthSession } from 'aws-amplify/auth';
+import {
+  parseGeneratePronunciationResponse,
+  parseTtsSettings,
+  type GeneratePronunciationResponse,
+  type TtsSettings,
+} from '@vela/common';
 
-export interface TTSResponse {
-  audioUrl: string;
-  cached: boolean;
-}
-
-export interface TTSSettings {
-  provider: string;
-  voiceId: string | null;
-  model: string | null;
-  hasApiKey: boolean;
-}
+export type TTSResponse = GeneratePronunciationResponse;
+export type TTSSettings = TtsSettings;
 
 // In-session audio URL cache keyed by user + settings + vocabularyId.
 // Presigned S3 URLs expire in 15 minutes; cache for 14 minutes to avoid serving expired URLs.
@@ -192,7 +189,7 @@ export async function generatePronunciation(
       throw new Error(errorMessage);
     }
 
-    const result: TTSResponse = await response.json();
+    const result = parseGeneratePronunciationResponse(await response.json());
     setCachedAudioUrl(cacheKey, result.audioUrl);
     return result;
   })();
@@ -317,7 +314,7 @@ export async function getTTSSettings(_userId?: string): Promise<TTSSettings> {
     throw new Error(errorMessage);
   }
 
-  return response.json();
+  return parseTtsSettings(await response.json());
 }
 
 /**

--- a/apps/vela/src/services/ttsService.ts
+++ b/apps/vela/src/services/ttsService.ts
@@ -275,9 +275,15 @@ export async function getAudioUrl(vocabularyId: string, userId: string): Promise
   }
 
   const data = await response.json();
-  const audioUrl = parseTtsAudioUrlResponse(data).audioUrl;
-  setCachedAudioUrl(cacheKey, audioUrl);
-  return audioUrl;
+  const parsed = parseTtsAudioUrlResponse(data);
+  // Skip caching when the backend's effective settings differ from the GET
+  // snapshot used to derive `cacheKey`: the audio lives under a settings
+  // partition the client did not request, so it must not be served from a
+  // stale-settings cache entry. The URL is still returned for immediate use.
+  if (effectiveSettingsMatch(settings, parsed.effectiveSettings)) {
+    setCachedAudioUrl(cacheKey, parsed.audioUrl);
+  }
+  return parsed.audioUrl;
 }
 
 /**

--- a/apps/vela/src/services/ttsService.ts
+++ b/apps/vela/src/services/ttsService.ts
@@ -6,6 +6,7 @@ import {
   parseTtsAudioUrlResponse,
   parseTtsSettings,
   type GeneratePronunciationResponse,
+  type TtsEffectiveSettings,
   type TtsSettings,
 } from '@vela/common';
 
@@ -83,6 +84,29 @@ function setCachedAudioUrl(cacheKey: string, url: string): void {
   audioUrlCache.delete(cacheKey);
   audioUrlCache.set(cacheKey, { url, expiresAt: now + CACHE_TTL_MS });
   enforceCacheSizeLimit();
+}
+
+/**
+ * Compare the GET /tts/settings snapshot (used to derive the client cache key)
+ * against the effective settings the backend reports it actually used for the
+ * generation. When they differ, the audio was produced under new settings but
+ * the client key was derived from the old snapshot, so the entry must not be
+ * cached under that stale key.
+ *
+ * When the backend omits `effectiveSettings` (older deployment), this returns
+ * false to avoid caching under a settings identity the backend did not
+ * confirm. Playback still succeeds; only the memory cache is skipped.
+ */
+function effectiveSettingsMatch(
+  snapshot: TtsSettings,
+  effective: TtsEffectiveSettings | undefined,
+): boolean {
+  if (!effective) return false;
+  return (
+    effective.provider === snapshot.provider &&
+    effective.voiceId === snapshot.voiceId &&
+    effective.model === snapshot.model
+  );
 }
 
 /**
@@ -191,7 +215,12 @@ export async function generatePronunciation(
     }
 
     const result = parseGeneratePronunciationResponse(await response.json());
-    setCachedAudioUrl(cacheKey, result.audioUrl);
+    // Skip caching when the backend's effective settings differ from the GET
+    // snapshot used to derive `cacheKey`: the audio was produced under new
+    // settings and must not be served from a stale-settings cache entry.
+    if (effectiveSettingsMatch(settings, result.effectiveSettings)) {
+      setCachedAudioUrl(cacheKey, result.audioUrl);
+    }
     return result;
   })();
 

--- a/apps/vela/src/services/ttsService.ts
+++ b/apps/vela/src/services/ttsService.ts
@@ -2,11 +2,11 @@ import type { Vocabulary } from '../types/database';
 import { getApiUrl } from '../utils/api';
 import { fetchAuthSession } from 'aws-amplify/auth';
 import {
+  effectiveSettingsMatch,
   parseGeneratePronunciationResponse,
   parseTtsAudioUrlResponse,
   parseTtsSettings,
   type GeneratePronunciationResponse,
-  type TtsEffectiveSettings,
   type TtsSettings,
 } from '@vela/common';
 
@@ -84,29 +84,6 @@ function setCachedAudioUrl(cacheKey: string, url: string): void {
   audioUrlCache.delete(cacheKey);
   audioUrlCache.set(cacheKey, { url, expiresAt: now + CACHE_TTL_MS });
   enforceCacheSizeLimit();
-}
-
-/**
- * Compare the GET /tts/settings snapshot (used to derive the client cache key)
- * against the effective settings the backend reports it actually used for the
- * generation. When they differ, the audio was produced under new settings but
- * the client key was derived from the old snapshot, so the entry must not be
- * cached under that stale key.
- *
- * When the backend omits `effectiveSettings` (older deployment), this returns
- * false to avoid caching under a settings identity the backend did not
- * confirm. Playback still succeeds; only the memory cache is skipped.
- */
-function effectiveSettingsMatch(
-  snapshot: TtsSettings,
-  effective: TtsEffectiveSettings | undefined,
-): boolean {
-  if (!effective) return false;
-  return (
-    effective.provider === snapshot.provider &&
-    effective.voiceId === snapshot.voiceId &&
-    effective.model === snapshot.model
-  );
 }
 
 /**

--- a/docs/superpowers/plans/2026-07-31-mobile-authenticated-tts-pronunciation.md
+++ b/docs/superpowers/plans/2026-07-31-mobile-authenticated-tts-pronunciation.md
@@ -1,0 +1,1396 @@
+# Authenticated iOS TTS Pronunciation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver a production-shaped authenticated pronunciation diagnostic in the Capacitor iOS app, validate HTML audio on Simulator and a physical iPhone, and record whether the MVP can retain HTML playback, needs native audio-session configuration, or needs a native player adapter.
+
+**Architecture:** Add platform-neutral validated TTS contracts in `@vela/common`, preserve server-side secret ownership, and extend the existing coordinator-owned mobile request path with replayable JSON POST bodies and bounded per-request deadlines. Build a mobile TTS service with settings-partitioned URL caching, a replaceable `MobileAudioPlayer`, a controller state machine, and an authenticated development-only diagnostic route. Keep the existing web TTS flow compatible while sharing response validation.
+
+**Tech Stack:** TypeScript 5.6, Bun, Vitest, Vue 3, Quasar 2, TanStack Vue Query 5, Capacitor 7, Hono, Zod, AWS Lambda, DynamoDB, S3 presigned URLs, WebKit `HTMLAudioElement`, iOS/Xcode.
+
+## Global Constraints
+
+- Keep `GET tts/settings`, due-count, and ordinary mobile JSON requests on the existing 8-second overall deadline.
+- Use a 45-second overall deadline for `POST tts/generate`.
+- Keep the coordinator's 15-second default physical-fetch cap; permit validated per-request overrides no greater than 50 seconds.
+- All JSON POST bodies must be serialized once to replayable immutable strings before coordinator dispatch.
+- The coordinator remains the only owner of Cognito ID tokens and `Authorization` headers.
+- No provider key, Cognito token, complete presigned URL, or raw server error detail may be rendered, logged, or placed in verification records.
+- Cap both JSON and text error bodies at 16 KiB before parsing or retention.
+- Treat network, provider, validator, 4xx, 5xx, and deadline failures as manual-only retries.
+- Permit exactly one same-user continuation for auth-control races or completed session recovery.
+- Keep URL/media refresh separate from transport retry and allow at most one automatic URL refresh per tap.
+- Mirror the backend cache identity: user ID, vocabulary ID, provider, voice, and model; text is an unenforced fixed-pair client precondition.
+- Use fixed diagnostic input `{ vocabularyId: '水:ミズ', text: '水' }`; do not add free-form text.
+- The diagnostic route is `/diagnostics/tts-pronunciation`, development-only, inside the authenticated shell, with no `bypassMobileAuth` metadata.
+- Preserve existing explicit auth-bypass tests for the iOS interaction diagnostic routes.
+- Use the existing `boot/capacitor-lifecycle.ts` native listener to feed shared lifecycle state; add no third listener.
+- Background playback, microphone input, STT, AI buddy audio, offline storage, Now Playing controls, and Android are out of scope.
+- Do not install a native audio plugin before physical-device evidence selects the required follow-up layer.
+
+---
+
+## File Structure
+
+### Shared contracts
+
+- Create `packages/common/src/contracts/tts.ts` — TTS providers, success/error contracts, request validation, and runtime parsers.
+- Create `packages/common/src/contracts/tts.test.ts` — parser and request-validation coverage.
+- Modify `packages/common/src/index.ts` — export TTS contracts and parsers.
+
+### Existing web client
+
+- Modify `apps/vela/src/services/ttsService.ts` — import shared types/parsers and validate successful settings/generate responses.
+- Modify `apps/vela/src/services/ttsService.test.ts` — valid-response regression and malformed-success tests.
+
+### Backend
+
+- Modify `apps/vela-api/src/routes/tts.ts` — additive stable TTS error codes; preserve messages and statuses.
+- Modify `apps/vela-api/test/routes/tts.test.ts` — code/message/status compatibility and validator-shaped 400 coverage.
+
+### Mobile authenticated transport
+
+- Modify `apps/vela-mobile/src/auth/mobile-auth-contract.ts` — `transportTimeoutMs` and `invalid_request_timeout`.
+- Modify `apps/vela-mobile/src/services/mobile-auth.ts` — bounded per-dispatch timeout override and identical-body 401 replay.
+- Modify `apps/vela-mobile/src/services/mobile-auth.test.ts` — default/override validation and POST replay.
+- Modify `apps/vela-mobile/src/services/mobile-api-client.ts` — `postJson`, per-request overall deadlines, bounded body reader, structured non-enumerable errors.
+- Modify `apps/vela-mobile/src/services/mobile-api-client.test.ts` — JSON POST, timeout, body bounds, redaction, classification, cause/name regression.
+- Modify `apps/vela-mobile/src/composables/useDueReviewCount.test.ts` — pin 400/no retry, 500/retry, and network/retry after `client` classification is added.
+
+### Mobile TTS domain service
+
+- Create `apps/vela-mobile/src/services/mobile-tts.ts` — settings read, generate call, timings, error normalization, URL cache, single-flight generation, invalidation generations.
+- Create `apps/vela-mobile/src/services/mobile-tts.test.ts` — service, cache, concurrency, error, timeout, and invalidation coverage.
+- Modify `apps/vela-mobile/src/services/mobile-services.ts` — provide `MobileTtsService`.
+- Modify `apps/vela-mobile/src/services/mobile-services.test.ts` — registry wiring.
+- Create `apps/vela-mobile/src/services/mobile-tts-auth-isolation.ts` — stop audio and clear prior-user TTS state on auth transitions.
+- Create `apps/vela-mobile/src/services/mobile-tts-auth-isolation.test.ts` — previous-user-only cleanup and successor-race coverage.
+
+### Audio and lifecycle
+
+- Create `apps/vela-mobile/src/audio/mobile-audio-contract.ts` — browser-free playback interfaces and errors.
+- Create `apps/vela-mobile/src/audio/html-audio-player.ts` — one-active-element HTML adapter.
+- Create `apps/vela-mobile/src/audio/html-audio-player.test.ts` — outcome, error, pause-ordering, cleanup, and exactly-once tests.
+- Modify `apps/vela-mobile/src/services/mobile-lifecycle.ts` — active state and timestamps.
+- Modify `apps/vela-mobile/src/services/mobile-lifecycle.test.ts` — state transition semantics.
+- Modify `apps/vela-mobile/src/boot/capacitor-lifecycle.ts` — feed shared state from the existing listener.
+- Create or modify `apps/vela-mobile/src/boot/capacitor-lifecycle.test.ts` — listener ownership and focus behavior.
+
+### Controller and diagnostic UI
+
+- Create `apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts` — state machine, manual retry, auth continuation, playback, expiry, lifecycle, and teardown.
+- Create `apps/vela-mobile/src/composables/usePronunciationDiagnostic.test.ts` — controller state and race coverage.
+- Create `apps/vela-mobile/src/diagnostics/tts-pronunciation-contract.ts` — route path, fixed word, labels, test IDs, and forbidden production tokens.
+- Modify `apps/vela-mobile/src/router/diagnostic-routes.ts` — split bypass/authenticated diagnostic collections and add route.
+- Modify `apps/vela-mobile/src/router/diagnostic-routes.test.ts` — preserve bypass invariant and verify authenticated route.
+- Create `apps/vela-mobile/src/components/mobile/TtsPronunciationDiagnosticsEntry.vue` — More-page entry.
+- Create `apps/vela-mobile/src/components/mobile/TtsPronunciationDiagnosticsEntry.test.ts` — entry navigation.
+- Modify `apps/vela-mobile/src/pages/MorePage.vue` — development-only lazy entry.
+- Modify `apps/vela-mobile/src/pages/MorePage.test.ts` — development/production entry behavior.
+- Create `apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.vue` — authenticated diagnostic presentation.
+- Create `apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts` — all view states, controls, redaction, and accessibility.
+- Modify `apps/vela-mobile/scripts/verify-production-diagnostics.mjs` — scan for TTS diagnostic tokens.
+- Modify `apps/vela-mobile/scripts/verify-production-diagnostics.test.mjs` — production exclusion tests.
+
+### Evidence
+
+- Create `apps/vela-mobile/docs/tts-pronunciation-ios.md` during verification — exact tested versions, timings, matrix, audibility evidence, limitations, and final architecture conclusion.
+
+---
+
+### Task 1: Add Shared TTS Contracts and Adopt Them in Web Success Paths
+
+**Files:**
+- Create: `packages/common/src/contracts/tts.ts`
+- Create: `packages/common/src/contracts/tts.test.ts`
+- Modify: `packages/common/src/index.ts`
+- Modify: `apps/vela/src/services/ttsService.ts`
+- Modify: `apps/vela/src/services/ttsService.test.ts`
+
+**Interfaces:**
+- Produces: `TtsProvider`, `TtsSettings`, `GeneratePronunciationRequest`, `GeneratePronunciationResponse`, `TtsApiErrorCode`, `TtsApiErrorResponse`, `parseTtsSettings()`, `parseGeneratePronunciationRequest()`, `parseGeneratePronunciationResponse()`, and `parseTtsApiErrorResponse()`.
+- Consumers: backend route tests, mobile TTS service, and existing web TTS service.
+
+- [ ] **Step 1: Write failing shared-contract tests**
+
+```ts
+import {
+  parseGeneratePronunciationRequest,
+  parseGeneratePronunciationResponse,
+  parseTtsApiErrorResponse,
+  parseTtsSettings,
+} from './tts';
+
+it('parses a valid configured TTS settings response', () => {
+  expect(
+    parseTtsSettings({
+      provider: 'openai',
+      voiceId: 'alloy',
+      model: 'tts-1',
+      hasApiKey: true,
+      ignored: 'field',
+    }),
+  ).toEqual({ provider: 'openai', voiceId: 'alloy', model: 'tts-1', hasApiKey: true });
+});
+
+it('rejects a non-HTTPS audio URL', () => {
+  expect(() =>
+    parseGeneratePronunciationResponse({ audioUrl: 'http://example.com/a.mp3', cached: false }),
+  ).toThrow('invalid_tts_generate_response:audioUrl');
+});
+
+it('trims and validates fixed generation input', () => {
+  expect(parseGeneratePronunciationRequest({ vocabularyId: ' 水:ミズ ', text: ' 水 ' })).toEqual({
+    vocabularyId: '水:ミズ',
+    text: '水',
+  });
+});
+
+it('accepts uncoded legacy error bodies', () => {
+  expect(parseTtsApiErrorResponse({ error: 'Failed to generate TTS audio' })).toEqual({
+    error: 'Failed to generate TTS audio',
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused tests and confirm failure**
+
+Run:
+
+```bash
+bun run --cwd packages/common test -- src/contracts/tts.test.ts
+```
+
+Expected: FAIL because `./tts` and its exports do not exist.
+
+- [ ] **Step 3: Implement the shared parsers**
+
+```ts
+export type TtsProvider = 'elevenlabs' | 'openai' | 'gemini';
+
+export type TtsSettings = {
+  provider: TtsProvider;
+  voiceId: string | null;
+  model: string | null;
+  hasApiKey: boolean;
+};
+
+export type GeneratePronunciationRequest = {
+  vocabularyId: string;
+  text: string;
+};
+
+export type GeneratePronunciationResponse = {
+  audioUrl: string;
+  cached: boolean;
+};
+
+export function parseGeneratePronunciationResponse(value: unknown): GeneratePronunciationResponse {
+  const record = requireRecord(value, 'generate_response');
+  const audioUrl = requireString(record.audioUrl, 'generate_response:audioUrl');
+  const parsedUrl = new URL(audioUrl);
+  if (parsedUrl.protocol !== 'https:') throw new TypeError('invalid_tts_generate_response:audioUrl');
+  return { audioUrl, cached: requireBoolean(record.cached, 'generate_response:cached') };
+}
+```
+
+Implement equivalent strict checks for settings, request input, and error response. Ignore unknown fields. Export all values from `packages/common/src/index.ts`.
+
+- [ ] **Step 4: Adopt parsers in the web service**
+
+Replace direct casts on successful settings/generate responses:
+
+```ts
+const raw = await response.json();
+const result = parseGeneratePronunciationResponse(raw);
+setCachedAudioUrl(cacheKey, result.audioUrl);
+return result;
+```
+
+```ts
+return parseTtsSettings(await response.json());
+```
+
+Do not alter request bodies, cache keys, non-2xx error parsing, or `playAudio()`.
+
+- [ ] **Step 5: Add web regression tests**
+
+Add cases proving:
+
+```ts
+it('keeps valid generate responses unchanged through the shared parser', async () => {
+  // Existing settings mock plus { audioUrl: HTTPS_URL, cached: false }.
+  await expect(generatePronunciation('水:ミズ', '水', 'user-1')).resolves.toEqual({
+    audioUrl: HTTPS_URL,
+    cached: false,
+  });
+});
+
+it('rejects malformed successful generate responses', async () => {
+  // Return 200 JSON with audioUrl missing.
+  await expect(generatePronunciation('水:ミズ', '水', 'user-1')).rejects.toThrow(
+    'invalid_tts_generate_response:audioUrl',
+  );
+});
+```
+
+- [ ] **Step 6: Run focused and package tests**
+
+```bash
+bun run --cwd packages/common test -- src/contracts/tts.test.ts
+bun run --cwd apps/vela test:unit -- src/services/ttsService.test.ts
+```
+
+Expected: PASS with existing web cache, auth, and playback tests unchanged.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/common/src/contracts/tts.ts packages/common/src/contracts/tts.test.ts \
+  packages/common/src/index.ts apps/vela/src/services/ttsService.ts \
+  apps/vela/src/services/ttsService.test.ts
+git commit -m "feat: share validated TTS contracts"
+```
+
+---
+
+### Task 2: Add Stable Backend TTS Error Codes Without Changing Existing Messages
+
+**Files:**
+- Modify: `apps/vela-api/src/routes/tts.ts`
+- Modify: `apps/vela-api/test/routes/tts.test.ts`
+
+**Interfaces:**
+- Consumes: `TtsApiErrorCode` from `@vela/common` when package boundaries allow; otherwise use a locally type-checked helper whose literals match the shared union.
+- Produces: existing `{ error }` responses augmented with stable `code` fields.
+
+- [ ] **Step 1: Add failing route tests for every mapped failure**
+
+```ts
+expect(response.status).toBe(400);
+expect(await response.json()).toEqual({
+  error: 'TTS API key not configured. Please configure in Settings.',
+  code: 'tts_not_configured',
+});
+```
+
+Add equivalent assertions for invalid provider, S3 unavailable, provider timeout, provider failure, upload failure, and signing failure. Preserve exact current messages and statuses.
+
+Add a validator case with malformed input:
+
+```ts
+const response = await app.request('/api/tts/generate', {
+  method: 'POST',
+  headers: authHeaders,
+  body: JSON.stringify({ vocabularyId: '', text: '' }),
+});
+expect(response.status).toBe(400);
+expect(await response.json()).toMatchObject({ success: false });
+```
+
+The validator response remains uncoded and Zod-shaped; mobile maps it by status.
+
+- [ ] **Step 2: Run the route test and confirm failure**
+
+```bash
+bun test apps/vela-api/test/routes/tts.test.ts
+```
+
+Expected: FAIL because error responses do not yet include `code`.
+
+- [ ] **Step 3: Introduce one response helper and replace route branches**
+
+```ts
+function ttsError(
+  c: Context,
+  status: ContentfulStatusCode,
+  code: TtsApiErrorCode,
+  error: string,
+) {
+  return c.json({ error, code }, status);
+}
+```
+
+Use this helper only for route-owned TTS failures. Do not intercept or reshape `zValidator` failures.
+
+- [ ] **Step 4: Run backend tests**
+
+```bash
+bun test apps/vela-api/test/routes/tts.test.ts
+bun run --cwd apps/vela-api typecheck
+```
+
+Expected: PASS; messages/statuses remain exactly compatible.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/vela-api/src/routes/tts.ts apps/vela-api/test/routes/tts.test.ts
+git commit -m "feat(api): add stable TTS error codes"
+```
+
+---
+
+### Task 3: Add Bounded Coordinator Transport Overrides and Replayable Authenticated POST Recovery
+
+**Files:**
+- Modify: `apps/vela-mobile/src/auth/mobile-auth-contract.ts`
+- Modify: `apps/vela-mobile/src/services/mobile-auth.ts`
+- Modify: `apps/vela-mobile/src/services/mobile-auth.test.ts`
+
+**Interfaces:**
+- Produces: `transportTimeoutMs?: number`, `MOBILE_AUTH_MAX_FEATURE_NETWORK_TIMEOUT_MS`, and `invalid_request_timeout`.
+- Preserves: coordinator token ownership and one authenticated retry after successful 401 recovery.
+
+- [ ] **Step 1: Write failing contract/timeout tests**
+
+```ts
+it.each([0, -1, 1.5, Number.NaN, 50_001])(
+  'rejects invalid feature transport timeout %s',
+  async (transportTimeoutMs) => {
+    await expect(
+      coordinator.requestAuthenticatedApi({ path: 'tts/generate', transportTimeoutMs }),
+    ).rejects.toMatchObject({ code: 'invalid_request_timeout' });
+  },
+);
+```
+
+Add fake-timer tests proving omitted timeout aborts at 15 seconds and `45_000` does not abort before 45 seconds.
+
+- [ ] **Step 2: Write the failing identical-POST replay test**
+
+```ts
+it('replays one JSON POST with the identical body after successful 401 recovery', async () => {
+  const body = JSON.stringify({ vocabularyId: '水:ミズ', text: '水' });
+  fetchMock
+    .mockResolvedValueOnce(new Response('', { status: 401 }))
+    .mockResolvedValueOnce(sessionVerificationResponseForRefreshedToken())
+    .mockResolvedValueOnce(new Response(JSON.stringify({ audioUrl: HTTPS_URL, cached: true })));
+
+  await coordinator.requestAuthenticatedApi({
+    path: 'tts/generate',
+    transportTimeoutMs: 45_000,
+    init: { method: 'POST', headers: { 'Content-Type': 'application/json' }, body },
+  });
+
+  const featureCalls = fetchMock.mock.calls.filter(([url]) => String(url).includes('tts/generate'));
+  expect(featureCalls).toHaveLength(2);
+  expect(featureCalls[0]?.[1]?.body).toBe(body);
+  expect(featureCalls[1]?.[1]?.body).toBe(body);
+  expect(featureCalls[1]?.[1]?.method).toBe('POST');
+});
+```
+
+- [ ] **Step 3: Run focused tests and confirm failure**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- src/services/mobile-auth.test.ts
+```
+
+Expected: FAIL because the contract lacks the override and error code.
+
+- [ ] **Step 4: Implement validation and per-attempt timeout selection**
+
+```ts
+export const MOBILE_AUTH_NETWORK_TIMEOUT_MS = 15_000;
+export const MOBILE_AUTH_MAX_FEATURE_NETWORK_TIMEOUT_MS = 50_000;
+
+function featureTransportTimeout(request: MobileAuthenticatedApiRequest): number {
+  const value = request.transportTimeoutMs;
+  if (value === undefined) return MOBILE_AUTH_NETWORK_TIMEOUT_MS;
+  if (!Number.isInteger(value) || value <= 0 || value > MOBILE_AUTH_MAX_FEATURE_NETWORK_TIMEOUT_MS) {
+    throw new MobileAuthenticatedApiRequestError('invalid_request_timeout');
+  }
+  return value;
+}
+```
+
+Compute the timeout before dispatch. Continue spreading the same `request.init` into each physical attempt so the string body is replayed unchanged.
+
+- [ ] **Step 5: Run mobile auth tests and typecheck**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- src/services/mobile-auth.test.ts
+bun run --cwd apps/vela-mobile typecheck
+```
+
+Expected: PASS with existing GET, 401, cancellation, sign-out, and generation-safety tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/vela-mobile/src/auth/mobile-auth-contract.ts \
+  apps/vela-mobile/src/services/mobile-auth.ts \
+  apps/vela-mobile/src/services/mobile-auth.test.ts
+git commit -m "feat(mobile): support bounded feature transport timeouts"
+```
+
+---
+
+### Task 4: Extend MobileApiClient with Replayable JSON POST, Deadlines, and Safe Structured Errors
+
+**Files:**
+- Modify: `apps/vela-mobile/src/services/mobile-api-client.ts`
+- Modify: `apps/vela-mobile/src/services/mobile-api-client.test.ts`
+- Modify: `apps/vela-mobile/src/composables/useDueReviewCount.test.ts`
+
+**Interfaces:**
+- Produces: `postJson()`, `MobileApiRequestOptions.timeoutMs`, `MOBILE_API_MAX_ERROR_BODY_BYTES`, `MobileApiError.details`, and `client` classification.
+- Consumes: coordinator `transportTimeoutMs` from Task 3.
+
+- [ ] **Step 1: Write failing POST serialization tests**
+
+```ts
+it('serializes JSON once before coordinator dispatch', async () => {
+  const body = { vocabularyId: '水:ミズ', text: '水' };
+  coordinator.requestAuthenticatedApi.mockResolvedValue(jsonResponse({ audioUrl: HTTPS_URL, cached: false }));
+
+  await client.postJson('tts/generate', body, { timeoutMs: 45_000 });
+
+  expect(coordinator.requestAuthenticatedApi).toHaveBeenCalledWith({
+    path: 'tts/generate',
+    transportTimeoutMs: 45_000,
+    init: expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: expect.any(Headers),
+    }),
+  });
+});
+
+it('rejects circular JSON before coordinator dispatch', async () => {
+  const body: Record<string, unknown> = {};
+  body.self = body;
+  await expect(client.postJson('tts/generate', body)).rejects.toMatchObject({ code: 'invalid_request' });
+  expect(coordinator.requestAuthenticatedApi).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Write failing timeout, classification, and body-bound tests**
+
+Cover:
+
+```ts
+expect((await captureError(client.getJson('bad'))).code).toBe('client'); // HTTP 400
+expect((await captureError(client.getJson('bad'))).details.status).toBe(400);
+expect(Object.keys(error)).not.toContain('details');
+expect('cause' in new MobileApiError('network')).toBe(false);
+```
+
+Create a response body larger than 16 KiB for both JSON and text cases. Assert retained internal detail is bounded and safe logging uses only `{ code, status }`.
+
+- [ ] **Step 3: Run focused tests and confirm failure**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- src/services/mobile-api-client.test.ts
+```
+
+Expected: FAIL because `postJson`, `client`, timeout override, and details do not exist.
+
+- [ ] **Step 4: Implement one private `requestJson()` path**
+
+```ts
+export const MOBILE_API_DEFAULT_TIMEOUT_MS = 8_000;
+export const MOBILE_API_MAX_ERROR_BODY_BYTES = 16_384;
+
+export type MobileApiRequestOptions = { signal?: AbortSignal; timeoutMs?: number };
+
+async function requestJson(
+  method: 'GET' | 'POST',
+  path: string,
+  serializedBody: string | undefined,
+  options: MobileApiRequestOptions,
+): Promise<unknown> {
+  const timeoutMs = validateOverallTimeout(options.timeoutMs ?? MOBILE_API_DEFAULT_TIMEOUT_MS);
+  // Build one AbortController, apply the outer deadline, call coordinator,
+  // consume the bounded body, and map response classes.
+}
+```
+
+Pass `transportTimeoutMs: timeoutMs` to the coordinator. For POST, set `Content-Type` through `Headers`; do not allow caller-provided headers in the public API.
+
+- [ ] **Step 5: Implement non-enumerable details and bounded body consumption**
+
+```ts
+export class MobileApiError extends Error {
+  readonly details: MobileApiErrorDetails;
+
+  constructor(code: MobileApiErrorCode, details: MobileApiErrorDetails = {}) {
+    super(code, details.cause === undefined ? undefined : { cause: details.cause });
+    this.name = 'MobileApiError';
+    Object.defineProperty(this, 'details', { value: details, enumerable: false });
+  }
+}
+```
+
+Use one reader that obtains at most 16 KiB before attempting `JSON.parse`. Never call `console.error(error)` from this layer.
+
+- [ ] **Step 6: Pin due-count retry behavior**
+
+```ts
+expect(retryDueCountQuery(0, new MobileApiError('client', { status: 400 }))).toBe(false);
+expect(retryDueCountQuery(0, new MobileApiError('server', { status: 500 }))).toBe(true);
+expect(retryDueCountQuery(0, new MobileApiError('network'))).toBe(true);
+```
+
+- [ ] **Step 7: Run focused tests and typecheck**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- \
+  src/services/mobile-api-client.test.ts \
+  src/composables/useDueReviewCount.test.ts
+bun run --cwd apps/vela-mobile typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/vela-mobile/src/services/mobile-api-client.ts \
+  apps/vela-mobile/src/services/mobile-api-client.test.ts \
+  apps/vela-mobile/src/composables/useDueReviewCount.test.ts
+git commit -m "feat(mobile): add replayable JSON requests and safe API errors"
+```
+
+---
+
+### Task 5: Implement the Mobile TTS Service, Cache, Error Mapping, and Timings
+
+**Files:**
+- Create: `apps/vela-mobile/src/services/mobile-tts.ts`
+- Create: `apps/vela-mobile/src/services/mobile-tts.test.ts`
+
+**Interfaces:**
+- Consumes: shared TTS parsers and `MobileApiClient` from Tasks 1 and 4.
+- Produces: `MobileTtsService`, `PreparedPronunciation`, `PreparationTimings`, `MobileTtsError`, `MOBILE_TTS_GENERATE_TIMEOUT_MS`, and targeted invalidation.
+
+- [ ] **Step 1: Write failing settings/generate/error tests**
+
+```ts
+it('uses the default deadline for settings and 45 seconds for generation', async () => {
+  await service.preparePronunciation(INPUT);
+  expect(api.getJson).toHaveBeenCalledWith('tts/settings', { signal: expect.any(AbortSignal) });
+  expect(api.postJson).toHaveBeenCalledWith(
+    'tts/generate',
+    { vocabularyId: '水:ミズ', text: '水' },
+    { signal: expect.any(AbortSignal), timeoutMs: 45_000 },
+  );
+});
+
+it('maps an uncoded validator 400 to invalid_input', async () => {
+  api.postJson.mockRejectedValue(new MobileApiError('client', { status: 400, serverBody: { success: false } }));
+  await expect(service.preparePronunciation(INPUT)).rejects.toMatchObject({ code: 'invalid_input' });
+});
+```
+
+Add cases for every stable code, exact legacy 400 message, status-only 503/504, uncoded 500, client deadline/network, and structural success failure.
+
+- [ ] **Step 2: Write failing cache and single-flight tests**
+
+Cover:
+
+```ts
+it('shares generation after settings-derived full-key resolution', async () => { /* two callers, one POST */ });
+it('creates a distinct key after voice/model changes', async () => { /* two POSTs */ });
+it('expires memory URLs after 14 minutes', async () => { /* fake timers */ });
+it('evicts the least-recently-used item above 300 entries', async () => { /* deterministic loop */ });
+it('sweeps expired entries every five minutes', async () => { /* fake timers */ });
+```
+
+- [ ] **Step 3: Write failing invalidation-generation tests**
+
+```ts
+it('invalidates every settings partition for one user and vocabulary', () => {
+  // Seed provider A and provider B entries, invalidate, then require both to re-fetch.
+});
+
+it('prevents stale pending completion from repopulating after invalidation', async () => {
+  const pending = service.preparePronunciation(INPUT);
+  service.invalidatePronunciation('user-1', '水:ミズ');
+  resolveGenerate({ audioUrl: HTTPS_URL, cached: false });
+  await pending;
+  await service.preparePronunciation(INPUT);
+  expect(api.postJson).toHaveBeenCalledTimes(2);
+});
+```
+
+- [ ] **Step 4: Run focused tests and confirm failure**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- src/services/mobile-tts.test.ts
+```
+
+Expected: FAIL because `mobile-tts.ts` does not exist.
+
+- [ ] **Step 5: Implement public types and ordered error normalization**
+
+```ts
+export const MOBILE_TTS_GENERATE_TIMEOUT_MS = 45_000;
+
+export type PreparedPronunciation = {
+  audioUrl: string;
+  source: 'memory-cache' | 'server-cache' | 'generated';
+  expiresAt: number;
+  timings: { settingsMs: number; generateMs: number };
+};
+
+function normalizeTtsError(error: unknown): never {
+  // 1 stable code, 2 exact legacy 400 message, 3 auth/session/network,
+  // 4 status mapping, 5 generation_failed fallback.
+}
+```
+
+Do not expose `serverBody` or `serverMessage` through `MobileTtsError`.
+
+- [ ] **Step 6: Implement preparation, cache, and full-key pending index**
+
+Use encoded key components:
+
+```ts
+const key = [userId, vocabularyId, provider, voiceId ?? '', model ?? '']
+  .map(encodeURIComponent)
+  .join('|');
+```
+
+Fetch settings before checking the full-key cache or pending map. Record settings and generate timings separately. Set local expiry to `now + 14 * 60_000`.
+
+- [ ] **Step 7: Implement invalidation generations**
+
+Maintain:
+
+```ts
+const userGeneration = new Map<string, number>();
+const vocabularyGeneration = new Map<string, number>();
+```
+
+Capture both before generation. Cache only when both still match. Targeted invalidation removes all matching cache/pending-index entries without aborting existing callers.
+
+- [ ] **Step 8: Run focused tests and typecheck**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- src/services/mobile-tts.test.ts
+bun run --cwd apps/vela-mobile typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/vela-mobile/src/services/mobile-tts.ts \
+  apps/vela-mobile/src/services/mobile-tts.test.ts
+git commit -m "feat(mobile): add authenticated TTS service"
+```
+
+---
+
+### Task 6: Register TTS Services and Install Auth Isolation
+
+**Files:**
+- Modify: `apps/vela-mobile/src/services/mobile-services.ts`
+- Modify: `apps/vela-mobile/src/services/mobile-services.test.ts`
+- Create: `apps/vela-mobile/src/services/mobile-tts-auth-isolation.ts`
+- Create: `apps/vela-mobile/src/services/mobile-tts-auth-isolation.test.ts`
+- Modify: `apps/vela-mobile/src/boot/mobile-auth.ts`
+- Modify: `apps/vela-mobile/src/boot/mobile-auth.test.ts`
+
+**Interfaces:**
+- Produces: `MOBILE_TTS_SERVICE_KEY` and an auth-isolation disposer.
+- Consumes: coordinator state and `MobileTtsService.clearUser()`.
+
+- [ ] **Step 1: Write failing service-registry tests**
+
+```ts
+expect(app.provide).toHaveBeenCalledWith(MOBILE_TTS_SERVICE_KEY, expect.any(Object));
+```
+
+Assert the same `MobileApiClient` instance is passed to both SRS and TTS services.
+
+- [ ] **Step 2: Write failing auth-isolation tests**
+
+Cover prior-user sign-out, identity replacement, null-to-user no-op, unusable recovery detach, and a successor authenticating while asynchronous prior cleanup is queued.
+
+```ts
+expect(tts.clearUser).toHaveBeenCalledWith('previous-user');
+expect(tts.clearUser).not.toHaveBeenCalledWith('successor-user');
+expect(stopPlayback).toHaveBeenCalledTimes(1);
+```
+
+- [ ] **Step 3: Run focused tests and confirm failure**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- \
+  src/services/mobile-services.test.ts \
+  src/services/mobile-tts-auth-isolation.test.ts \
+  src/boot/mobile-auth.test.ts
+```
+
+Expected: FAIL because TTS registration/isolation do not exist.
+
+- [ ] **Step 4: Implement registry wiring**
+
+```ts
+export const MOBILE_TTS_SERVICE_KEY: InjectionKey<MobileTtsService> = Symbol('mobile-tts-service');
+
+const ttsService = createMobileTtsService(apiClient);
+app.provide(MOBILE_TTS_SERVICE_KEY, ttsService);
+```
+
+Return the created services from an internal factory if tests need direct access; keep public app wiring unchanged.
+
+- [ ] **Step 5: Implement prior-user-only isolation watcher**
+
+Model it after `mobile-query-auth-isolation.ts`, but call only TTS cleanup and a supplied playback stop callback. Serialize cleanup and re-check user identity after awaited work; never clear a null or successor identity.
+
+- [ ] **Step 6: Wire isolation in mobile boot**
+
+Install after services and coordinator exist. Store the disposer if boot teardown has an established hook; otherwise expose it for tests and document app-lifetime ownership.
+
+- [ ] **Step 7: Run focused tests**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- \
+  src/services/mobile-services.test.ts \
+  src/services/mobile-tts-auth-isolation.test.ts \
+  src/boot/mobile-auth.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/vela-mobile/src/services/mobile-services.ts \
+  apps/vela-mobile/src/services/mobile-services.test.ts \
+  apps/vela-mobile/src/services/mobile-tts-auth-isolation.ts \
+  apps/vela-mobile/src/services/mobile-tts-auth-isolation.test.ts \
+  apps/vela-mobile/src/boot/mobile-auth.ts apps/vela-mobile/src/boot/mobile-auth.test.ts
+git commit -m "feat(mobile): register and isolate TTS services"
+```
+
+---
+
+### Task 7: Implement the Browser-Free Audio Contract and HTML Adapter
+
+**Files:**
+- Create: `apps/vela-mobile/src/audio/mobile-audio-contract.ts`
+- Create: `apps/vela-mobile/src/audio/html-audio-player.ts`
+- Create: `apps/vela-mobile/src/audio/html-audio-player.test.ts`
+
+**Interfaces:**
+- Produces: `MobileAudioPlayer`, `MobileAudioPlaybackHandle`, `MobileAudioPlaybackOutcome`, and `MobileAudioError`.
+- Consumers: pronunciation controller and future native adapter.
+
+- [ ] **Step 1: Write failing adapter tests with an injected audio factory**
+
+Create a deterministic fake element supporting `play`, `pause`, `currentTime`, `src`, event listeners, and synchronous `pause` dispatch.
+
+Test:
+
+```ts
+it('settles restart before synchronous pause can become interruption', async () => {
+  const first = player.play(URL_A);
+  const second = player.play(URL_B);
+  await expect(first.finished).resolves.toEqual({ kind: 'stopped', reason: 'restart' });
+  expect(activeElements()).toHaveLength(1);
+  fakeFor(URL_B).dispatch('ended');
+  await expect(second.finished).resolves.toEqual({ kind: 'ended' });
+});
+```
+
+Also cover `NotAllowedError`, media error, generic play rejection, external pause, explicit stop, dispose, listener removal, and exactly-once settlement.
+
+- [ ] **Step 2: Run focused tests and confirm failure**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- src/audio/html-audio-player.test.ts
+```
+
+Expected: FAIL because audio files do not exist.
+
+- [ ] **Step 3: Define browser-free interfaces**
+
+```ts
+export type MobileAudioPlaybackOutcome =
+  | { kind: 'ended' }
+  | { kind: 'stopped'; reason: 'restart' | 'user' | 'dispose' }
+  | { kind: 'interrupted'; reason: 'background' | 'external' };
+
+export type MobileAudioPlayer = {
+  play(url: string): MobileAudioPlaybackHandle;
+  interruptActive(reason: 'background' | 'external'): void;
+  dispose(): void;
+};
+```
+
+No DOM types appear in this file.
+
+- [ ] **Step 4: Implement `HtmlAudioPlayer` with strict cleanup ordering**
+
+Before `pause()`, mark settled, detach listeners, and clear active ownership. Set `preload = 'auto'`. Do not set `crossOrigin`. Clear `src` only after listeners are detached.
+
+- [ ] **Step 5: Run tests and typecheck**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- src/audio/html-audio-player.test.ts
+bun run --cwd apps/vela-mobile typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/vela-mobile/src/audio/mobile-audio-contract.ts \
+  apps/vela-mobile/src/audio/html-audio-player.ts \
+  apps/vela-mobile/src/audio/html-audio-player.test.ts
+git commit -m "feat(mobile): add replaceable HTML audio adapter"
+```
+
+---
+
+### Task 8: Extend Shared Mobile Lifecycle State Without Adding a Native Listener
+
+**Files:**
+- Modify: `apps/vela-mobile/src/services/mobile-lifecycle.ts`
+- Modify: `apps/vela-mobile/src/services/mobile-lifecycle.test.ts`
+- Modify: `apps/vela-mobile/src/boot/capacitor-lifecycle.ts`
+- Create or modify: `apps/vela-mobile/src/boot/capacitor-lifecycle.test.ts`
+
+**Interfaces:**
+- Produces: `mobileLifecycleState.isActive`, state timestamps, and `recordAppStateChange()`.
+- Consumers: pronunciation controller.
+
+- [ ] **Step 1: Write failing lifecycle-state tests**
+
+```ts
+it('records active and inactive transitions without incrementing resume count', () => {
+  resetMobileLifecycleForTests();
+  recordAppStateChange(false, 100);
+  expect(mobileLifecycleState.isActive.value).toBe(false);
+  expect(mobileLifecycleState.lastBecameInactiveAt.value).toBe(100);
+  expect(mobileLifecycleState.resumeCount.value).toBe(0);
+
+  recordAppStateChange(true, 200);
+  expect(mobileLifecycleState.lastBecameActiveAt.value).toBe(200);
+  expect(mobileLifecycleState.resumeCount.value).toBe(0);
+});
+```
+
+- [ ] **Step 2: Write failing boot-listener tests**
+
+Capture the existing `appStateChange` callback. Assert it calls `recordAppStateChange(isActive)` and `focusManager.setFocused(isActive)`. Assert only the existing listener is registered.
+
+- [ ] **Step 3: Run focused tests and confirm failure**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- \
+  src/services/mobile-lifecycle.test.ts \
+  src/boot/capacitor-lifecycle.test.ts
+```
+
+Expected: FAIL because active state/timestamps do not exist.
+
+- [ ] **Step 4: Implement state and canonical recorder**
+
+```ts
+const isActive = ref(true);
+const lastStateChangeAt = ref<number | null>(null);
+const lastBecameActiveAt = ref<number | null>(null);
+const lastBecameInactiveAt = ref<number | null>(null);
+
+export function recordAppStateChange(next: boolean, at = Date.now()): void {
+  isActive.value = next;
+  lastStateChangeAt.value = at;
+  if (next) lastBecameActiveAt.value = at;
+  else lastBecameInactiveAt.value = at;
+}
+```
+
+Reset every field in `resetMobileLifecycleForTests()`.
+
+- [ ] **Step 5: Feed state from the existing boot listener**
+
+```ts
+await adapter.addListener('appStateChange', (event) => {
+  recordAppStateChange(event.isActive);
+  focusManager.setFocused(event.isActive);
+});
+```
+
+Do not touch the auth coordinator's private listener.
+
+- [ ] **Step 6: Run tests and commit**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- \
+  src/services/mobile-lifecycle.test.ts \
+  src/boot/capacitor-lifecycle.test.ts
+
+git add apps/vela-mobile/src/services/mobile-lifecycle.ts \
+  apps/vela-mobile/src/services/mobile-lifecycle.test.ts \
+  apps/vela-mobile/src/boot/capacitor-lifecycle.ts \
+  apps/vela-mobile/src/boot/capacitor-lifecycle.test.ts
+git commit -m "feat(mobile): expose shared app activity state"
+```
+
+---
+
+### Task 9: Implement the Pronunciation Controller State Machine
+
+**Files:**
+- Create: `apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts`
+- Create: `apps/vela-mobile/src/composables/usePronunciationDiagnostic.test.ts`
+
+**Interfaces:**
+- Consumes: `MobileTtsService`, `MobileAudioPlayer`, coordinator feature-session status, and shared lifecycle state.
+- Produces: `PronunciationDiagnosticState`, `playOrRetry()`, `invalidateForTest()`, `simulateInvalidUrlForTest()`, counters, and `dispose()`.
+
+- [ ] **Step 1: Write failing happy-path and gesture tests**
+
+```ts
+it('moves idle -> preparing -> playing -> ready', async () => { /* resolve service, end audio */ });
+it('keeps a prepared URL when async first play requires a direct second tap', async () => {
+  audio.play.mockReturnValueOnce(rejectedHandle(new MobileAudioError('gesture_required')));
+  await controller.playOrRetry();
+  expect(controller.state.value.kind).toBe('ready');
+  expect(controller.state.value.notice).toBe('gesture_required');
+});
+```
+
+Assert settings/generate timings and tap-to-play latency are recorded separately.
+
+- [ ] **Step 2: Write failing concurrency and replay tests**
+
+Cover disabled/ignored tap during preparation, deterministic restart during playing, no overlap, ready live replay with no service call, and one active playback.
+
+- [ ] **Step 3: Write failing error/recovery tests**
+
+Cover:
+
+- manual-only network/provider/server/invalid-input failures;
+- one same-user `session_changed`/`session_unavailable` retry;
+- one recovery-pending continuation after same user becomes usable;
+- second control failure visible;
+- identity change cancels continuation;
+- proactive expiry before audio creation;
+- one media-unavailable refresh per tap;
+- refresh failure visible without transport auto-retry;
+- background interruption, no auto-resume, explicit replay;
+- sign-out/dispose cancels or detaches stale completion.
+
+- [ ] **Step 4: Run focused tests and confirm failure**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- src/composables/usePronunciationDiagnostic.test.ts
+```
+
+Expected: FAIL because controller does not exist.
+
+- [ ] **Step 5: Implement state model and operation ownership**
+
+```ts
+export type PronunciationDiagnosticState =
+  | { kind: 'idle' }
+  | { kind: 'preparing'; attempt: number; recoveringSession: boolean }
+  | { kind: 'ready'; pronunciation: PreparedPronunciation; notice: ReadyNotice | null }
+  | { kind: 'playing'; pronunciation: PreparedPronunciation }
+  | { kind: 'interrupted'; pronunciation: PreparedPronunciation; reason: 'background' | 'external' }
+  | { kind: 'error'; error: PronunciationDiagnosticError; pronunciation: PreparedPronunciation | null };
+```
+
+Use an operation generation counter so old promises cannot overwrite successor state.
+
+- [ ] **Step 6: Implement tap, auth continuation, expiry, and playback result handling**
+
+Keep transport retries manual. Reuse live prepared URLs directly. Invalidate all settings partitions on expiry/media failure. Stop playback before restart. Observe shared `isActive` rather than registering a native listener.
+
+- [ ] **Step 7: Run focused tests and typecheck**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- src/composables/usePronunciationDiagnostic.test.ts
+bun run --cwd apps/vela-mobile typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts \
+  apps/vela-mobile/src/composables/usePronunciationDiagnostic.test.ts
+git commit -m "feat(mobile): add pronunciation diagnostic controller"
+```
+
+---
+
+### Task 10: Add the Authenticated Development Diagnostic Route and More Entry
+
+**Files:**
+- Create: `apps/vela-mobile/src/diagnostics/tts-pronunciation-contract.ts`
+- Modify: `apps/vela-mobile/src/router/diagnostic-routes.ts`
+- Modify: `apps/vela-mobile/src/router/diagnostic-routes.test.ts`
+- Create: `apps/vela-mobile/src/components/mobile/TtsPronunciationDiagnosticsEntry.vue`
+- Create: `apps/vela-mobile/src/components/mobile/TtsPronunciationDiagnosticsEntry.test.ts`
+- Modify: `apps/vela-mobile/src/pages/MorePage.vue`
+- Modify: `apps/vela-mobile/src/pages/MorePage.test.ts`
+
+**Interfaces:**
+- Produces: `TTS_PRONUNCIATION_DIAGNOSTIC_PATH`, fixed word, labels, markers, and route registration.
+- Consumes: existing mobile navigation helpers.
+
+- [ ] **Step 1: Write failing route-partition tests**
+
+```ts
+expect(bypassDevelopmentDiagnosticRoutes.every((r) => r.meta?.bypassMobileAuth === true)).toBe(true);
+expect(authenticatedDevelopmentDiagnosticRoutes).toHaveLength(1);
+expect(authenticatedDevelopmentDiagnosticRoutes[0]?.path).toBe('diagnostics/tts-pronunciation');
+expect(authenticatedDevelopmentDiagnosticRoutes[0]?.meta?.bypassMobileAuth).not.toBe(true);
+```
+
+Keep the combined `developmentDiagnosticRoutes` and production five-route assertions.
+
+- [ ] **Step 2: Write failing entry/More tests**
+
+Assert development builds render the lazy entry, clicking it calls `pushMobileRoute(router, TTS_PRONUNCIATION_DIAGNOSTIC_PATH)`, and production builds omit it.
+
+- [ ] **Step 3: Run focused tests and confirm failure**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- \
+  src/router/diagnostic-routes.test.ts \
+  src/components/mobile/TtsPronunciationDiagnosticsEntry.test.ts \
+  src/pages/MorePage.test.ts
+```
+
+Expected: FAIL because contract, route, and entry do not exist.
+
+- [ ] **Step 4: Define diagnostic constants**
+
+```ts
+export const TTS_PRONUNCIATION_DIAGNOSTIC_PATH = '/diagnostics/tts-pronunciation';
+export const TTS_PRONUNCIATION_DIAGNOSTIC_LABEL = 'Pronunciation diagnostics';
+export const DIAGNOSTIC_WORD = {
+  vocabularyId: '水:ミズ',
+  text: '水',
+  reading: 'みず',
+  translation: 'water',
+} as const;
+```
+
+Add unique marker/test ID strings for production scanning.
+
+- [ ] **Step 5: Split route arrays and add authenticated route**
+
+Keep existing iOS interaction routes in the bypass array. Add the TTS page only to the authenticated array with header fallback `/more` and no auth bypass.
+
+- [ ] **Step 6: Add the More entry**
+
+Follow the existing lazy diagnostic-entry pattern. Render it only when `import.meta.env.DEV` is true.
+
+- [ ] **Step 7: Run tests and commit**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- \
+  src/router/diagnostic-routes.test.ts \
+  src/components/mobile/TtsPronunciationDiagnosticsEntry.test.ts \
+  src/pages/MorePage.test.ts
+
+git add apps/vela-mobile/src/diagnostics/tts-pronunciation-contract.ts \
+  apps/vela-mobile/src/router/diagnostic-routes.ts \
+  apps/vela-mobile/src/router/diagnostic-routes.test.ts \
+  apps/vela-mobile/src/components/mobile/TtsPronunciationDiagnosticsEntry.vue \
+  apps/vela-mobile/src/components/mobile/TtsPronunciationDiagnosticsEntry.test.ts \
+  apps/vela-mobile/src/pages/MorePage.vue apps/vela-mobile/src/pages/MorePage.test.ts
+git commit -m "feat(mobile): register authenticated TTS diagnostics"
+```
+
+---
+
+### Task 11: Build the Diagnostic Page and Accessible State Presentation
+
+**Files:**
+- Create: `apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.vue`
+- Create: `apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts`
+
+**Interfaces:**
+- Consumes: `usePronunciationDiagnostic`, fixed word, audio adapter factory, mobile TTS service injection, and coordinator state.
+- Produces: accessible diagnostic controls, counters, latency displays, safe error summaries, and development controls.
+
+- [ ] **Step 1: Write failing page tests for visible states**
+
+Cover idle, preparing, recovering session, playing, ready/completed, gesture-required, interrupted, invalid input, network/deadline, provider timeout, service unavailable, refreshed URL, and playback failure.
+
+```ts
+expect(wrapper.get('[data-testid="tts-play-button"]').attributes('aria-label')).toBe(
+  'Prepare and play pronunciation',
+);
+expect(wrapper.get('[role="status"]').text()).toContain('Preparing pronunciation');
+```
+
+- [ ] **Step 2: Write failing safety/accessibility tests**
+
+Assert:
+
+- word, reading, and translation render;
+- `role=status`, `aria-live=polite`, and `role=alert` are used appropriately;
+- source/settings/generate/tap timings are labeled diagnostic-only;
+- complete signed URL never renders;
+- `serverBody`/`serverMessage` never render;
+- button is disabled during preparation and reflects retry/restart labels;
+- diagnostic invalidation/simulated-invalid-URL controls call controller methods.
+
+- [ ] **Step 3: Run focused tests and confirm failure**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- \
+  src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts
+```
+
+Expected: FAIL because page does not exist.
+
+- [ ] **Step 4: Implement the page**
+
+Inject dependencies and instantiate the controller. Do not access Cognito tokens or call APIs directly. Render only safe stable error labels. Redact URL to hostname plus a non-query suffix only when diagnostic detail is enabled.
+
+- [ ] **Step 5: Dispose on unmount and stop playback**
+
+```ts
+onUnmounted(() => controller.dispose());
+```
+
+Ensure auth loss makes the route inaccessible through the existing gate and clears controller state through isolation.
+
+- [ ] **Step 6: Run page tests and typecheck**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- \
+  src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts
+bun run --cwd apps/vela-mobile typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.vue \
+  apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts
+git commit -m "feat(mobile): add authenticated pronunciation diagnostic page"
+```
+
+---
+
+### Task 12: Prove Production Exclusion and Run the Automated Merge Gates
+
+**Files:**
+- Modify: `apps/vela-mobile/scripts/verify-production-diagnostics.mjs`
+- Modify: `apps/vela-mobile/scripts/verify-production-diagnostics.test.mjs`
+- Modify as needed: existing tests touched by Tasks 1–11
+
+**Interfaces:**
+- Consumes: forbidden tokens from the TTS diagnostic contract.
+- Produces: production-bundle leak detection and a complete automated validation record for the PR.
+
+- [ ] **Step 1: Write failing scanner tests**
+
+Add each TTS diagnostic marker, route, label, and test ID to a synthetic bundle and assert verification fails. Assert a normal production bundle passes.
+
+- [ ] **Step 2: Run scanner tests and confirm failure**
+
+```bash
+bun test apps/vela-mobile/scripts/verify-production-diagnostics.test.mjs
+```
+
+Expected: FAIL because the scanner does not know TTS tokens.
+
+- [ ] **Step 3: Extend forbidden-token scanning**
+
+Import or duplicate only build-safe literal tokens according to the existing script structure. Do not import Vue/browser code into the Node verification script.
+
+- [ ] **Step 4: Run all focused suites**
+
+```bash
+bun run --cwd packages/common test -- src/contracts/tts.test.ts
+bun test apps/vela-api/test/routes/tts.test.ts
+bun run --cwd apps/vela test:unit -- src/services/ttsService.test.ts
+bun run --cwd apps/vela-mobile test:unit -- \
+  src/services/mobile-auth.test.ts \
+  src/services/mobile-api-client.test.ts \
+  src/services/mobile-tts.test.ts \
+  src/services/mobile-services.test.ts \
+  src/services/mobile-tts-auth-isolation.test.ts \
+  src/audio/html-audio-player.test.ts \
+  src/services/mobile-lifecycle.test.ts \
+  src/boot/capacitor-lifecycle.test.ts \
+  src/composables/usePronunciationDiagnostic.test.ts \
+  src/router/diagnostic-routes.test.ts \
+  src/components/mobile/TtsPronunciationDiagnosticsEntry.test.ts \
+  src/pages/MorePage.test.ts \
+  src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run package and repository gates**
+
+```bash
+bun run --cwd apps/vela-mobile lint
+bun run --cwd apps/vela-mobile typecheck
+bun run --cwd apps/vela-mobile test:unit
+bun run --cwd apps/vela-mobile verify:production-diagnostics
+bun run --cwd apps/vela-api typecheck
+bun run test
+```
+
+Expected: every command exits 0. Record exact test counts and coverage in the implementation PR; do not copy counts from earlier PRs.
+
+- [ ] **Step 6: Build native assets and open Simulator**
+
+```bash
+bun run --cwd apps/vela-mobile build:ios:assets
+bun run --cwd apps/vela-mobile build:ios:ide
+```
+
+Expected: production assets pass diagnostics and the Xcode project opens/builds without adding a native audio dependency.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/vela-mobile/scripts/verify-production-diagnostics.mjs \
+  apps/vela-mobile/scripts/verify-production-diagnostics.test.mjs
+git commit -m "test(mobile): verify TTS diagnostic exclusion"
+```
+
+---
+
+### Task 13: Complete Simulator and Physical-iPhone Evidence and Record the Architecture Decision
+
+**Files:**
+- Create: `apps/vela-mobile/docs/tts-pronunciation-ios.md`
+- Modify only if evidence requires: `packages/cdk/lib/storage-stack.ts`
+- Modify only if CORS changes: `packages/cdk/test/storage-stack.test.ts`
+- Create a follow-up Linear issue only if evidence selects native audio-session or native player work.
+
+**Interfaces:**
+- Produces: HPA-208 closure evidence consumed by HPA-210.
+
+- [ ] **Step 1: Prepare the test account and capture non-secret configuration**
+
+Confirm the account has TTS configured through web settings. Record provider, voice, and model identifiers only. Do not record the provider key, tokens, or complete signed URLs.
+
+- [ ] **Step 2: Run the Simulator matrix**
+
+Record exact pass/fail and timings for:
+
+- restored authentication;
+- configured settings;
+- first server-cache request;
+- genuinely uncached generation;
+- async first-tap attempt;
+- prepared direct-tap playback;
+- ten replays;
+- rapid preparation and playback taps;
+- proactive expiry;
+- disabled network and explicit retry;
+- invalid URL refresh;
+- background during preparation/playback;
+- sign-out ready/playing;
+- relaunch and replay.
+
+Capture settings latency, generate/cache latency, and tap-to-play-attempt latency separately.
+
+- [ ] **Step 3: Run the physical-iPhone matrix**
+
+Repeat the applicable Simulator matrix and additionally verify by human hearing on the built-in speaker:
+
+1. Ring/Silent off, media volume nonzero: `水` is audible and correct.
+2. Ring/Silent on, media volume nonzero: prepared direct tap is audible or inaudible.
+3. External/system audio interruption leaves playback replayable.
+4. Ten prepared replays have no intermittent silent or stuck state.
+
+Do not infer audibility from `play`, `playing`, or `ended` events.
+
+- [ ] **Step 4: Diagnose valid-URL failures before changing infrastructure**
+
+If valid presigned media fails, collect WebKit/native console evidence. Change S3 CORS only when evidence identifies origin rejection. Add exact `capacitor://localhost` GET/HEAD origin support, preserve web origins, and test arbitrary-origin rejection. Do not use `*`.
+
+- [ ] **Step 5: Write the verification record with actual observations**
+
+The document must contain:
+
+```markdown
+# iOS TTS Pronunciation Verification
+
+- Tested commit: `<actual SHA>`
+- Xcode: `<actual version>`
+- iOS Simulator/device: `<actual versions/models>`
+- Quasar/Capacitor/Bun: `<actual versions>`
+- Provider/voice/model: `<non-secret identifiers>`
+- Settings latency: `<actual measurements>`
+- Generation/cache latency: `<actual measurements>`
+- Tap-to-play-attempt latency: `<actual measurements>`
+- Normal speaker audibility: pass/fail with observation
+- Ring/Silent speaker audibility: pass/fail with observation
+- Final decision: HTML-only accepted | native audio-session integration required | native player adapter required
+```
+
+Replace every angle-bracket value with measured evidence before committing; do not commit an incomplete record.
+
+- [ ] **Step 6: Create the evidence-driven follow-up when required**
+
+If silent-mode is the only failure and HTML decoding/lifecycle are reliable, create a Linear issue for minimal app-level `AVAudioSession` `.playback` configuration while retaining `HtmlAudioPlayer`.
+
+If HTML playback remains unreliable after correct CORS/session configuration, create a Linear issue for a native implementation of `MobileAudioPlayer` and name the failed gate.
+
+- [ ] **Step 7: Re-run automated gates after any evidence-driven code change**
+
+```bash
+bun run --cwd apps/vela-mobile lint
+bun run --cwd apps/vela-mobile typecheck
+bun run --cwd apps/vela-mobile test:unit
+bun run --cwd apps/vela-mobile verify:production-diagnostics
+bun run test
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 8: Commit evidence**
+
+```bash
+git add apps/vela-mobile/docs/tts-pronunciation-ios.md \
+  packages/cdk/lib/storage-stack.ts packages/cdk/test/storage-stack.test.ts
+git commit -m "docs(mobile): record iOS TTS pronunciation verification"
+```
+
+Stage the CDK files only when they actually changed.
+
+- [ ] **Step 9: Update HPA-208 and HPA-210**
+
+Add links to the implementation PR, tested commit, verification document, completed matrix, final architecture conclusion, and any follow-up issue. HPA-208 closes only after physical-iPhone evidence exists.
+
+---
+
+## Final Self-Review Checklist
+
+Before implementation begins, confirm the plan covers every approved design requirement:
+
+- [ ] Shared TTS contracts and web parser adoption.
+- [ ] Additive backend codes and unchanged legacy messages/statuses.
+- [ ] Uncoded validator 400 mapping.
+- [ ] 8-second default, 45-second generate deadline, 15-second coordinator default, and 50-second maximum override.
+- [ ] Replayable JSON POST across one 401 recovery.
+- [ ] Bounded non-enumerable error details and safe logging.
+- [ ] Due-count 4xx retry migration regression tests.
+- [ ] Settings-derived cache key, 14-minute TTL, 300-entry bound, five-minute sweep.
+- [ ] All-partition targeted invalidation and stale-completion guards.
+- [ ] Fixed vocabulary ID/text precondition and backend collision warning.
+- [ ] Manual-only transport/provider retries and one same-user auth continuation.
+- [ ] One-active-element audio adapter and pause-ordering invariant.
+- [ ] Shared lifecycle state fed by the existing boot listener.
+- [ ] Authenticated `/diagnostics/tts-pronunciation` route with preserved bypass assertions.
+- [ ] Accessible UI, diagnostic-only timing/source metadata, and redaction.
+- [ ] Production diagnostic exclusion.
+- [ ] Simulator and physical-iPhone matrix, including human speaker audibility and silent-switch evidence.
+- [ ] Evidence-driven HTML-only/native-session/native-player conclusion.

--- a/docs/superpowers/plans/2026-07-31-mobile-authenticated-tts-pronunciation.md
+++ b/docs/superpowers/plans/2026-07-31-mobile-authenticated-tts-pronunciation.md
@@ -2,103 +2,97 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Deliver a production-shaped authenticated pronunciation diagnostic in the Capacitor iOS app, validate HTML audio on Simulator and a physical iPhone, and record whether the MVP can retain HTML playback, needs native audio-session configuration, or needs a native player adapter.
+**Goal:** Deliver an authenticated iOS pronunciation diagnostic that exercises Vela's existing TTS and presigned-audio flow, then record whether the MVP can retain HTML playback, needs native audio-session configuration, or needs a native player adapter.
 
-**Architecture:** Add platform-neutral validated TTS contracts in `@vela/common`, preserve server-side secret ownership, and extend the existing coordinator-owned mobile request path with replayable JSON POST bodies and bounded per-request deadlines. Build a mobile TTS service with settings-partitioned URL caching, a replaceable `MobileAudioPlayer`, a controller state machine, and an authenticated development-only diagnostic route. Keep the existing web TTS flow compatible while sharing response validation.
+**Architecture:** Add strict platform-neutral TTS contracts in `@vela/common`; preserve backend ownership of provider credentials; extend the coordinator-owned mobile request path with replayable JSON POST bodies, bounded per-request deadlines, and structured redacted failures. Build a settings-partitioned mobile TTS service, a browser-free playback interface with an HTML implementation, a controller state machine, and an authenticated development-only diagnostic route. Validate the result on Simulator and a physical iPhone.
 
 **Tech Stack:** TypeScript 5.6, Bun, Vitest, Vue 3, Quasar 2, TanStack Vue Query 5, Capacitor 7, Hono, Zod, AWS Lambda, DynamoDB, S3 presigned URLs, WebKit `HTMLAudioElement`, iOS/Xcode.
 
 ## Global Constraints
 
-- Keep `GET tts/settings`, due-count, and ordinary mobile JSON requests on the existing 8-second overall deadline.
+- Keep `GET tts/settings`, due-count, and ordinary mobile JSON calls on the existing 8-second overall deadline.
 - Use a 45-second overall deadline for `POST tts/generate`.
 - Keep the coordinator's 15-second default physical-fetch cap; permit validated per-request overrides no greater than 50 seconds.
-- All JSON POST bodies must be serialized once to replayable immutable strings before coordinator dispatch.
-- The coordinator remains the only owner of Cognito ID tokens and `Authorization` headers.
-- No provider key, Cognito token, complete presigned URL, or raw server error detail may be rendered, logged, or placed in verification records.
-- Cap both JSON and text error bodies at 16 KiB before parsing or retention.
-- Treat network, provider, validator, 4xx, 5xx, and deadline failures as manual-only retries.
-- Permit exactly one same-user continuation for auth-control races or completed session recovery.
-- Keep URL/media refresh separate from transport retry and allow at most one automatic URL refresh per tap.
-- Mirror the backend cache identity: user ID, vocabulary ID, provider, voice, and model; text is an unenforced fixed-pair client precondition.
-- Use fixed diagnostic input `{ vocabularyId: '水:ミズ', text: '水' }`; do not add free-form text.
-- The diagnostic route is `/diagnostics/tts-pronunciation`, development-only, inside the authenticated shell, with no `bypassMobileAuth` metadata.
-- Preserve existing explicit auth-bypass tests for the iOS interaction diagnostic routes.
-- Use the existing `boot/capacitor-lifecycle.ts` native listener to feed shared lifecycle state; add no third listener.
-- Background playback, microphone input, STT, AI buddy audio, offline storage, Now Playing controls, and Android are out of scope.
-- Do not install a native audio plugin before physical-device evidence selects the required follow-up layer.
+- Serialize every JSON POST body exactly once to an immutable string before coordinator dispatch and reuse that string after one successful 401 recovery.
+- Keep Cognito tokens and `Authorization` ownership inside `MobileAuthCoordinator`.
+- Never render, log, or persist provider keys, Cognito tokens, complete presigned URLs, or raw server error bodies.
+- Limit both JSON and text error bodies to 16 KiB before parsing or retention.
+- Make network, provider, validator, 4xx, 5xx, and deadline failures manual-only retries.
+- Permit one same-user continuation for auth-control races or completed session recovery.
+- Keep URL/media refresh separate from transport retry; allow at most one automatic URL refresh per tap.
+- Mirror backend cache identity: user ID, vocabulary ID, provider, voice, and model. Text is an unenforced fixed-pair client precondition.
+- Use only `{ vocabularyId: '水:ミズ', text: '水' }`; add no free-form text entry.
+- Register `/diagnostics/tts-pronunciation` only in development, inside the authenticated shell, without `bypassMobileAuth`.
+- Preserve existing explicit bypass assertions for the iOS interaction diagnostic routes.
+- Feed shared lifecycle state through the existing `boot/capacitor-lifecycle.ts` listener; add no third native listener.
+- Keep background playback, microphone input, STT, AI buddy audio, offline storage, Now Playing controls, and Android out of scope.
+- Do not install a native audio plugin before physical-device evidence selects a follow-up layer.
 
 ---
 
-## File Structure
+## File Map
 
-### Shared contracts
+### Shared and web
 
-- Create `packages/common/src/contracts/tts.ts` — TTS providers, success/error contracts, request validation, and runtime parsers.
-- Create `packages/common/src/contracts/tts.test.ts` — parser and request-validation coverage.
-- Modify `packages/common/src/index.ts` — export TTS contracts and parsers.
-
-### Existing web client
-
-- Modify `apps/vela/src/services/ttsService.ts` — import shared types/parsers and validate successful settings/generate responses.
-- Modify `apps/vela/src/services/ttsService.test.ts` — valid-response regression and malformed-success tests.
+- Create `packages/common/src/contracts/tts.ts`.
+- Create `packages/common/src/contracts/tts.test.ts`.
+- Modify `packages/common/src/index.ts`.
+- Modify `apps/vela/src/services/ttsService.ts`.
+- Modify `apps/vela/src/services/ttsService.test.ts`.
 
 ### Backend
 
-- Modify `apps/vela-api/src/routes/tts.ts` — additive stable TTS error codes; preserve messages and statuses.
-- Modify `apps/vela-api/test/routes/tts.test.ts` — code/message/status compatibility and validator-shaped 400 coverage.
+- Modify `apps/vela-api/src/routes/tts.ts`.
+- Modify `apps/vela-api/test/routes/tts.test.ts`.
 
-### Mobile authenticated transport
+### Mobile transport and domain services
 
-- Modify `apps/vela-mobile/src/auth/mobile-auth-contract.ts` — `transportTimeoutMs` and `invalid_request_timeout`.
-- Modify `apps/vela-mobile/src/services/mobile-auth.ts` — bounded per-dispatch timeout override and identical-body 401 replay.
-- Modify `apps/vela-mobile/src/services/mobile-auth.test.ts` — default/override validation and POST replay.
-- Modify `apps/vela-mobile/src/services/mobile-api-client.ts` — `postJson`, per-request overall deadlines, bounded body reader, structured non-enumerable errors.
-- Modify `apps/vela-mobile/src/services/mobile-api-client.test.ts` — JSON POST, timeout, body bounds, redaction, classification, cause/name regression.
-- Modify `apps/vela-mobile/src/composables/useDueReviewCount.test.ts` — pin 400/no retry, 500/retry, and network/retry after `client` classification is added.
+- Modify `apps/vela-mobile/src/auth/mobile-auth-contract.ts`.
+- Modify `apps/vela-mobile/src/services/mobile-auth.ts`.
+- Modify `apps/vela-mobile/src/services/mobile-auth.test.ts`.
+- Modify `apps/vela-mobile/src/services/mobile-api-client.ts`.
+- Modify `apps/vela-mobile/src/services/mobile-api-client.test.ts`.
+- Modify `apps/vela-mobile/src/composables/useDueReviewCount.test.ts`.
+- Create `apps/vela-mobile/src/services/mobile-tts.ts`.
+- Create `apps/vela-mobile/src/services/mobile-tts.test.ts`.
+- Modify `apps/vela-mobile/src/services/mobile-services.ts`.
+- Modify `apps/vela-mobile/src/services/mobile-services.test.ts`.
+- Create `apps/vela-mobile/src/services/mobile-tts-auth-isolation.ts`.
+- Create `apps/vela-mobile/src/services/mobile-tts-auth-isolation.test.ts`.
+- Modify `apps/vela-mobile/src/boot/mobile-auth.ts`.
+- Modify `apps/vela-mobile/src/boot/mobile-auth.test.ts`.
 
-### Mobile TTS domain service
+### Audio, lifecycle, and controller
 
-- Create `apps/vela-mobile/src/services/mobile-tts.ts` — settings read, generate call, timings, error normalization, URL cache, single-flight generation, invalidation generations.
-- Create `apps/vela-mobile/src/services/mobile-tts.test.ts` — service, cache, concurrency, error, timeout, and invalidation coverage.
-- Modify `apps/vela-mobile/src/services/mobile-services.ts` — provide `MobileTtsService`.
-- Modify `apps/vela-mobile/src/services/mobile-services.test.ts` — registry wiring.
-- Create `apps/vela-mobile/src/services/mobile-tts-auth-isolation.ts` — stop audio and clear prior-user TTS state on auth transitions.
-- Create `apps/vela-mobile/src/services/mobile-tts-auth-isolation.test.ts` — previous-user-only cleanup and successor-race coverage.
+- Create `apps/vela-mobile/src/audio/mobile-audio-contract.ts`.
+- Create `apps/vela-mobile/src/audio/html-audio-player.ts`.
+- Create `apps/vela-mobile/src/audio/html-audio-player.test.ts`.
+- Modify `apps/vela-mobile/src/services/mobile-lifecycle.ts`.
+- Modify `apps/vela-mobile/src/services/mobile-lifecycle.test.ts`.
+- Modify `apps/vela-mobile/src/boot/capacitor-lifecycle.ts`.
+- Create or modify `apps/vela-mobile/src/boot/capacitor-lifecycle.test.ts`.
+- Create `apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts`.
+- Create `apps/vela-mobile/src/composables/usePronunciationDiagnostic.test.ts`.
 
-### Audio and lifecycle
+### Diagnostic UI and evidence
 
-- Create `apps/vela-mobile/src/audio/mobile-audio-contract.ts` — browser-free playback interfaces and errors.
-- Create `apps/vela-mobile/src/audio/html-audio-player.ts` — one-active-element HTML adapter.
-- Create `apps/vela-mobile/src/audio/html-audio-player.test.ts` — outcome, error, pause-ordering, cleanup, and exactly-once tests.
-- Modify `apps/vela-mobile/src/services/mobile-lifecycle.ts` — active state and timestamps.
-- Modify `apps/vela-mobile/src/services/mobile-lifecycle.test.ts` — state transition semantics.
-- Modify `apps/vela-mobile/src/boot/capacitor-lifecycle.ts` — feed shared state from the existing listener.
-- Create or modify `apps/vela-mobile/src/boot/capacitor-lifecycle.test.ts` — listener ownership and focus behavior.
-
-### Controller and diagnostic UI
-
-- Create `apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts` — state machine, manual retry, auth continuation, playback, expiry, lifecycle, and teardown.
-- Create `apps/vela-mobile/src/composables/usePronunciationDiagnostic.test.ts` — controller state and race coverage.
-- Create `apps/vela-mobile/src/diagnostics/tts-pronunciation-contract.ts` — route path, fixed word, labels, test IDs, and forbidden production tokens.
-- Modify `apps/vela-mobile/src/router/diagnostic-routes.ts` — split bypass/authenticated diagnostic collections and add route.
-- Modify `apps/vela-mobile/src/router/diagnostic-routes.test.ts` — preserve bypass invariant and verify authenticated route.
-- Create `apps/vela-mobile/src/components/mobile/TtsPronunciationDiagnosticsEntry.vue` — More-page entry.
-- Create `apps/vela-mobile/src/components/mobile/TtsPronunciationDiagnosticsEntry.test.ts` — entry navigation.
-- Modify `apps/vela-mobile/src/pages/MorePage.vue` — development-only lazy entry.
-- Modify `apps/vela-mobile/src/pages/MorePage.test.ts` — development/production entry behavior.
-- Create `apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.vue` — authenticated diagnostic presentation.
-- Create `apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts` — all view states, controls, redaction, and accessibility.
-- Modify `apps/vela-mobile/scripts/verify-production-diagnostics.mjs` — scan for TTS diagnostic tokens.
-- Modify `apps/vela-mobile/scripts/verify-production-diagnostics.test.mjs` — production exclusion tests.
-
-### Evidence
-
-- Create `apps/vela-mobile/docs/tts-pronunciation-ios.md` during verification — exact tested versions, timings, matrix, audibility evidence, limitations, and final architecture conclusion.
+- Create `apps/vela-mobile/src/diagnostics/tts-pronunciation-contract.ts`.
+- Modify `apps/vela-mobile/src/router/diagnostic-routes.ts`.
+- Modify `apps/vela-mobile/src/router/diagnostic-routes.test.ts`.
+- Create `apps/vela-mobile/src/components/mobile/TtsPronunciationDiagnosticsEntry.vue`.
+- Create `apps/vela-mobile/src/components/mobile/TtsPronunciationDiagnosticsEntry.test.ts`.
+- Modify `apps/vela-mobile/src/pages/MorePage.vue`.
+- Modify `apps/vela-mobile/src/pages/MorePage.test.ts`.
+- Create `apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.vue`.
+- Create `apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts`.
+- Modify `apps/vela-mobile/scripts/verify-production-diagnostics.mjs`.
+- Modify `apps/vela-mobile/scripts/verify-production-diagnostics.test.mjs`.
+- Create `apps/vela-mobile/docs/tts-pronunciation-ios.md` only after collecting actual evidence.
+- Modify `packages/cdk/lib/storage-stack.ts` and create or modify `packages/cdk/test/storage-stack.test.ts` only if evidence proves a CORS correction is necessary.
 
 ---
 
-### Task 1: Add Shared TTS Contracts and Adopt Them in Web Success Paths
+### Task 1: Add Shared TTS Contracts and Web Success Validation
 
 **Files:**
 - Create: `packages/common/src/contracts/tts.ts`
@@ -108,10 +102,10 @@
 - Modify: `apps/vela/src/services/ttsService.test.ts`
 
 **Interfaces:**
-- Produces: `TtsProvider`, `TtsSettings`, `GeneratePronunciationRequest`, `GeneratePronunciationResponse`, `TtsApiErrorCode`, `TtsApiErrorResponse`, `parseTtsSettings()`, `parseGeneratePronunciationRequest()`, `parseGeneratePronunciationResponse()`, and `parseTtsApiErrorResponse()`.
-- Consumers: backend route tests, mobile TTS service, and existing web TTS service.
+- Produces: `TtsProvider`, `TtsSettings`, `GeneratePronunciationRequest`, `GeneratePronunciationResponse`, `TtsApiErrorCode`, `TtsApiErrorResponse`, `parseTtsSettings()`, `parseGeneratePronunciationRequest()`, `parseGeneratePronunciationResponse()`, `parseTtsApiErrorResponse()`.
+- Consumers: backend tests and `MobileTtsService`.
 
-- [ ] **Step 1: Write failing shared-contract tests**
+- [ ] **Step 1: Write failing contract tests**
 
 ```ts
 import {
@@ -121,49 +115,58 @@ import {
   parseTtsSettings,
 } from './tts';
 
-it('parses a valid configured TTS settings response', () => {
+const HTTPS_AUDIO = 'https://audio.example.test/mizu.mp3';
+
+it('parses valid settings and ignores unknown fields', () => {
   expect(
     parseTtsSettings({
       provider: 'openai',
       voiceId: 'alloy',
       model: 'tts-1',
       hasApiKey: true,
-      ignored: 'field',
+      ignored: 'value',
     }),
   ).toEqual({ provider: 'openai', voiceId: 'alloy', model: 'tts-1', hasApiKey: true });
 });
 
-it('rejects a non-HTTPS audio URL', () => {
+it('parses a valid generate response', () => {
+  expect(parseGeneratePronunciationResponse({ audioUrl: HTTPS_AUDIO, cached: false })).toEqual({
+    audioUrl: HTTPS_AUDIO,
+    cached: false,
+  });
+});
+
+it('rejects non-HTTPS audio URLs', () => {
   expect(() =>
-    parseGeneratePronunciationResponse({ audioUrl: 'http://example.com/a.mp3', cached: false }),
+    parseGeneratePronunciationResponse({ audioUrl: 'http://audio.example.test/mizu.mp3', cached: false }),
   ).toThrow('invalid_tts_generate_response:audioUrl');
 });
 
-it('trims and validates fixed generation input', () => {
+it('trims generation input', () => {
   expect(parseGeneratePronunciationRequest({ vocabularyId: ' 水:ミズ ', text: ' 水 ' })).toEqual({
     vocabularyId: '水:ミズ',
     text: '水',
   });
 });
 
-it('accepts uncoded legacy error bodies', () => {
+it('accepts an uncoded legacy error body', () => {
   expect(parseTtsApiErrorResponse({ error: 'Failed to generate TTS audio' })).toEqual({
     error: 'Failed to generate TTS audio',
   });
 });
 ```
 
-- [ ] **Step 2: Run the focused tests and confirm failure**
+Add table-driven failures for unsupported provider, missing booleans, non-string nullable fields, blank request fields, malformed error bodies, and unknown coded errors.
 
-Run:
+- [ ] **Step 2: Run the focused tests and verify red**
 
 ```bash
 bun run --cwd packages/common test -- src/contracts/tts.test.ts
 ```
 
-Expected: FAIL because `./tts` and its exports do not exist.
+Expected: FAIL because `contracts/tts.ts` does not exist.
 
-- [ ] **Step 3: Implement the shared parsers**
+- [ ] **Step 3: Implement strict shared parsers**
 
 ```ts
 export type TtsProvider = 'elevenlabs' | 'openai' | 'gemini';
@@ -186,23 +189,20 @@ export type GeneratePronunciationResponse = {
 };
 
 export function parseGeneratePronunciationResponse(value: unknown): GeneratePronunciationResponse {
-  const record = requireRecord(value, 'generate_response');
-  const audioUrl = requireString(record.audioUrl, 'generate_response:audioUrl');
-  const parsedUrl = new URL(audioUrl);
-  if (parsedUrl.protocol !== 'https:') throw new TypeError('invalid_tts_generate_response:audioUrl');
-  return { audioUrl, cached: requireBoolean(record.cached, 'generate_response:cached') };
+  const root = requireRecord(value, 'generate_response');
+  const audioUrl = requireString(root.audioUrl, 'generate_response:audioUrl');
+  const parsed = new URL(audioUrl);
+  if (parsed.protocol !== 'https:') throw new TypeError('invalid_tts_generate_response:audioUrl');
+  return { audioUrl, cached: requireBoolean(root.cached, 'generate_response:cached') };
 }
 ```
 
-Implement equivalent strict checks for settings, request input, and error response. Ignore unknown fields. Export all values from `packages/common/src/index.ts`.
+Implement equivalent strict helpers for settings, request input, and optional coded error responses. Export them from `packages/common/src/index.ts`.
 
-- [ ] **Step 4: Adopt parsers in the web service**
-
-Replace direct casts on successful settings/generate responses:
+- [ ] **Step 4: Adopt parsers in web success paths**
 
 ```ts
-const raw = await response.json();
-const result = parseGeneratePronunciationResponse(raw);
+const result = parseGeneratePronunciationResponse(await response.json());
 setCachedAudioUrl(cacheKey, result.audioUrl);
 return result;
 ```
@@ -211,41 +211,48 @@ return result;
 return parseTtsSettings(await response.json());
 ```
 
-Do not alter request bodies, cache keys, non-2xx error parsing, or `playAudio()`.
+Do not alter web request bodies, cache keys, non-2xx parsing, or audio playback.
 
 - [ ] **Step 5: Add web regression tests**
 
-Add cases proving:
-
 ```ts
-it('keeps valid generate responses unchanged through the shared parser', async () => {
-  // Existing settings mock plus { audioUrl: HTTPS_URL, cached: false }.
+it('keeps a valid generated response unchanged', async () => {
+  mockFetch.mockImplementation((url: string) => {
+    if (url === '/api/tts/settings') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTTSSettings) });
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ audioUrl: HTTPS_AUDIO, cached: false }),
+    });
+  });
+
   await expect(generatePronunciation('水:ミズ', '水', 'user-1')).resolves.toEqual({
-    audioUrl: HTTPS_URL,
+    audioUrl: HTTPS_AUDIO,
     cached: false,
   });
 });
 
-it('rejects malformed successful generate responses', async () => {
-  // Return 200 JSON with audioUrl missing.
+it('rejects a malformed successful generate response', async () => {
+  mockFetch.mockImplementation((url: string) => {
+    if (url === '/api/tts/settings') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTTSSettings) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ cached: false }) });
+  });
+
   await expect(generatePronunciation('水:ミズ', '水', 'user-1')).rejects.toThrow(
     'invalid_tts_generate_response:audioUrl',
   );
 });
 ```
 
-- [ ] **Step 6: Run focused and package tests**
+- [ ] **Step 6: Run green tests and commit**
 
 ```bash
 bun run --cwd packages/common test -- src/contracts/tts.test.ts
 bun run --cwd apps/vela test:unit -- src/services/ttsService.test.ts
-```
 
-Expected: PASS with existing web cache, auth, and playback tests unchanged.
-
-- [ ] **Step 7: Commit**
-
-```bash
 git add packages/common/src/contracts/tts.ts packages/common/src/contracts/tts.test.ts \
   packages/common/src/index.ts apps/vela/src/services/ttsService.ts \
   apps/vela/src/services/ttsService.test.ts
@@ -254,84 +261,85 @@ git commit -m "feat: share validated TTS contracts"
 
 ---
 
-### Task 2: Add Stable Backend TTS Error Codes Without Changing Existing Messages
+### Task 2: Add Stable Backend Error Codes Without Changing Legacy Responses
 
 **Files:**
 - Modify: `apps/vela-api/src/routes/tts.ts`
 - Modify: `apps/vela-api/test/routes/tts.test.ts`
 
 **Interfaces:**
-- Consumes: `TtsApiErrorCode` from `@vela/common` when package boundaries allow; otherwise use a locally type-checked helper whose literals match the shared union.
-- Produces: existing `{ error }` responses augmented with stable `code` fields.
+- Produces: route-owned errors with stable `code` plus unchanged `error` and HTTP status.
+- Preserves: Hono/Zod validator-generated 400 shape.
 
-- [ ] **Step 1: Add failing route tests for every mapped failure**
+- [ ] **Step 1: Write failing route tests**
 
 ```ts
-expect(response.status).toBe(400);
-expect(await response.json()).toEqual({
-  error: 'TTS API key not configured. Please configure in Settings.',
-  code: 'tts_not_configured',
+it('returns a stable code when TTS is not configured', async () => {
+  ttsSettingsGet.mockResolvedValue(null);
+  const response = await app.request('/api/tts/generate', authenticatedPost({
+    vocabularyId: '水:ミズ',
+    text: '水',
+  }));
+
+  expect(response.status).toBe(400);
+  expect(await response.json()).toEqual({
+    error: 'TTS API key not configured. Please configure in Settings.',
+    code: 'tts_not_configured',
+  });
+});
+
+it('leaves request-validator failures uncoded', async () => {
+  const response = await app.request('/api/tts/generate', authenticatedPost({
+    vocabularyId: '',
+    text: '',
+  }));
+
+  expect(response.status).toBe(400);
+  const body = await response.json();
+  expect(body).toMatchObject({ success: false });
+  expect(body).not.toHaveProperty('code');
 });
 ```
 
-Add equivalent assertions for invalid provider, S3 unavailable, provider timeout, provider failure, upload failure, and signing failure. Preserve exact current messages and statuses.
+Add exact message/status/code assertions for invalid provider, S3 service unavailable, provider timeout, provider failure, upload failure, and signing failure.
 
-Add a validator case with malformed input:
-
-```ts
-const response = await app.request('/api/tts/generate', {
-  method: 'POST',
-  headers: authHeaders,
-  body: JSON.stringify({ vocabularyId: '', text: '' }),
-});
-expect(response.status).toBe(400);
-expect(await response.json()).toMatchObject({ success: false });
-```
-
-The validator response remains uncoded and Zod-shaped; mobile maps it by status.
-
-- [ ] **Step 2: Run the route test and confirm failure**
+- [ ] **Step 2: Run the route test and verify red**
 
 ```bash
 bun test apps/vela-api/test/routes/tts.test.ts
 ```
 
-Expected: FAIL because error responses do not yet include `code`.
+Expected: route-owned error tests fail because `code` is absent.
 
-- [ ] **Step 3: Introduce one response helper and replace route branches**
+- [ ] **Step 3: Add codes to route-owned branches**
+
+Use exact literals from `TtsApiErrorCode`:
 
 ```ts
-function ttsError(
-  c: Context,
-  status: ContentfulStatusCode,
-  code: TtsApiErrorCode,
-  error: string,
-) {
-  return c.json({ error, code }, status);
-}
+return c.json(
+  {
+    error: 'TTS API key not configured. Please configure in Settings.',
+    code: 'tts_not_configured',
+  },
+  400,
+);
 ```
 
-Use this helper only for route-owned TTS failures. Do not intercept or reshape `zValidator` failures.
+Repeat for all approved mappings. Do not wrap `zValidator` or alter its failure body.
 
-- [ ] **Step 4: Run backend tests**
+- [ ] **Step 4: Run green tests and commit**
 
 ```bash
 bun test apps/vela-api/test/routes/tts.test.ts
 bun run --cwd apps/vela-api typecheck
-```
 
-Expected: PASS; messages/statuses remain exactly compatible.
-
-- [ ] **Step 5: Commit**
-
-```bash
 git add apps/vela-api/src/routes/tts.ts apps/vela-api/test/routes/tts.test.ts
 git commit -m "feat(api): add stable TTS error codes"
 ```
 
 ---
 
-### Task 3: Add Bounded Coordinator Transport Overrides and Replayable Authenticated POST Recovery
+### Task 3: Add Coordinator Transport Overrides and Identical POST Replay
 
 **Files:**
 - Modify: `apps/vela-mobile/src/auth/mobile-auth-contract.ts`
@@ -340,13 +348,13 @@ git commit -m "feat(api): add stable TTS error codes"
 
 **Interfaces:**
 - Produces: `transportTimeoutMs?: number`, `MOBILE_AUTH_MAX_FEATURE_NETWORK_TIMEOUT_MS`, and `invalid_request_timeout`.
-- Preserves: coordinator token ownership and one authenticated retry after successful 401 recovery.
+- Preserves: one authenticated replay after successful 401 recovery.
 
-- [ ] **Step 1: Write failing contract/timeout tests**
+- [ ] **Step 1: Write failing timeout-validation tests**
 
 ```ts
 it.each([0, -1, 1.5, Number.NaN, 50_001])(
-  'rejects invalid feature transport timeout %s',
+  'rejects invalid transport timeout %s',
   async (transportTimeoutMs) => {
     await expect(
       coordinator.requestAuthenticatedApi({ path: 'tts/generate', transportTimeoutMs }),
@@ -355,41 +363,47 @@ it.each([0, -1, 1.5, Number.NaN, 50_001])(
 );
 ```
 
-Add fake-timer tests proving omitted timeout aborts at 15 seconds and `45_000` does not abort before 45 seconds.
+Add fake-timer tests proving omitted timeout aborts a physical fetch after 15 seconds and `45_000` remains active at 15 seconds but aborts at 45 seconds.
 
-- [ ] **Step 2: Write the failing identical-POST replay test**
+- [ ] **Step 2: Write the failing replay test**
 
 ```ts
-it('replays one JSON POST with the identical body after successful 401 recovery', async () => {
+it('replays a JSON POST once with the identical body after refresh', async () => {
   const body = JSON.stringify({ vocabularyId: '水:ミズ', text: '水' });
-  fetchMock
+  featureFetch
     .mockResolvedValueOnce(new Response('', { status: 401 }))
-    .mockResolvedValueOnce(sessionVerificationResponseForRefreshedToken())
-    .mockResolvedValueOnce(new Response(JSON.stringify({ audioUrl: HTTPS_URL, cached: true })));
+    .mockResolvedValueOnce(new Response(JSON.stringify({ audioUrl: HTTPS_AUDIO, cached: true })));
+  refreshSession.mockResolvedValue(refreshedSession());
 
   await coordinator.requestAuthenticatedApi({
     path: 'tts/generate',
     transportTimeoutMs: 45_000,
-    init: { method: 'POST', headers: { 'Content-Type': 'application/json' }, body },
+    init: {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    },
   });
 
-  const featureCalls = fetchMock.mock.calls.filter(([url]) => String(url).includes('tts/generate'));
-  expect(featureCalls).toHaveLength(2);
-  expect(featureCalls[0]?.[1]?.body).toBe(body);
-  expect(featureCalls[1]?.[1]?.body).toBe(body);
-  expect(featureCalls[1]?.[1]?.method).toBe('POST');
+  const attempts = featureFetch.mock.calls.filter(([url]) => String(url).includes('tts/generate'));
+  expect(attempts).toHaveLength(2);
+  expect(attempts[0]?.[1]?.body).toBe(body);
+  expect(attempts[1]?.[1]?.body).toBe(body);
+  expect(attempts[1]?.[1]?.method).toBe('POST');
 });
 ```
 
-- [ ] **Step 3: Run focused tests and confirm failure**
+Adapt helper names to the existing test harness; retain the exact assertions.
+
+- [ ] **Step 3: Run focused tests and verify red**
 
 ```bash
 bun run --cwd apps/vela-mobile test:unit -- src/services/mobile-auth.test.ts
 ```
 
-Expected: FAIL because the contract lacks the override and error code.
+Expected: timeout contract tests fail.
 
-- [ ] **Step 4: Implement validation and per-attempt timeout selection**
+- [ ] **Step 4: Implement validated per-attempt timeout selection**
 
 ```ts
 export const MOBILE_AUTH_NETWORK_TIMEOUT_MS = 15_000;
@@ -405,20 +419,14 @@ function featureTransportTimeout(request: MobileAuthenticatedApiRequest): number
 }
 ```
 
-Compute the timeout before dispatch. Continue spreading the same `request.init` into each physical attempt so the string body is replayed unchanged.
+Use the selected value for each physical fetch attempt. Continue spreading the same `request.init` into the post-refresh attempt.
 
-- [ ] **Step 5: Run mobile auth tests and typecheck**
+- [ ] **Step 5: Run green tests and commit**
 
 ```bash
 bun run --cwd apps/vela-mobile test:unit -- src/services/mobile-auth.test.ts
 bun run --cwd apps/vela-mobile typecheck
-```
 
-Expected: PASS with existing GET, 401, cancellation, sign-out, and generation-safety tests.
-
-- [ ] **Step 6: Commit**
-
-```bash
 git add apps/vela-mobile/src/auth/mobile-auth-contract.ts \
   apps/vela-mobile/src/services/mobile-auth.ts \
   apps/vela-mobile/src/services/mobile-auth.test.ts
@@ -427,7 +435,7 @@ git commit -m "feat(mobile): support bounded feature transport timeouts"
 
 ---
 
-### Task 4: Extend MobileApiClient with Replayable JSON POST, Deadlines, and Safe Structured Errors
+### Task 4: Extend MobileApiClient with Replayable JSON POST and Safe Structured Errors
 
 **Files:**
 - Modify: `apps/vela-mobile/src/services/mobile-api-client.ts`
@@ -436,26 +444,28 @@ git commit -m "feat(mobile): support bounded feature transport timeouts"
 
 **Interfaces:**
 - Produces: `postJson()`, `MobileApiRequestOptions.timeoutMs`, `MOBILE_API_MAX_ERROR_BODY_BYTES`, `MobileApiError.details`, and `client` classification.
-- Consumes: coordinator `transportTimeoutMs` from Task 3.
+- Consumes: coordinator timeout override from Task 3.
 
-- [ ] **Step 1: Write failing POST serialization tests**
+- [ ] **Step 1: Write failing POST tests**
 
 ```ts
-it('serializes JSON once before coordinator dispatch', async () => {
-  const body = { vocabularyId: '水:ミズ', text: '水' };
-  coordinator.requestAuthenticatedApi.mockResolvedValue(jsonResponse({ audioUrl: HTTPS_URL, cached: false }));
+it('serializes JSON before coordinator dispatch', async () => {
+  coordinator.requestAuthenticatedApi.mockResolvedValue(
+    new Response(JSON.stringify({ audioUrl: HTTPS_AUDIO, cached: false })),
+  );
 
-  await client.postJson('tts/generate', body, { timeoutMs: 45_000 });
+  await client.postJson(
+    'tts/generate',
+    { vocabularyId: '水:ミズ', text: '水' },
+    { timeoutMs: 45_000 },
+  );
 
-  expect(coordinator.requestAuthenticatedApi).toHaveBeenCalledWith({
-    path: 'tts/generate',
-    transportTimeoutMs: 45_000,
-    init: expect.objectContaining({
-      method: 'POST',
-      body: JSON.stringify(body),
-      headers: expect.any(Headers),
-    }),
-  });
+  const request = coordinator.requestAuthenticatedApi.mock.calls[0]?.[0];
+  expect(request.path).toBe('tts/generate');
+  expect(request.transportTimeoutMs).toBe(45_000);
+  expect(request.init?.method).toBe('POST');
+  expect(request.init?.body).toBe(JSON.stringify({ vocabularyId: '水:ミズ', text: '水' }));
+  expect(new Headers(request.init?.headers).get('Content-Type')).toBe('application/json');
 });
 
 it('rejects circular JSON before coordinator dispatch', async () => {
@@ -466,50 +476,53 @@ it('rejects circular JSON before coordinator dispatch', async () => {
 });
 ```
 
-- [ ] **Step 2: Write failing timeout, classification, and body-bound tests**
-
-Cover:
+- [ ] **Step 2: Write failing classification and redaction tests**
 
 ```ts
-expect((await captureError(client.getJson('bad'))).code).toBe('client'); // HTTP 400
-expect((await captureError(client.getJson('bad'))).details.status).toBe(400);
-expect(Object.keys(error)).not.toContain('details');
-expect('cause' in new MobileApiError('network')).toBe(false);
+it('classifies 400 as a non-enumerable client error', async () => {
+  coordinator.requestAuthenticatedApi.mockResolvedValue(
+    new Response(JSON.stringify({ success: false, error: { issues: [] } }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+
+  const error = await captureError(client.getJson('invalid'));
+  expect(error).toMatchObject({ code: 'client' });
+  expect(error.details.status).toBe(400);
+  expect(Object.keys(error)).not.toContain('details');
+});
+
+it('preserves absence of cause when none is provided', () => {
+  expect('cause' in new MobileApiError('network')).toBe(false);
+});
 ```
 
-Create a response body larger than 16 KiB for both JSON and text cases. Assert retained internal detail is bounded and safe logging uses only `{ code, status }`.
+Add JSON and text bodies larger than 16 KiB. Assert retained details do not exceed the cap and safe summaries contain only `code` and `status`.
 
-- [ ] **Step 3: Run focused tests and confirm failure**
+- [ ] **Step 3: Run focused tests and verify red**
 
 ```bash
 bun run --cwd apps/vela-mobile test:unit -- src/services/mobile-api-client.test.ts
 ```
 
-Expected: FAIL because `postJson`, `client`, timeout override, and details do not exist.
+Expected: `postJson`, `client`, and structured details are absent.
 
-- [ ] **Step 4: Implement one private `requestJson()` path**
+- [ ] **Step 4: Implement one private JSON request path**
 
 ```ts
 export const MOBILE_API_DEFAULT_TIMEOUT_MS = 8_000;
 export const MOBILE_API_MAX_ERROR_BODY_BYTES = 16_384;
 
-export type MobileApiRequestOptions = { signal?: AbortSignal; timeoutMs?: number };
-
-async function requestJson(
-  method: 'GET' | 'POST',
-  path: string,
-  serializedBody: string | undefined,
-  options: MobileApiRequestOptions,
-): Promise<unknown> {
-  const timeoutMs = validateOverallTimeout(options.timeoutMs ?? MOBILE_API_DEFAULT_TIMEOUT_MS);
-  // Build one AbortController, apply the outer deadline, call coordinator,
-  // consume the bounded body, and map response classes.
-}
+export type MobileApiRequestOptions = {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+};
 ```
 
-Pass `transportTimeoutMs: timeoutMs` to the coordinator. For POST, set `Content-Type` through `Headers`; do not allow caller-provided headers in the public API.
+Serialize POST data before dispatch. Use one outer deadline across auth recovery, physical fetch, and body consumption. Pass the selected timeout as `transportTimeoutMs`.
 
-- [ ] **Step 5: Implement non-enumerable details and bounded body consumption**
+- [ ] **Step 5: Implement conditional cause and non-enumerable details**
 
 ```ts
 export class MobileApiError extends Error {
@@ -518,14 +531,19 @@ export class MobileApiError extends Error {
   constructor(code: MobileApiErrorCode, details: MobileApiErrorDetails = {}) {
     super(code, details.cause === undefined ? undefined : { cause: details.cause });
     this.name = 'MobileApiError';
-    Object.defineProperty(this, 'details', { value: details, enumerable: false });
+    Object.defineProperty(this, 'details', {
+      value: details,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
   }
 }
 ```
 
-Use one reader that obtains at most 16 KiB before attempting `JSON.parse`. Never call `console.error(error)` from this layer.
+Read no more than 16 KiB before parsing either JSON or text. Never log the entire error object from this layer.
 
-- [ ] **Step 6: Pin due-count retry behavior**
+- [ ] **Step 6: Pin due-count retry migration**
 
 ```ts
 expect(retryDueCountQuery(0, new MobileApiError('client', { status: 400 }))).toBe(false);
@@ -533,20 +551,14 @@ expect(retryDueCountQuery(0, new MobileApiError('server', { status: 500 }))).toB
 expect(retryDueCountQuery(0, new MobileApiError('network'))).toBe(true);
 ```
 
-- [ ] **Step 7: Run focused tests and typecheck**
+- [ ] **Step 7: Run green tests and commit**
 
 ```bash
 bun run --cwd apps/vela-mobile test:unit -- \
   src/services/mobile-api-client.test.ts \
   src/composables/useDueReviewCount.test.ts
 bun run --cwd apps/vela-mobile typecheck
-```
 
-Expected: PASS.
-
-- [ ] **Step 8: Commit**
-
-```bash
 git add apps/vela-mobile/src/services/mobile-api-client.ts \
   apps/vela-mobile/src/services/mobile-api-client.test.ts \
   apps/vela-mobile/src/composables/useDueReviewCount.test.ts
@@ -555,21 +567,25 @@ git commit -m "feat(mobile): add replayable JSON requests and safe API errors"
 
 ---
 
-### Task 5: Implement the Mobile TTS Service, Cache, Error Mapping, and Timings
+### Task 5: Implement MobileTtsService, Cache, Error Mapping, and Timings
 
 **Files:**
 - Create: `apps/vela-mobile/src/services/mobile-tts.ts`
 - Create: `apps/vela-mobile/src/services/mobile-tts.test.ts`
 
 **Interfaces:**
-- Consumes: shared TTS parsers and `MobileApiClient` from Tasks 1 and 4.
-- Produces: `MobileTtsService`, `PreparedPronunciation`, `PreparationTimings`, `MobileTtsError`, `MOBILE_TTS_GENERATE_TIMEOUT_MS`, and targeted invalidation.
+- Consumes: shared contracts and `MobileApiClient`.
+- Produces: `MobileTtsService`, `PreparedPronunciation`, `PreparationTimings`, `MobileTtsError`, `MOBILE_TTS_GENERATE_TIMEOUT_MS`.
 
-- [ ] **Step 1: Write failing settings/generate/error tests**
+- [ ] **Step 1: Write failing request and mapping tests**
 
 ```ts
-it('uses the default deadline for settings and 45 seconds for generation', async () => {
+it('uses default settings timeout and 45-second generate timeout', async () => {
+  api.getJson.mockResolvedValue(CONFIGURED_SETTINGS);
+  api.postJson.mockResolvedValue({ audioUrl: HTTPS_AUDIO, cached: false });
+
   await service.preparePronunciation(INPUT);
+
   expect(api.getJson).toHaveBeenCalledWith('tts/settings', { signal: expect.any(AbortSignal) });
   expect(api.postJson).toHaveBeenCalledWith(
     'tts/generate',
@@ -579,105 +595,130 @@ it('uses the default deadline for settings and 45 seconds for generation', async
 });
 
 it('maps an uncoded validator 400 to invalid_input', async () => {
-  api.postJson.mockRejectedValue(new MobileApiError('client', { status: 400, serverBody: { success: false } }));
+  api.getJson.mockResolvedValue(CONFIGURED_SETTINGS);
+  api.postJson.mockRejectedValue(
+    new MobileApiError('client', { status: 400, serverBody: { success: false, error: { issues: [] } } }),
+  );
+
   await expect(service.preparePronunciation(INPUT)).rejects.toMatchObject({ code: 'invalid_input' });
 });
 ```
 
-Add cases for every stable code, exact legacy 400 message, status-only 503/504, uncoded 500, client deadline/network, and structural success failure.
+Add explicit cases for each stable code, both exact legacy 400 messages, status-only 503 and 504, uncoded 500, client deadline/network, and structurally invalid 2xx response.
 
-- [ ] **Step 2: Write failing cache and single-flight tests**
-
-Cover:
+- [ ] **Step 2: Write failing single-flight and cache tests**
 
 ```ts
-it('shares generation after settings-derived full-key resolution', async () => { /* two callers, one POST */ });
-it('creates a distinct key after voice/model changes', async () => { /* two POSTs */ });
-it('expires memory URLs after 14 minutes', async () => { /* fake timers */ });
-it('evicts the least-recently-used item above 300 entries', async () => { /* deterministic loop */ });
-it('sweeps expired entries every five minutes', async () => { /* fake timers */ });
-```
+it('shares generation after resolving the same settings-derived key', async () => {
+  api.getJson.mockResolvedValue(CONFIGURED_SETTINGS);
+  const generation = deferred<unknown>();
+  api.postJson.mockReturnValue(generation.promise);
 
-- [ ] **Step 3: Write failing invalidation-generation tests**
+  const first = service.preparePronunciation(INPUT);
+  const second = service.preparePronunciation(INPUT);
+  generation.resolve({ audioUrl: HTTPS_AUDIO, cached: false });
 
-```ts
-it('invalidates every settings partition for one user and vocabulary', () => {
-  // Seed provider A and provider B entries, invalidate, then require both to re-fetch.
+  await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+  expect(api.postJson).toHaveBeenCalledTimes(1);
 });
 
-it('prevents stale pending completion from repopulating after invalidation', async () => {
-  const pending = service.preparePronunciation(INPUT);
-  service.invalidatePronunciation('user-1', '水:ミズ');
-  resolveGenerate({ audioUrl: HTTPS_URL, cached: false });
-  await pending;
+it('uses a distinct key after voice changes', async () => {
+  api.getJson
+    .mockResolvedValueOnce(CONFIGURED_SETTINGS)
+    .mockResolvedValueOnce({ ...CONFIGURED_SETTINGS, voiceId: 'nova' });
+  api.postJson
+    .mockResolvedValueOnce({ audioUrl: HTTPS_AUDIO, cached: false })
+    .mockResolvedValueOnce({ audioUrl: 'https://audio.example.test/mizu-nova.mp3', cached: false });
+
+  await service.preparePronunciation(INPUT);
   await service.preparePronunciation(INPUT);
   expect(api.postJson).toHaveBeenCalledTimes(2);
 });
 ```
 
-- [ ] **Step 4: Run focused tests and confirm failure**
+Add fake-timer tests for 14-minute expiry, five-minute sweeps, LRU refresh, and 300-entry eviction.
+
+- [ ] **Step 3: Write failing invalidation-generation tests**
+
+```ts
+it('removes every settings partition for one user and vocabulary', async () => {
+  await seedPrepared(service, INPUT, CONFIGURED_SETTINGS, HTTPS_AUDIO);
+  await seedPrepared(
+    service,
+    INPUT,
+    { ...CONFIGURED_SETTINGS, voiceId: 'nova' },
+    'https://audio.example.test/mizu-nova.mp3',
+  );
+
+  service.invalidatePronunciation('user-1', '水:ミズ');
+  expect(service.inspectForTests().matchingCacheEntries('user-1', '水:ミズ')).toBe(0);
+});
+
+it('does not cache a stale completion after invalidation', async () => {
+  api.getJson.mockResolvedValue(CONFIGURED_SETTINGS);
+  const generation = deferred<unknown>();
+  api.postJson.mockReturnValue(generation.promise);
+
+  const first = service.preparePronunciation(INPUT);
+  service.invalidatePronunciation('user-1', '水:ミズ');
+  generation.resolve({ audioUrl: HTTPS_AUDIO, cached: false });
+  await first;
+
+  api.postJson.mockResolvedValue({ audioUrl: HTTPS_AUDIO, cached: true });
+  await service.preparePronunciation(INPUT);
+  expect(api.postJson).toHaveBeenCalledTimes(2);
+});
+```
+
+Expose deterministic test inspection only when the project already accepts test-only exports; otherwise assert through public request counts.
+
+- [ ] **Step 4: Run focused tests and verify red**
 
 ```bash
 bun run --cwd apps/vela-mobile test:unit -- src/services/mobile-tts.test.ts
 ```
 
-Expected: FAIL because `mobile-tts.ts` does not exist.
+Expected: module does not exist.
 
-- [ ] **Step 5: Implement public types and ordered error normalization**
+- [ ] **Step 5: Implement public types and ordered error mapping**
 
 ```ts
 export const MOBILE_TTS_GENERATE_TIMEOUT_MS = 45_000;
+
+export type PreparationTimings = { settingsMs: number; generateMs: number };
 
 export type PreparedPronunciation = {
   audioUrl: string;
   source: 'memory-cache' | 'server-cache' | 'generated';
   expiresAt: number;
-  timings: { settingsMs: number; generateMs: number };
+  timings: PreparationTimings;
 };
-
-function normalizeTtsError(error: unknown): never {
-  // 1 stable code, 2 exact legacy 400 message, 3 auth/session/network,
-  // 4 status mapping, 5 generation_failed fallback.
-}
 ```
 
-Do not expose `serverBody` or `serverMessage` through `MobileTtsError`.
+Map in this order: recognized stable code, exact legacy 400 message, auth/session/network code, HTTP status, structural response failure.
 
-- [ ] **Step 6: Implement preparation, cache, and full-key pending index**
+- [ ] **Step 6: Implement preparation and cache semantics**
 
-Use encoded key components:
+Fetch settings before deriving the key. Record settings and generation timings separately. Use encoded key components:
 
 ```ts
-const key = [userId, vocabularyId, provider, voiceId ?? '', model ?? '']
+const cacheKey = [userId, vocabularyId, provider, voiceId ?? '', model ?? '']
   .map(encodeURIComponent)
   .join('|');
 ```
 
-Fetch settings before checking the full-key cache or pending map. Record settings and generate timings separately. Set local expiry to `now + 14 * 60_000`.
+Use `now + 14 * 60_000` expiry, 300-entry LRU bound, and five-minute sweep interval. Do not include text in only the client key; document the fixed-pair precondition in code.
 
-- [ ] **Step 7: Implement invalidation generations**
+- [ ] **Step 7: Implement per-user and per-user/vocabulary invalidation generations**
 
-Maintain:
+Capture both generations before generation. Cache only when both still match. Remove matching pending records from the join index during invalidation, but do not abort work already awaited by existing callers.
 
-```ts
-const userGeneration = new Map<string, number>();
-const vocabularyGeneration = new Map<string, number>();
-```
-
-Capture both before generation. Cache only when both still match. Targeted invalidation removes all matching cache/pending-index entries without aborting existing callers.
-
-- [ ] **Step 8: Run focused tests and typecheck**
+- [ ] **Step 8: Run green tests and commit**
 
 ```bash
 bun run --cwd apps/vela-mobile test:unit -- src/services/mobile-tts.test.ts
 bun run --cwd apps/vela-mobile typecheck
-```
 
-Expected: PASS.
-
-- [ ] **Step 9: Commit**
-
-```bash
 git add apps/vela-mobile/src/services/mobile-tts.ts \
   apps/vela-mobile/src/services/mobile-tts.test.ts
 git commit -m "feat(mobile): add authenticated TTS service"
@@ -685,7 +726,7 @@ git commit -m "feat(mobile): add authenticated TTS service"
 
 ---
 
-### Task 6: Register TTS Services and Install Auth Isolation
+### Task 6: Register MobileTtsService and Clear Prior-User Cache on Auth Transitions
 
 **Files:**
 - Modify: `apps/vela-mobile/src/services/mobile-services.ts`
@@ -696,28 +737,49 @@ git commit -m "feat(mobile): add authenticated TTS service"
 - Modify: `apps/vela-mobile/src/boot/mobile-auth.test.ts`
 
 **Interfaces:**
-- Produces: `MOBILE_TTS_SERVICE_KEY` and an auth-isolation disposer.
-- Consumes: coordinator state and `MobileTtsService.clearUser()`.
+- Produces: `MOBILE_TTS_SERVICE_KEY` and `installMobileTtsAuthIsolation()`.
+- Responsibility boundary: this watcher clears app-wide TTS cache/pending indexes only; the mounted controller owns active audio stop/dispose.
 
-- [ ] **Step 1: Write failing service-registry tests**
-
-```ts
-expect(app.provide).toHaveBeenCalledWith(MOBILE_TTS_SERVICE_KEY, expect.any(Object));
-```
-
-Assert the same `MobileApiClient` instance is passed to both SRS and TTS services.
-
-- [ ] **Step 2: Write failing auth-isolation tests**
-
-Cover prior-user sign-out, identity replacement, null-to-user no-op, unusable recovery detach, and a successor authenticating while asynchronous prior cleanup is queued.
+- [ ] **Step 1: Write failing registry tests**
 
 ```ts
-expect(tts.clearUser).toHaveBeenCalledWith('previous-user');
-expect(tts.clearUser).not.toHaveBeenCalledWith('successor-user');
-expect(stopPlayback).toHaveBeenCalledTimes(1);
+it('provides SRS and TTS services from one API client', () => {
+  provideMobileServices(app, coordinator);
+  expect(app.provide).toHaveBeenCalledWith(MOBILE_API_CLIENT_KEY, expect.any(Object));
+  expect(app.provide).toHaveBeenCalledWith(MOBILE_SRS_SERVICE_KEY, expect.any(Object));
+  expect(app.provide).toHaveBeenCalledWith(MOBILE_TTS_SERVICE_KEY, expect.any(Object));
+});
 ```
 
-- [ ] **Step 3: Run focused tests and confirm failure**
+- [ ] **Step 2: Write failing isolation tests**
+
+```ts
+it('clears only the previous user on identity replacement', async () => {
+  const state = reactive(authenticatedState('user-a'));
+  const tts = { clearUser: vi.fn() };
+  installMobileTtsAuthIsolation({ state, ttsService: tts as MobileTtsService });
+
+  Object.assign(state, authenticatedState('user-b'));
+  await nextTick();
+
+  expect(tts.clearUser).toHaveBeenCalledWith('user-a');
+  expect(tts.clearUser).not.toHaveBeenCalledWith('user-b');
+});
+
+it('does nothing for null to user transition', async () => {
+  const state = reactive(signedOutState());
+  const tts = { clearUser: vi.fn() };
+  installMobileTtsAuthIsolation({ state, ttsService: tts as MobileTtsService });
+
+  Object.assign(state, authenticatedState('user-a'));
+  await nextTick();
+  expect(tts.clearUser).not.toHaveBeenCalled();
+});
+```
+
+Add sign-out, cleanup retry, unusable recovery, and successor-race cases modeled after `mobile-query-auth-isolation.test.ts`.
+
+- [ ] **Step 3: Run focused tests and verify red**
 
 ```bash
 bun run --cwd apps/vela-mobile test:unit -- \
@@ -726,52 +788,43 @@ bun run --cwd apps/vela-mobile test:unit -- \
   src/boot/mobile-auth.test.ts
 ```
 
-Expected: FAIL because TTS registration/isolation do not exist.
+Expected: TTS key and isolation installer are absent.
 
-- [ ] **Step 4: Implement registry wiring**
+- [ ] **Step 4: Register the service and install prior-user cleanup**
 
 ```ts
 export const MOBILE_TTS_SERVICE_KEY: InjectionKey<MobileTtsService> = Symbol('mobile-tts-service');
 
+const apiClient = createMobileApiClient(coordinator);
+const srsService = createMobileSrsService(apiClient);
 const ttsService = createMobileTtsService(apiClient);
-app.provide(MOBILE_TTS_SERVICE_KEY, ttsService);
 ```
 
-Return the created services from an internal factory if tests need direct access; keep public app wiring unchanged.
+Install a serialized watcher that captures the previous user ID and calls only `ttsService.clearUser(previousUserId)`. Do not use `queryClient.clear()` and do not clear successor state.
 
-- [ ] **Step 5: Implement prior-user-only isolation watcher**
+- [ ] **Step 5: Wire the watcher from existing mobile boot**
 
-Model it after `mobile-query-auth-isolation.ts`, but call only TTS cleanup and a supplied playback stop callback. Serialize cleanup and re-check user identity after awaited work; never clear a null or successor identity.
+After providing services, install the watcher with the coordinator's readonly state. Expose a testable factory return value rather than duplicating construction in tests.
 
-- [ ] **Step 6: Wire isolation in mobile boot**
-
-Install after services and coordinator exist. Store the disposer if boot teardown has an established hook; otherwise expose it for tests and document app-lifetime ownership.
-
-- [ ] **Step 7: Run focused tests**
+- [ ] **Step 6: Run green tests and commit**
 
 ```bash
 bun run --cwd apps/vela-mobile test:unit -- \
   src/services/mobile-services.test.ts \
   src/services/mobile-tts-auth-isolation.test.ts \
   src/boot/mobile-auth.test.ts
-```
 
-Expected: PASS.
-
-- [ ] **Step 8: Commit**
-
-```bash
 git add apps/vela-mobile/src/services/mobile-services.ts \
   apps/vela-mobile/src/services/mobile-services.test.ts \
   apps/vela-mobile/src/services/mobile-tts-auth-isolation.ts \
   apps/vela-mobile/src/services/mobile-tts-auth-isolation.test.ts \
   apps/vela-mobile/src/boot/mobile-auth.ts apps/vela-mobile/src/boot/mobile-auth.test.ts
-git commit -m "feat(mobile): register and isolate TTS services"
+git commit -m "feat(mobile): register and isolate TTS service"
 ```
 
 ---
 
-### Task 7: Implement the Browser-Free Audio Contract and HTML Adapter
+### Task 7: Add Browser-Free Audio Contract and HTML Adapter
 
 **Files:**
 - Create: `apps/vela-mobile/src/audio/mobile-audio-contract.ts`
@@ -779,37 +832,41 @@ git commit -m "feat(mobile): register and isolate TTS services"
 - Create: `apps/vela-mobile/src/audio/html-audio-player.test.ts`
 
 **Interfaces:**
-- Produces: `MobileAudioPlayer`, `MobileAudioPlaybackHandle`, `MobileAudioPlaybackOutcome`, and `MobileAudioError`.
-- Consumers: pronunciation controller and future native adapter.
+- Produces: `MobileAudioPlayer`, `MobileAudioPlaybackHandle`, `MobileAudioPlaybackOutcome`, `MobileAudioError`.
 
-- [ ] **Step 1: Write failing adapter tests with an injected audio factory**
-
-Create a deterministic fake element supporting `play`, `pause`, `currentTime`, `src`, event listeners, and synchronous `pause` dispatch.
-
-Test:
+- [ ] **Step 1: Write a deterministic fake audio element and failing tests**
 
 ```ts
 it('settles restart before synchronous pause can become interruption', async () => {
-  const first = player.play(URL_A);
-  const second = player.play(URL_B);
+  const first = player.play('https://audio.example.test/one.mp3');
+  const second = player.play('https://audio.example.test/two.mp3');
+
   await expect(first.finished).resolves.toEqual({ kind: 'stopped', reason: 'restart' });
-  expect(activeElements()).toHaveLength(1);
-  fakeFor(URL_B).dispatch('ended');
+  expect(factory.activeElements()).toHaveLength(1);
+
+  factory.elementFor('https://audio.example.test/two.mp3').dispatch('ended');
   await expect(second.finished).resolves.toEqual({ kind: 'ended' });
+});
+
+it('maps a rejected play caused by user activation to gesture_required', async () => {
+  factory.nextPlayError = new DOMException('Not allowed', 'NotAllowedError');
+  await expect(player.play('https://audio.example.test/mizu.mp3').finished).rejects.toMatchObject({
+    code: 'gesture_required',
+  });
 });
 ```
 
-Also cover `NotAllowedError`, media error, generic play rejection, external pause, explicit stop, dispose, listener removal, and exactly-once settlement.
+Add explicit tests for media error, generic play rejection, external pause, explicit stop, background interruption, dispose, listener cleanup, and exactly-once settlement.
 
-- [ ] **Step 2: Run focused tests and confirm failure**
+- [ ] **Step 2: Run focused tests and verify red**
 
 ```bash
 bun run --cwd apps/vela-mobile test:unit -- src/audio/html-audio-player.test.ts
 ```
 
-Expected: FAIL because audio files do not exist.
+Expected: audio modules do not exist.
 
-- [ ] **Step 3: Define browser-free interfaces**
+- [ ] **Step 3: Define the DOM-free contract**
 
 ```ts
 export type MobileAudioPlaybackOutcome =
@@ -824,24 +881,16 @@ export type MobileAudioPlayer = {
 };
 ```
 
-No DOM types appear in this file.
+- [ ] **Step 4: Implement strict cleanup ordering**
 
-- [ ] **Step 4: Implement `HtmlAudioPlayer` with strict cleanup ordering**
+Before calling `pause()`, mark the handle settled, detach listeners, and clear active ownership. Set `preload = 'auto'`; do not set `crossOrigin`; clear `src` only after listener removal.
 
-Before `pause()`, mark settled, detach listeners, and clear active ownership. Set `preload = 'auto'`. Do not set `crossOrigin`. Clear `src` only after listeners are detached.
-
-- [ ] **Step 5: Run tests and typecheck**
+- [ ] **Step 5: Run green tests and commit**
 
 ```bash
 bun run --cwd apps/vela-mobile test:unit -- src/audio/html-audio-player.test.ts
 bun run --cwd apps/vela-mobile typecheck
-```
 
-Expected: PASS.
-
-- [ ] **Step 6: Commit**
-
-```bash
 git add apps/vela-mobile/src/audio/mobile-audio-contract.ts \
   apps/vela-mobile/src/audio/html-audio-player.ts \
   apps/vela-mobile/src/audio/html-audio-player.test.ts
@@ -850,7 +899,7 @@ git commit -m "feat(mobile): add replaceable HTML audio adapter"
 
 ---
 
-### Task 8: Extend Shared Mobile Lifecycle State Without Adding a Native Listener
+### Task 8: Extend Shared Lifecycle State Through the Existing Listener
 
 **Files:**
 - Modify: `apps/vela-mobile/src/services/mobile-lifecycle.ts`
@@ -859,13 +908,12 @@ git commit -m "feat(mobile): add replaceable HTML audio adapter"
 - Create or modify: `apps/vela-mobile/src/boot/capacitor-lifecycle.test.ts`
 
 **Interfaces:**
-- Produces: `mobileLifecycleState.isActive`, state timestamps, and `recordAppStateChange()`.
-- Consumers: pronunciation controller.
+- Produces: `mobileLifecycleState.isActive`, transition timestamps, and `recordAppStateChange()`.
 
-- [ ] **Step 1: Write failing lifecycle-state tests**
+- [ ] **Step 1: Write failing lifecycle tests**
 
 ```ts
-it('records active and inactive transitions without incrementing resume count', () => {
+it('records app-state transitions without incrementing resume count', () => {
   resetMobileLifecycleForTests();
   recordAppStateChange(false, 100);
   expect(mobileLifecycleState.isActive.value).toBe(false);
@@ -878,11 +926,11 @@ it('records active and inactive transitions without incrementing resume count', 
 });
 ```
 
-- [ ] **Step 2: Write failing boot-listener tests**
+- [ ] **Step 2: Write failing boot ownership tests**
 
-Capture the existing `appStateChange` callback. Assert it calls `recordAppStateChange(isActive)` and `focusManager.setFocused(isActive)`. Assert only the existing listener is registered.
+Capture the existing `appStateChange` callback and assert one invocation updates both shared lifecycle state and TanStack focus. Assert registration count remains one in this boot module.
 
-- [ ] **Step 3: Run focused tests and confirm failure**
+- [ ] **Step 3: Run focused tests and verify red**
 
 ```bash
 bun run --cwd apps/vela-mobile test:unit -- \
@@ -890,16 +938,11 @@ bun run --cwd apps/vela-mobile test:unit -- \
   src/boot/capacitor-lifecycle.test.ts
 ```
 
-Expected: FAIL because active state/timestamps do not exist.
+Expected: active state and recorder are absent.
 
-- [ ] **Step 4: Implement state and canonical recorder**
+- [ ] **Step 4: Implement state and recorder**
 
 ```ts
-const isActive = ref(true);
-const lastStateChangeAt = ref<number | null>(null);
-const lastBecameActiveAt = ref<number | null>(null);
-const lastBecameInactiveAt = ref<number | null>(null);
-
 export function recordAppStateChange(next: boolean, at = Date.now()): void {
   isActive.value = next;
   lastStateChangeAt.value = at;
@@ -908,9 +951,9 @@ export function recordAppStateChange(next: boolean, at = Date.now()): void {
 }
 ```
 
-Reset every field in `resetMobileLifecycleForTests()`.
+Reset all new refs in `resetMobileLifecycleForTests()`.
 
-- [ ] **Step 5: Feed state from the existing boot listener**
+- [ ] **Step 5: Feed state from the existing boot callback**
 
 ```ts
 await adapter.addListener('appStateChange', (event) => {
@@ -919,9 +962,9 @@ await adapter.addListener('appStateChange', (event) => {
 });
 ```
 
-Do not touch the auth coordinator's private listener.
+Do not change the auth coordinator's private lifecycle listener.
 
-- [ ] **Step 6: Run tests and commit**
+- [ ] **Step 6: Run green tests and commit**
 
 ```bash
 bun run --cwd apps/vela-mobile test:unit -- \
@@ -937,58 +980,70 @@ git commit -m "feat(mobile): expose shared app activity state"
 
 ---
 
-### Task 9: Implement the Pronunciation Controller State Machine
+### Task 9: Implement Pronunciation Controller State Machine
 
 **Files:**
 - Create: `apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts`
 - Create: `apps/vela-mobile/src/composables/usePronunciationDiagnostic.test.ts`
 
 **Interfaces:**
-- Consumes: `MobileTtsService`, `MobileAudioPlayer`, coordinator feature-session status, and shared lifecycle state.
-- Produces: `PronunciationDiagnosticState`, `playOrRetry()`, `invalidateForTest()`, `simulateInvalidUrlForTest()`, counters, and `dispose()`.
+- Consumes: `MobileTtsService`, `MobileAudioPlayer`, feature-session selector, and shared lifecycle state.
+- Produces: controller state, `playOrRetry()`, diagnostic invalidation actions, counters, and `dispose()`.
 
 - [ ] **Step 1: Write failing happy-path and gesture tests**
 
 ```ts
-it('moves idle -> preparing -> playing -> ready', async () => { /* resolve service, end audio */ });
-it('keeps a prepared URL when async first play requires a direct second tap', async () => {
-  audio.play.mockReturnValueOnce(rejectedHandle(new MobileAudioError('gesture_required')));
-  await controller.playOrRetry();
+it('moves idle to preparing to playing to ready', async () => {
+  tts.preparePronunciation.mockResolvedValue(PREPARED);
+  const handle = controllablePlaybackHandle();
+  audio.play.mockReturnValue(handle.publicHandle);
+  const controller = createController();
+
+  const action = controller.playOrRetry();
+  await flushPromises();
+  expect(controller.state.value.kind).toBe('playing');
+
+  handle.resolve({ kind: 'ended' });
+  await action;
   expect(controller.state.value.kind).toBe('ready');
-  expect(controller.state.value.notice).toBe('gesture_required');
+  expect(controller.counters.completedPlays.value).toBe(1);
+});
+
+it('retains prepared audio after gesture rejection', async () => {
+  tts.preparePronunciation.mockResolvedValue(PREPARED);
+  audio.play.mockReturnValue(rejectedPlaybackHandle(new MobileAudioError('gesture_required')));
+  const controller = createController();
+
+  await controller.playOrRetry();
+  expect(controller.state.value).toMatchObject({ kind: 'ready', notice: 'gesture_required' });
 });
 ```
 
-Assert settings/generate timings and tap-to-play latency are recorded separately.
+- [ ] **Step 2: Write failing concurrency and live-replay tests**
 
-- [ ] **Step 2: Write failing concurrency and replay tests**
+Use deferred preparation and playback handles. Assert a second tap during preparation makes no second service call; a tap during playback settles the first handle as restart before starting the second; a live ready tap calls audio directly and makes no settings/generate request.
 
-Cover disabled/ignored tap during preparation, deterministic restart during playing, no overlap, ready live replay with no service call, and one active playback.
+- [ ] **Step 3: Write failing recovery tests**
 
-- [ ] **Step 3: Write failing error/recovery tests**
+Create named cases that assert:
 
-Cover:
+```ts
+expect(tts.preparePronunciation).toHaveBeenCalledTimes(1); // network failure: no auto retry
+expect(tts.preparePronunciation).toHaveBeenCalledTimes(2); // one same-user session_changed retry
+expect(tts.invalidatePronunciation).toHaveBeenCalledWith('user-1', '水:ミズ'); // expiry/media
+```
 
-- manual-only network/provider/server/invalid-input failures;
-- one same-user `session_changed`/`session_unavailable` retry;
-- one recovery-pending continuation after same user becomes usable;
-- second control failure visible;
-- identity change cancels continuation;
-- proactive expiry before audio creation;
-- one media-unavailable refresh per tap;
-- refresh failure visible without transport auto-retry;
-- background interruption, no auto-resume, explicit replay;
-- sign-out/dispose cancels or detaches stale completion.
+Add cases for recovery-pending continuation, second control failure, identity replacement, one media refresh per tap, refresh failure, background interruption, no auto-resume, and stale completion after dispose.
 
-- [ ] **Step 4: Run focused tests and confirm failure**
+- [ ] **Step 4: Run focused tests and verify red**
 
 ```bash
 bun run --cwd apps/vela-mobile test:unit -- src/composables/usePronunciationDiagnostic.test.ts
 ```
 
-Expected: FAIL because controller does not exist.
+Expected: controller does not exist.
 
-- [ ] **Step 5: Implement state model and operation ownership**
+- [ ] **Step 5: Implement state and operation generations**
 
 ```ts
 export type PronunciationDiagnosticState =
@@ -1000,24 +1055,18 @@ export type PronunciationDiagnosticState =
   | { kind: 'error'; error: PronunciationDiagnosticError; pronunciation: PreparedPronunciation | null };
 ```
 
-Use an operation generation counter so old promises cannot overwrite successor state.
+Use an operation generation counter to prevent old promises from writing successor state.
 
-- [ ] **Step 6: Implement tap, auth continuation, expiry, and playback result handling**
+- [ ] **Step 6: Implement manual retry, auth continuation, expiry, and lifecycle behavior**
 
-Keep transport retries manual. Reuse live prepared URLs directly. Invalidate all settings partitions on expiry/media failure. Stop playback before restart. Observe shared `isActive` rather than registering a native listener.
+Retry transport failures only after a new explicit action. Permit one same-user control/recovery continuation. Invalidate every settings partition on local expiry or media failure. Stop active audio on identity loss, unmount, and inactive lifecycle state; never auto-resume.
 
-- [ ] **Step 7: Run focused tests and typecheck**
+- [ ] **Step 7: Run green tests and commit**
 
 ```bash
 bun run --cwd apps/vela-mobile test:unit -- src/composables/usePronunciationDiagnostic.test.ts
 bun run --cwd apps/vela-mobile typecheck
-```
 
-Expected: PASS.
-
-- [ ] **Step 8: Commit**
-
-```bash
 git add apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts \
   apps/vela-mobile/src/composables/usePronunciationDiagnostic.test.ts
 git commit -m "feat(mobile): add pronunciation diagnostic controller"
@@ -1025,7 +1074,7 @@ git commit -m "feat(mobile): add pronunciation diagnostic controller"
 
 ---
 
-### Task 10: Add the Authenticated Development Diagnostic Route and More Entry
+### Task 10: Add Authenticated Development Route and More Entry
 
 **Files:**
 - Create: `apps/vela-mobile/src/diagnostics/tts-pronunciation-contract.ts`
@@ -1037,25 +1086,36 @@ git commit -m "feat(mobile): add pronunciation diagnostic controller"
 - Modify: `apps/vela-mobile/src/pages/MorePage.test.ts`
 
 **Interfaces:**
-- Produces: `TTS_PRONUNCIATION_DIAGNOSTIC_PATH`, fixed word, labels, markers, and route registration.
-- Consumes: existing mobile navigation helpers.
+- Produces: route path, fixed word, labels, markers, test IDs, and split route collections.
 
 - [ ] **Step 1: Write failing route-partition tests**
 
 ```ts
-expect(bypassDevelopmentDiagnosticRoutes.every((r) => r.meta?.bypassMobileAuth === true)).toBe(true);
+expect(bypassDevelopmentDiagnosticRoutes.every((route) => route.meta?.bypassMobileAuth === true)).toBe(true);
 expect(authenticatedDevelopmentDiagnosticRoutes).toHaveLength(1);
 expect(authenticatedDevelopmentDiagnosticRoutes[0]?.path).toBe('diagnostics/tts-pronunciation');
 expect(authenticatedDevelopmentDiagnosticRoutes[0]?.meta?.bypassMobileAuth).not.toBe(true);
+expect(developmentDiagnosticRoutes).toEqual([
+  ...bypassDevelopmentDiagnosticRoutes,
+  ...authenticatedDevelopmentDiagnosticRoutes,
+]);
 ```
 
-Keep the combined `developmentDiagnosticRoutes` and production five-route assertions.
+Retain the production five-shell-route assertion.
 
-- [ ] **Step 2: Write failing entry/More tests**
+- [ ] **Step 2: Write failing entry tests**
 
-Assert development builds render the lazy entry, clicking it calls `pushMobileRoute(router, TTS_PRONUNCIATION_DIAGNOSTIC_PATH)`, and production builds omit it.
+```ts
+it('navigates to authenticated TTS diagnostics', async () => {
+  const wrapper = mountEntry();
+  await wrapper.get('[data-testid="tts-pronunciation-entry"]').trigger('click');
+  expect(pushMobileRoute).toHaveBeenCalledWith(router, '/diagnostics/tts-pronunciation');
+});
+```
 
-- [ ] **Step 3: Run focused tests and confirm failure**
+Add More-page tests proving development inclusion and production omission.
+
+- [ ] **Step 3: Run focused tests and verify red**
 
 ```bash
 bun run --cwd apps/vela-mobile test:unit -- \
@@ -1064,9 +1124,9 @@ bun run --cwd apps/vela-mobile test:unit -- \
   src/pages/MorePage.test.ts
 ```
 
-Expected: FAIL because contract, route, and entry do not exist.
+Expected: route contract and entry are absent.
 
-- [ ] **Step 4: Define diagnostic constants**
+- [ ] **Step 4: Define constants and split routes**
 
 ```ts
 export const TTS_PRONUNCIATION_DIAGNOSTIC_PATH = '/diagnostics/tts-pronunciation';
@@ -1079,17 +1139,13 @@ export const DIAGNOSTIC_WORD = {
 } as const;
 ```
 
-Add unique marker/test ID strings for production scanning.
+Keep current iOS interaction routes in `bypassDevelopmentDiagnosticRoutes`; add TTS only to `authenticatedDevelopmentDiagnosticRoutes` with fallback `/more` and no bypass metadata.
 
-- [ ] **Step 5: Split route arrays and add authenticated route**
+- [ ] **Step 5: Add development-only More entry**
 
-Keep existing iOS interaction routes in the bypass array. Add the TTS page only to the authenticated array with header fallback `/more` and no auth bypass.
+Follow the existing lazy entry pattern and use `import.meta.env.DEV` as the only exposure switch.
 
-- [ ] **Step 6: Add the More entry**
-
-Follow the existing lazy diagnostic-entry pattern. Render it only when `import.meta.env.DEV` is true.
-
-- [ ] **Step 7: Run tests and commit**
+- [ ] **Step 6: Run green tests and commit**
 
 ```bash
 bun run --cwd apps/vela-mobile test:unit -- \
@@ -1108,106 +1164,109 @@ git commit -m "feat(mobile): register authenticated TTS diagnostics"
 
 ---
 
-### Task 11: Build the Diagnostic Page and Accessible State Presentation
+### Task 11: Build Accessible Diagnostic Page
 
 **Files:**
 - Create: `apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.vue`
 - Create: `apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts`
 
 **Interfaces:**
-- Consumes: `usePronunciationDiagnostic`, fixed word, audio adapter factory, mobile TTS service injection, and coordinator state.
-- Produces: accessible diagnostic controls, counters, latency displays, safe error summaries, and development controls.
+- Consumes: controller, fixed word, injected TTS service/coordinator, and HTML audio player factory.
+- Produces: accessible controls, safe counters, timings, and development actions.
 
-- [ ] **Step 1: Write failing page tests for visible states**
-
-Cover idle, preparing, recovering session, playing, ready/completed, gesture-required, interrupted, invalid input, network/deadline, provider timeout, service unavailable, refreshed URL, and playback failure.
+- [ ] **Step 1: Write failing state-rendering tests**
 
 ```ts
-expect(wrapper.get('[data-testid="tts-play-button"]').attributes('aria-label')).toBe(
-  'Prepare and play pronunciation',
-);
-expect(wrapper.get('[role="status"]').text()).toContain('Preparing pronunciation');
+it('renders idle and preparing states accessibly', async () => {
+  const wrapper = mountPageWithController(idleController());
+  expect(wrapper.get('[data-testid="tts-play-button"]').attributes('aria-label')).toBe(
+    'Prepare and play pronunciation',
+  );
+
+  controller.state.value = { kind: 'preparing', attempt: 1, recoveringSession: false };
+  await nextTick();
+  expect(wrapper.get('[role="status"]').text()).toContain('Preparing pronunciation');
+  expect(wrapper.get('[data-testid="tts-play-button"]').attributes('disabled')).toBeDefined();
+});
 ```
 
-- [ ] **Step 2: Write failing safety/accessibility tests**
+Add explicit fixtures for recovering, playing, completed, gesture-required, interrupted, invalid-input, network/deadline, provider-timeout, service-unavailable, refreshed-URL, and playback-failure states.
 
-Assert:
+- [ ] **Step 2: Write failing safety tests**
 
-- word, reading, and translation render;
-- `role=status`, `aria-live=polite`, and `role=alert` are used appropriately;
-- source/settings/generate/tap timings are labeled diagnostic-only;
-- complete signed URL never renders;
-- `serverBody`/`serverMessage` never render;
-- button is disabled during preparation and reflects retry/restart labels;
-- diagnostic invalidation/simulated-invalid-URL controls call controller methods.
+```ts
+it('never renders internal server details or a signed query string', () => {
+  const wrapper = mountFailurePage({
+    safeCode: 'generation_failed',
+    signedUrl: 'https://s3.example.test/mizu?X-Amz-Signature=secret',
+    serverMessage: 'provider credential rejected',
+  });
 
-- [ ] **Step 3: Run focused tests and confirm failure**
+  expect(wrapper.text()).not.toContain('X-Amz-Signature');
+  expect(wrapper.text()).not.toContain('provider credential rejected');
+});
+```
+
+Assert role/live-region usage, word/reading/translation, timing labels, retry/restart labels, and diagnostic invalidation actions.
+
+- [ ] **Step 3: Run focused tests and verify red**
 
 ```bash
 bun run --cwd apps/vela-mobile test:unit -- \
   src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts
 ```
 
-Expected: FAIL because page does not exist.
+Expected: page does not exist.
 
-- [ ] **Step 4: Implement the page**
+- [ ] **Step 4: Implement page using only controller-safe state**
 
-Inject dependencies and instantiate the controller. Do not access Cognito tokens or call APIs directly. Render only safe stable error labels. Redact URL to hostname plus a non-query suffix only when diagnostic detail is enabled.
+Do not call API or auth methods directly. Render stable user messages, diagnostic source/timings, redacted host/path only, and controller actions. Dispose controller on unmount.
 
-- [ ] **Step 5: Dispose on unmount and stop playback**
-
-```ts
-onUnmounted(() => controller.dispose());
-```
-
-Ensure auth loss makes the route inaccessible through the existing gate and clears controller state through isolation.
-
-- [ ] **Step 6: Run page tests and typecheck**
+- [ ] **Step 5: Run green tests and commit**
 
 ```bash
 bun run --cwd apps/vela-mobile test:unit -- \
   src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts
 bun run --cwd apps/vela-mobile typecheck
-```
 
-Expected: PASS.
-
-- [ ] **Step 7: Commit**
-
-```bash
 git add apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.vue \
   apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts
-git commit -m "feat(mobile): add authenticated pronunciation diagnostic page"
+git commit -m "feat(mobile): add pronunciation diagnostic page"
 ```
 
 ---
 
-### Task 12: Prove Production Exclusion and Run the Automated Merge Gates
+### Task 12: Prove Production Exclusion and Run Automated Merge Gates
 
 **Files:**
 - Modify: `apps/vela-mobile/scripts/verify-production-diagnostics.mjs`
 - Modify: `apps/vela-mobile/scripts/verify-production-diagnostics.test.mjs`
-- Modify as needed: existing tests touched by Tasks 1–11
 
 **Interfaces:**
-- Consumes: forbidden tokens from the TTS diagnostic contract.
-- Produces: production-bundle leak detection and a complete automated validation record for the PR.
+- Produces: production-bundle leak detection for every TTS diagnostic token.
 
 - [ ] **Step 1: Write failing scanner tests**
 
-Add each TTS diagnostic marker, route, label, and test ID to a synthetic bundle and assert verification fails. Assert a normal production bundle passes.
+```js
+it('rejects a production bundle containing TTS diagnostic tokens', async () => {
+  await writeBundle('Pronunciation diagnostics /diagnostics/tts-pronunciation tts-pronunciation-entry');
+  await expect(verifyProductionDiagnostics()).rejects.toThrow('tts-pronunciation');
+});
+```
 
-- [ ] **Step 2: Run scanner tests and confirm failure**
+Keep the existing success fixture and iOS interaction token cases.
+
+- [ ] **Step 2: Run scanner test and verify red**
 
 ```bash
 bun test apps/vela-mobile/scripts/verify-production-diagnostics.test.mjs
 ```
 
-Expected: FAIL because the scanner does not know TTS tokens.
+Expected: TTS token fixture is not detected.
 
-- [ ] **Step 3: Extend forbidden-token scanning**
+- [ ] **Step 3: Extend scanner with build-safe literal tokens**
 
-Import or duplicate only build-safe literal tokens according to the existing script structure. Do not import Vue/browser code into the Node verification script.
+Do not import Vue/browser modules into the Node verification script. Include route, label, marker, and test ID.
 
 - [ ] **Step 4: Run all focused suites**
 
@@ -1231,7 +1290,7 @@ bun run --cwd apps/vela-mobile test:unit -- \
   src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts
 ```
 
-Expected: PASS.
+Expected: every focused suite exits 0.
 
 - [ ] **Step 5: Run package and repository gates**
 
@@ -1244,18 +1303,18 @@ bun run --cwd apps/vela-api typecheck
 bun run test
 ```
 
-Expected: every command exits 0. Record exact test counts and coverage in the implementation PR; do not copy counts from earlier PRs.
+Record fresh test counts and coverage in the implementation PR.
 
-- [ ] **Step 6: Build native assets and open Simulator**
+- [ ] **Step 6: Build iOS assets and project**
 
 ```bash
 bun run --cwd apps/vela-mobile build:ios:assets
 bun run --cwd apps/vela-mobile build:ios:ide
 ```
 
-Expected: production assets pass diagnostics and the Xcode project opens/builds without adding a native audio dependency.
+Expected: production diagnostics pass and the native project builds without a new audio dependency.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 7: Commit scanner changes**
 
 ```bash
 git add apps/vela-mobile/scripts/verify-production-diagnostics.mjs \
@@ -1265,24 +1324,32 @@ git commit -m "test(mobile): verify TTS diagnostic exclusion"
 
 ---
 
-### Task 13: Complete Simulator and Physical-iPhone Evidence and Record the Architecture Decision
+### Task 13: Collect Simulator and Physical-iPhone Evidence
 
 **Files:**
 - Create: `apps/vela-mobile/docs/tts-pronunciation-ios.md`
-- Modify only if evidence requires: `packages/cdk/lib/storage-stack.ts`
-- Modify only if CORS changes: `packages/cdk/test/storage-stack.test.ts`
-- Create a follow-up Linear issue only if evidence selects native audio-session or native player work.
+- Modify only after evidence: `packages/cdk/lib/storage-stack.ts`
+- Create or modify only after evidence: `packages/cdk/test/storage-stack.test.ts`
 
 **Interfaces:**
-- Produces: HPA-208 closure evidence consumed by HPA-210.
+- Produces: HPA-208 closure record consumed by HPA-210.
 
-- [ ] **Step 1: Prepare the test account and capture non-secret configuration**
+- [ ] **Step 1: Capture exact software and commit versions**
 
-Confirm the account has TTS configured through web settings. Record provider, voice, and model identifiers only. Do not record the provider key, tokens, or complete signed URLs.
+Run and paste the actual outputs into the verification record:
 
-- [ ] **Step 2: Run the Simulator matrix**
+```bash
+git rev-parse HEAD
+xcodebuild -version
+bun --version
+bun pm ls @capacitor/core quasar
+```
 
-Record exact pass/fail and timings for:
+Record Simulator model/iOS version from Xcode and physical-device model/iOS version from Settings or Xcode Devices and Simulators. Record only non-secret provider, voice, and model identifiers.
+
+- [ ] **Step 2: Run Simulator matrix and write measured rows immediately**
+
+Record pass/fail plus settings latency, generation/cache latency, and tap-to-play-attempt latency for:
 
 - restored authentication;
 - configured settings;
@@ -1291,7 +1358,7 @@ Record exact pass/fail and timings for:
 - async first-tap attempt;
 - prepared direct-tap playback;
 - ten replays;
-- rapid preparation and playback taps;
+- rapid taps during preparation and playback;
 - proactive expiry;
 - disabled network and explicit retry;
 - invalid URL refresh;
@@ -1299,52 +1366,52 @@ Record exact pass/fail and timings for:
 - sign-out ready/playing;
 - relaunch and replay.
 
-Capture settings latency, generate/cache latency, and tap-to-play-attempt latency separately.
+- [ ] **Step 3: Run physical-iPhone matrix with human speaker evidence**
 
-- [ ] **Step 3: Run the physical-iPhone matrix**
+Verify and record:
 
-Repeat the applicable Simulator matrix and additionally verify by human hearing on the built-in speaker:
-
-1. Ring/Silent off, media volume nonzero: `水` is audible and correct.
-2. Ring/Silent on, media volume nonzero: prepared direct tap is audible or inaudible.
-3. External/system audio interruption leaves playback replayable.
+1. Ring/Silent off and media volume nonzero: `水` is audible and correct through the built-in speaker.
+2. Ring/Silent on and media volume nonzero: prepared direct tap is audible or inaudible through the built-in speaker.
+3. External/system interruption leaves the controller replayable.
 4. Ten prepared replays have no intermittent silent or stuck state.
 
-Do not infer audibility from `play`, `playing`, or `ended` events.
+Do not infer audibility from media events.
 
 - [ ] **Step 4: Diagnose valid-URL failures before changing infrastructure**
 
-If valid presigned media fails, collect WebKit/native console evidence. Change S3 CORS only when evidence identifies origin rejection. Add exact `capacitor://localhost` GET/HEAD origin support, preserve web origins, and test arbitrary-origin rejection. Do not use `*`.
+If valid media fails, collect WebKit/native console evidence. Change S3 CORS only when evidence identifies origin rejection. Allow exact `capacitor://localhost` GET/HEAD access, preserve existing web origins, reject arbitrary origins, and never use `*`.
 
-- [ ] **Step 5: Write the verification record with actual observations**
+- [ ] **Step 5: Write the verification record using only actual observations**
 
-The document must contain:
+Use these section headings:
 
 ```markdown
 # iOS TTS Pronunciation Verification
 
-- Tested commit: `<actual SHA>`
-- Xcode: `<actual version>`
-- iOS Simulator/device: `<actual versions/models>`
-- Quasar/Capacitor/Bun: `<actual versions>`
-- Provider/voice/model: `<non-secret identifiers>`
-- Settings latency: `<actual measurements>`
-- Generation/cache latency: `<actual measurements>`
-- Tap-to-play-attempt latency: `<actual measurements>`
-- Normal speaker audibility: pass/fail with observation
-- Ring/Silent speaker audibility: pass/fail with observation
-- Final decision: HTML-only accepted | native audio-session integration required | native player adapter required
+## Tested Build and Environment
+## Non-Secret TTS Configuration
+## Timing Results
+## Simulator Matrix
+## Physical iPhone Matrix
+## CORS Findings
+## Known Limitations
+## Architecture Decision
+## Follow-up Issues
 ```
 
-Replace every angle-bracket value with measured evidence before committing; do not commit an incomplete record.
+Populate each section from Steps 1–4 before committing. The architecture decision must be exactly one of:
 
-- [ ] **Step 6: Create the evidence-driven follow-up when required**
+- `HTML-only accepted`
+- `native audio-session integration required`
+- `native player adapter required`
 
-If silent-mode is the only failure and HTML decoding/lifecycle are reliable, create a Linear issue for minimal app-level `AVAudioSession` `.playback` configuration while retaining `HtmlAudioPlayer`.
+- [ ] **Step 6: Create an evidence-driven Linear follow-up when required**
 
-If HTML playback remains unreliable after correct CORS/session configuration, create a Linear issue for a native implementation of `MobileAudioPlayer` and name the failed gate.
+If silent mode is the only failed gate and HTML decoding/lifecycle are reliable, create a minimal app-level `AVAudioSession` `.playback` issue that retains `HtmlAudioPlayer`.
 
-- [ ] **Step 7: Re-run automated gates after any evidence-driven code change**
+If HTML playback remains unreliable after correct CORS and audio-session configuration, create a native `MobileAudioPlayer` issue naming every failed criterion.
+
+- [ ] **Step 7: Re-run automated gates after any CORS code change**
 
 ```bash
 bun run --cwd apps/vela-mobile lint
@@ -1354,43 +1421,36 @@ bun run --cwd apps/vela-mobile verify:production-diagnostics
 bun run test
 ```
 
-Expected: all commands exit 0.
-
-- [ ] **Step 8: Commit evidence**
+- [ ] **Step 8: Commit complete evidence**
 
 ```bash
-git add apps/vela-mobile/docs/tts-pronunciation-ios.md \
-  packages/cdk/lib/storage-stack.ts packages/cdk/test/storage-stack.test.ts
+git add apps/vela-mobile/docs/tts-pronunciation-ios.md
+git add packages/cdk/lib/storage-stack.ts packages/cdk/test/storage-stack.test.ts 2>/dev/null || true
 git commit -m "docs(mobile): record iOS TTS pronunciation verification"
 ```
 
-Stage the CDK files only when they actually changed.
+Before committing, verify `git diff --cached` contains no incomplete evidence and no secrets.
 
 - [ ] **Step 9: Update HPA-208 and HPA-210**
 
-Add links to the implementation PR, tested commit, verification document, completed matrix, final architecture conclusion, and any follow-up issue. HPA-208 closes only after physical-iPhone evidence exists.
+Link the implementation PR, tested commit, verification document, completed matrix, final architecture conclusion, and any follow-up issue. Close HPA-208 only after physical-iPhone evidence exists.
 
 ---
 
-## Final Self-Review Checklist
+## Plan Self-Review Checklist
 
-Before implementation begins, confirm the plan covers every approved design requirement:
-
-- [ ] Shared TTS contracts and web parser adoption.
-- [ ] Additive backend codes and unchanged legacy messages/statuses.
-- [ ] Uncoded validator 400 mapping.
-- [ ] 8-second default, 45-second generate deadline, 15-second coordinator default, and 50-second maximum override.
-- [ ] Replayable JSON POST across one 401 recovery.
-- [ ] Bounded non-enumerable error details and safe logging.
-- [ ] Due-count 4xx retry migration regression tests.
-- [ ] Settings-derived cache key, 14-minute TTL, 300-entry bound, five-minute sweep.
-- [ ] All-partition targeted invalidation and stale-completion guards.
-- [ ] Fixed vocabulary ID/text precondition and backend collision warning.
-- [ ] Manual-only transport/provider retries and one same-user auth continuation.
-- [ ] One-active-element audio adapter and pause-ordering invariant.
-- [ ] Shared lifecycle state fed by the existing boot listener.
-- [ ] Authenticated `/diagnostics/tts-pronunciation` route with preserved bypass assertions.
-- [ ] Accessible UI, diagnostic-only timing/source metadata, and redaction.
-- [ ] Production diagnostic exclusion.
-- [ ] Simulator and physical-iPhone matrix, including human speaker audibility and silent-switch evidence.
-- [ ] Evidence-driven HTML-only/native-session/native-player conclusion.
+- [ ] Every design requirement maps to a task.
+- [ ] No `TBD`, `TODO`, incomplete evidence template, or omitted example body remains.
+- [ ] Shared parser names and mobile service types match across tasks.
+- [ ] Timeout values remain 8 seconds, 45 seconds, 15 seconds, and 50 seconds in the correct layers.
+- [ ] POST replay uses one serialized string and one post-refresh attempt.
+- [ ] Uncoded validator 400 maps to `invalid_input`.
+- [ ] Error details are bounded, non-enumerable, and excluded from UI/logging.
+- [ ] Due-count 400/500/network retry behavior is pinned.
+- [ ] Cache TTL, bound, sweep, key identity, and invalidation generations are covered.
+- [ ] Service auth isolation clears prior-user cache; controller owns active audio stop/dispose.
+- [ ] Audio cleanup ordering prevents self-generated pause interruptions.
+- [ ] Existing boot lifecycle listener is the only shared-state listener.
+- [ ] Existing bypass-route assertion remains meaningful after route splitting.
+- [ ] Production scanner covers every TTS diagnostic token.
+- [ ] Physical-device matrix requires human speaker evidence and an explicit architecture conclusion.

--- a/docs/superpowers/plans/2026-07-31-mobile-authenticated-tts-pronunciation.md
+++ b/docs/superpowers/plans/2026-07-31-mobile-authenticated-tts-pronunciation.md
@@ -1439,18 +1439,18 @@ Link the implementation PR, tested commit, verification document, completed matr
 
 ## Plan Self-Review Checklist
 
-- [ ] Every design requirement maps to a task.
-- [ ] No `TBD`, `TODO`, incomplete evidence template, or omitted example body remains.
-- [ ] Shared parser names and mobile service types match across tasks.
-- [ ] Timeout values remain 8 seconds, 45 seconds, 15 seconds, and 50 seconds in the correct layers.
-- [ ] POST replay uses one serialized string and one post-refresh attempt.
-- [ ] Uncoded validator 400 maps to `invalid_input`.
-- [ ] Error details are bounded, non-enumerable, and excluded from UI/logging.
-- [ ] Due-count 400/500/network retry behavior is pinned.
-- [ ] Cache TTL, bound, sweep, key identity, and invalidation generations are covered.
-- [ ] Service auth isolation clears prior-user cache; controller owns active audio stop/dispose.
-- [ ] Audio cleanup ordering prevents self-generated pause interruptions.
-- [ ] Existing boot lifecycle listener is the only shared-state listener.
-- [ ] Existing bypass-route assertion remains meaningful after route splitting.
-- [ ] Production scanner covers every TTS diagnostic token.
-- [ ] Physical-device matrix requires human speaker evidence and an explicit architecture conclusion.
+- [x] Every design requirement maps to a task.
+- [x] The plan contains no unresolved implementation-value placeholders or incomplete evidence template.
+- [x] Shared parser names and mobile service types match across tasks.
+- [x] Timeout values remain 8 seconds, 45 seconds, 15 seconds, and 50 seconds in the correct layers.
+- [x] POST replay uses one serialized string and one post-refresh attempt.
+- [x] Uncoded validator 400 maps to `invalid_input`.
+- [x] Error details are bounded, non-enumerable, and excluded from UI/logging.
+- [x] Due-count 400/500/network retry behavior is pinned.
+- [x] Cache TTL, bound, sweep, key identity, and invalidation generations are covered.
+- [x] Service auth isolation clears prior-user cache; controller owns active audio stop/dispose.
+- [x] Audio cleanup ordering prevents self-generated pause interruptions.
+- [x] Existing boot lifecycle listener is the only shared-state listener.
+- [x] Existing bypass-route assertion remains meaningful after route splitting.
+- [x] Production scanner covers every TTS diagnostic token.
+- [x] Physical-device matrix requires human speaker evidence and an explicit architecture conclusion.

--- a/docs/superpowers/plans/2026-07-31-mobile-authenticated-tts-pronunciation.md
+++ b/docs/superpowers/plans/2026-07-31-mobile-authenticated-tts-pronunciation.md
@@ -17,6 +17,7 @@
 - Keep Cognito tokens and `Authorization` ownership inside `MobileAuthCoordinator`.
 - Never render, log, or persist provider keys, Cognito tokens, complete presigned URLs, or raw server error bodies.
 - Limit both JSON and text error bodies to 16 KiB before parsing or retention.
+- In backend TTS handlers, log only an allowlisted, sanitized shape: the operation name, normalized error metadata (`errorName`, `errorMessage`), provider, and bucket. Never log raw error values, the user-scoped `s3Key` (which embeds the userId), or the `userId` itself.
 - Make network, provider, validator, 4xx, 5xx, and deadline failures manual-only retries.
 - Permit one same-user continuation for auth-control races or completed session recovery.
 - Keep URL/media refresh separate from transport retry; allow at most one automatic URL refresh per tap.
@@ -95,6 +96,7 @@
 ### Task 1: Add Shared TTS Contracts and Web Success Validation
 
 **Files:**
+
 - Create: `packages/common/src/contracts/tts.ts`
 - Create: `packages/common/src/contracts/tts.test.ts`
 - Modify: `packages/common/src/index.ts`
@@ -102,6 +104,7 @@
 - Modify: `apps/vela/src/services/ttsService.test.ts`
 
 **Interfaces:**
+
 - Produces: `TtsProvider`, `TtsSettings`, `GeneratePronunciationRequest`, `GeneratePronunciationResponse`, `TtsApiErrorCode`, `TtsApiErrorResponse`, `parseTtsSettings()`, `parseGeneratePronunciationRequest()`, `parseGeneratePronunciationResponse()`, `parseTtsApiErrorResponse()`.
 - Consumers: backend tests and `MobileTtsService`.
 
@@ -138,7 +141,10 @@ it('parses a valid generate response', () => {
 
 it('rejects non-HTTPS audio URLs', () => {
   expect(() =>
-    parseGeneratePronunciationResponse({ audioUrl: 'http://audio.example.test/mizu.mp3', cached: false }),
+    parseGeneratePronunciationResponse({
+      audioUrl: 'http://audio.example.test/mizu.mp3',
+      cached: false,
+    }),
   ).toThrow('invalid_tts_generate_response:audioUrl');
 });
 
@@ -189,10 +195,8 @@ export type GeneratePronunciationResponse = {
 };
 
 export function parseGeneratePronunciationResponse(value: unknown): GeneratePronunciationResponse {
-  const root = requireRecord(value, 'generate_response');
-  const audioUrl = requireString(root.audioUrl, 'generate_response:audioUrl');
-  const parsed = new URL(audioUrl);
-  if (parsed.protocol !== 'https:') throw new TypeError('invalid_tts_generate_response:audioUrl');
+  const root = requireRecord(value, 'generate_response:root');
+  const audioUrl = requireHttpsAudioUrl(root.audioUrl, 'generate_response:audioUrl');
   return { audioUrl, cached: requireBoolean(root.cached, 'generate_response:cached') };
 }
 ```
@@ -264,10 +268,12 @@ git commit -m "feat: share validated TTS contracts"
 ### Task 2: Add Stable Backend Error Codes Without Changing Legacy Responses
 
 **Files:**
+
 - Modify: `apps/vela-api/src/routes/tts.ts`
 - Modify: `apps/vela-api/test/routes/tts.test.ts`
 
 **Interfaces:**
+
 - Produces: route-owned errors with stable `code` plus unchanged `error` and HTTP status.
 - Preserves: Hono/Zod validator-generated 400 shape.
 
@@ -276,10 +282,13 @@ git commit -m "feat: share validated TTS contracts"
 ```ts
 it('returns a stable code when TTS is not configured', async () => {
   ttsSettingsGet.mockResolvedValue(null);
-  const response = await app.request('/api/tts/generate', authenticatedPost({
-    vocabularyId: '水:ミズ',
-    text: '水',
-  }));
+  const response = await app.request(
+    '/api/tts/generate',
+    authenticatedPost({
+      vocabularyId: '水:ミズ',
+      text: '水',
+    }),
+  );
 
   expect(response.status).toBe(400);
   expect(await response.json()).toEqual({
@@ -289,10 +298,13 @@ it('returns a stable code when TTS is not configured', async () => {
 });
 
 it('leaves request-validator failures uncoded', async () => {
-  const response = await app.request('/api/tts/generate', authenticatedPost({
-    vocabularyId: '',
-    text: '',
-  }));
+  const response = await app.request(
+    '/api/tts/generate',
+    authenticatedPost({
+      vocabularyId: '',
+      text: '',
+    }),
+  );
 
   expect(response.status).toBe(400);
   const body = await response.json();
@@ -342,11 +354,13 @@ git commit -m "feat(api): add stable TTS error codes"
 ### Task 3: Add Coordinator Transport Overrides and Identical POST Replay
 
 **Files:**
+
 - Modify: `apps/vela-mobile/src/auth/mobile-auth-contract.ts`
 - Modify: `apps/vela-mobile/src/services/mobile-auth.ts`
 - Modify: `apps/vela-mobile/src/services/mobile-auth.test.ts`
 
 **Interfaces:**
+
 - Produces: `transportTimeoutMs?: number`, `MOBILE_AUTH_MAX_FEATURE_NETWORK_TIMEOUT_MS`, and `invalid_request_timeout`.
 - Preserves: one authenticated replay after successful 401 recovery.
 
@@ -412,7 +426,11 @@ export const MOBILE_AUTH_MAX_FEATURE_NETWORK_TIMEOUT_MS = 50_000;
 function featureTransportTimeout(request: MobileAuthenticatedApiRequest): number {
   const value = request.transportTimeoutMs;
   if (value === undefined) return MOBILE_AUTH_NETWORK_TIMEOUT_MS;
-  if (!Number.isInteger(value) || value <= 0 || value > MOBILE_AUTH_MAX_FEATURE_NETWORK_TIMEOUT_MS) {
+  if (
+    !Number.isInteger(value) ||
+    value <= 0 ||
+    value > MOBILE_AUTH_MAX_FEATURE_NETWORK_TIMEOUT_MS
+  ) {
     throw new MobileAuthenticatedApiRequestError('invalid_request_timeout');
   }
   return value;
@@ -438,11 +456,13 @@ git commit -m "feat(mobile): support bounded feature transport timeouts"
 ### Task 4: Extend MobileApiClient with Replayable JSON POST and Safe Structured Errors
 
 **Files:**
+
 - Modify: `apps/vela-mobile/src/services/mobile-api-client.ts`
 - Modify: `apps/vela-mobile/src/services/mobile-api-client.test.ts`
 - Modify: `apps/vela-mobile/src/composables/useDueReviewCount.test.ts`
 
 **Interfaces:**
+
 - Produces: `postJson()`, `MobileApiRequestOptions.timeoutMs`, `MOBILE_API_MAX_ERROR_BODY_BYTES`, `MobileApiError.details`, and `client` classification.
 - Consumes: coordinator timeout override from Task 3.
 
@@ -471,7 +491,9 @@ it('serializes JSON before coordinator dispatch', async () => {
 it('rejects circular JSON before coordinator dispatch', async () => {
   const body: Record<string, unknown> = {};
   body.self = body;
-  await expect(client.postJson('tts/generate', body)).rejects.toMatchObject({ code: 'invalid_request' });
+  await expect(client.postJson('tts/generate', body)).rejects.toMatchObject({
+    code: 'invalid_request',
+  });
   expect(coordinator.requestAuthenticatedApi).not.toHaveBeenCalled();
 });
 ```
@@ -570,10 +592,12 @@ git commit -m "feat(mobile): add replayable JSON requests and safe API errors"
 ### Task 5: Implement MobileTtsService, Cache, Error Mapping, and Timings
 
 **Files:**
+
 - Create: `apps/vela-mobile/src/services/mobile-tts.ts`
 - Create: `apps/vela-mobile/src/services/mobile-tts.test.ts`
 
 **Interfaces:**
+
 - Consumes: shared contracts and `MobileApiClient`.
 - Produces: `MobileTtsService`, `PreparedPronunciation`, `PreparationTimings`, `MobileTtsError`, `MOBILE_TTS_GENERATE_TIMEOUT_MS`.
 
@@ -597,10 +621,15 @@ it('uses default settings timeout and 45-second generate timeout', async () => {
 it('maps an uncoded validator 400 to invalid_input', async () => {
   api.getJson.mockResolvedValue(CONFIGURED_SETTINGS);
   api.postJson.mockRejectedValue(
-    new MobileApiError('client', { status: 400, serverBody: { success: false, error: { issues: [] } } }),
+    new MobileApiError('client', {
+      status: 400,
+      serverBody: { success: false, error: { issues: [] } },
+    }),
   );
 
-  await expect(service.preparePronunciation(INPUT)).rejects.toMatchObject({ code: 'invalid_input' });
+  await expect(service.preparePronunciation(INPUT)).rejects.toMatchObject({
+    code: 'invalid_input',
+  });
 });
 ```
 
@@ -729,6 +758,7 @@ git commit -m "feat(mobile): add authenticated TTS service"
 ### Task 6: Register MobileTtsService and Clear Prior-User Cache on Auth Transitions
 
 **Files:**
+
 - Modify: `apps/vela-mobile/src/services/mobile-services.ts`
 - Modify: `apps/vela-mobile/src/services/mobile-services.test.ts`
 - Create: `apps/vela-mobile/src/services/mobile-tts-auth-isolation.ts`
@@ -737,6 +767,7 @@ git commit -m "feat(mobile): add authenticated TTS service"
 - Modify: `apps/vela-mobile/src/boot/mobile-auth.test.ts`
 
 **Interfaces:**
+
 - Produces: `MOBILE_TTS_SERVICE_KEY` and `installMobileTtsAuthIsolation()`.
 - Responsibility boundary: this watcher clears app-wide TTS cache/pending indexes only; the mounted controller owns active audio stop/dispose.
 
@@ -827,11 +858,13 @@ git commit -m "feat(mobile): register and isolate TTS service"
 ### Task 7: Add Browser-Free Audio Contract and HTML Adapter
 
 **Files:**
+
 - Create: `apps/vela-mobile/src/audio/mobile-audio-contract.ts`
 - Create: `apps/vela-mobile/src/audio/html-audio-player.ts`
 - Create: `apps/vela-mobile/src/audio/html-audio-player.test.ts`
 
 **Interfaces:**
+
 - Produces: `MobileAudioPlayer`, `MobileAudioPlaybackHandle`, `MobileAudioPlaybackOutcome`, `MobileAudioError`.
 
 - [ ] **Step 1: Write a deterministic fake audio element and failing tests**
@@ -902,12 +935,14 @@ git commit -m "feat(mobile): add replaceable HTML audio adapter"
 ### Task 8: Extend Shared Lifecycle State Through the Existing Listener
 
 **Files:**
+
 - Modify: `apps/vela-mobile/src/services/mobile-lifecycle.ts`
 - Modify: `apps/vela-mobile/src/services/mobile-lifecycle.test.ts`
 - Modify: `apps/vela-mobile/src/boot/capacitor-lifecycle.ts`
 - Create or modify: `apps/vela-mobile/src/boot/capacitor-lifecycle.test.ts`
 
 **Interfaces:**
+
 - Produces: `mobileLifecycleState.isActive`, transition timestamps, and `recordAppStateChange()`.
 
 - [ ] **Step 1: Write failing lifecycle tests**
@@ -944,10 +979,13 @@ Expected: active state and recorder are absent.
 
 ```ts
 export function recordAppStateChange(next: boolean, at = Date.now()): void {
+  const previous = isActive.value;
   isActive.value = next;
   lastStateChangeAt.value = at;
-  if (next) lastBecameActiveAt.value = at;
-  else lastBecameInactiveAt.value = at;
+  if (next !== previous) {
+    if (next) lastBecameActiveAt.value = at;
+    else lastBecameInactiveAt.value = at;
+  }
 }
 ```
 
@@ -983,10 +1021,12 @@ git commit -m "feat(mobile): expose shared app activity state"
 ### Task 9: Implement Pronunciation Controller State Machine
 
 **Files:**
+
 - Create: `apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts`
 - Create: `apps/vela-mobile/src/composables/usePronunciationDiagnostic.test.ts`
 
 **Interfaces:**
+
 - Consumes: `MobileTtsService`, `MobileAudioPlayer`, feature-session selector, and shared lifecycle state.
 - Produces: controller state, `playOrRetry()`, diagnostic invalidation actions, counters, and `dispose()`.
 
@@ -1052,7 +1092,11 @@ export type PronunciationDiagnosticState =
   | { kind: 'ready'; pronunciation: PreparedPronunciation; notice: ReadyNotice | null }
   | { kind: 'playing'; pronunciation: PreparedPronunciation }
   | { kind: 'interrupted'; pronunciation: PreparedPronunciation; reason: 'background' | 'external' }
-  | { kind: 'error'; error: PronunciationDiagnosticError; pronunciation: PreparedPronunciation | null };
+  | {
+      kind: 'error';
+      error: PronunciationDiagnosticError;
+      pronunciation: PreparedPronunciation | null;
+    };
 ```
 
 Use an operation generation counter to prevent old promises from writing successor state.
@@ -1077,6 +1121,7 @@ git commit -m "feat(mobile): add pronunciation diagnostic controller"
 ### Task 10: Add Authenticated Development Route and More Entry
 
 **Files:**
+
 - Create: `apps/vela-mobile/src/diagnostics/tts-pronunciation-contract.ts`
 - Modify: `apps/vela-mobile/src/router/diagnostic-routes.ts`
 - Modify: `apps/vela-mobile/src/router/diagnostic-routes.test.ts`
@@ -1086,12 +1131,15 @@ git commit -m "feat(mobile): add pronunciation diagnostic controller"
 - Modify: `apps/vela-mobile/src/pages/MorePage.test.ts`
 
 **Interfaces:**
+
 - Produces: route path, fixed word, labels, markers, test IDs, and split route collections.
 
 - [ ] **Step 1: Write failing route-partition tests**
 
 ```ts
-expect(bypassDevelopmentDiagnosticRoutes.every((route) => route.meta?.bypassMobileAuth === true)).toBe(true);
+expect(
+  bypassDevelopmentDiagnosticRoutes.every((route) => route.meta?.bypassMobileAuth === true),
+).toBe(true);
 expect(authenticatedDevelopmentDiagnosticRoutes).toHaveLength(1);
 expect(authenticatedDevelopmentDiagnosticRoutes[0]?.path).toBe('diagnostics/tts-pronunciation');
 expect(authenticatedDevelopmentDiagnosticRoutes[0]?.meta?.bypassMobileAuth).not.toBe(true);
@@ -1167,10 +1215,12 @@ git commit -m "feat(mobile): register authenticated TTS diagnostics"
 ### Task 11: Build Accessible Diagnostic Page
 
 **Files:**
+
 - Create: `apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.vue`
 - Create: `apps/vela-mobile/src/pages/diagnostics/TtsPronunciationDiagnosticsPage.test.ts`
 
 **Interfaces:**
+
 - Consumes: controller, fixed word, injected TTS service/coordinator, and HTML audio player factory.
 - Produces: accessible controls, safe counters, timings, and development actions.
 
@@ -1239,17 +1289,21 @@ git commit -m "feat(mobile): add pronunciation diagnostic page"
 ### Task 12: Prove Production Exclusion and Run Automated Merge Gates
 
 **Files:**
+
 - Modify: `apps/vela-mobile/scripts/verify-production-diagnostics.mjs`
 - Modify: `apps/vela-mobile/scripts/verify-production-diagnostics.test.mjs`
 
 **Interfaces:**
+
 - Produces: production-bundle leak detection for every TTS diagnostic token.
 
 - [ ] **Step 1: Write failing scanner tests**
 
 ```js
 it('rejects a production bundle containing TTS diagnostic tokens', async () => {
-  await writeBundle('Pronunciation diagnostics /diagnostics/tts-pronunciation tts-pronunciation-entry');
+  await writeBundle(
+    'Pronunciation diagnostics /diagnostics/tts-pronunciation tts-pronunciation-entry',
+  );
   await expect(verifyProductionDiagnostics()).rejects.toThrow('tts-pronunciation');
 });
 ```
@@ -1327,11 +1381,13 @@ git commit -m "test(mobile): verify TTS diagnostic exclusion"
 ### Task 13: Collect Simulator and Physical-iPhone Evidence
 
 **Files:**
+
 - Create: `apps/vela-mobile/docs/tts-pronunciation-ios.md`
 - Modify only after evidence: `packages/cdk/lib/storage-stack.ts`
 - Create or modify only after evidence: `packages/cdk/test/storage-stack.test.ts`
 
 **Interfaces:**
+
 - Produces: HPA-208 closure record consumed by HPA-210.
 
 - [ ] **Step 1: Capture exact software and commit versions**
@@ -1389,13 +1445,21 @@ Use these section headings:
 # iOS TTS Pronunciation Verification
 
 ## Tested Build and Environment
+
 ## Non-Secret TTS Configuration
+
 ## Timing Results
+
 ## Simulator Matrix
+
 ## Physical iPhone Matrix
+
 ## CORS Findings
+
 ## Known Limitations
+
 ## Architecture Decision
+
 ## Follow-up Issues
 ```
 

--- a/docs/superpowers/specs/2026-07-31-mobile-authenticated-tts-pronunciation-design.md
+++ b/docs/superpowers/specs/2026-07-31-mobile-authenticated-tts-pronunciation-design.md
@@ -405,7 +405,7 @@ The coordinator:
 - applies the timeout independently to each physical fetch attempt; and
 - remains subject to the API client's outer abort signal, so auth recovery and retries cannot exceed the overall deadline.
 
-`MobileApiClient` passes the effective request timeout as `transportTimeoutMs`. If an auth recovery consumes part of the overall budget, the outer signal still aborts any later attempt at the original deadline.
+`MobileApiClient` passes the effective request timeout as `transportTimeoutMs`. If auth recovery consumes part of the overall budget, the outer signal still aborts any later attempt at the original deadline.
 
 `postJson()` sets `Content-Type: application/json` and serializes the supplied body. Authorization remains exclusively owned by `MobileAuthCoordinator`; callers cannot supply or override it.
 

--- a/docs/superpowers/specs/2026-07-31-mobile-authenticated-tts-pronunciation-design.md
+++ b/docs/superpowers/specs/2026-07-31-mobile-authenticated-tts-pronunciation-design.md
@@ -428,10 +428,11 @@ Omitting `timeoutMs` retains the existing eight-second default.
 `postJson()` must:
 
 1. Validate and serialize the supplied value with `JSON.stringify()` before dispatch.
-2. Store the resulting immutable string in `RequestInit.body`.
-3. Use the same serialized string for the initial authenticated attempt and the one permitted post-refresh replay.
-4. Set `Content-Type: application/json` identically on both attempts.
-5. Reject serialization failure as `invalid_request` before contacting the coordinator.
+2. Require `typeof serialized === 'string'` after `JSON.stringify()` and before coordinator dispatch, rejecting `undefined` and other non-string results (functions, symbols) as `invalid_request`.
+3. Store the resulting immutable string in `RequestInit.body`.
+4. Use the same serialized string for the initial authenticated attempt and the one permitted post-refresh replay.
+5. Set `Content-Type: application/json` identically on both attempts.
+6. Reject serialization failure as `invalid_request` before contacting the coordinator.
 
 This client does not expose streaming bodies, `ReadableStream`, `Blob`, or `FormData`. A future API for non-replayable bodies must define its own 401/retry policy rather than silently reusing this contract.
 
@@ -831,10 +832,11 @@ The controller keeps the prepared URL while it is locally live, including after 
 2. Transition to `preparing`.
 3. Prepare pronunciation under the retry policy above.
 4. Save the returned pronunciation.
-5. Immediately call `audioPlayer.play()` in the continuation of the original tap.
-6. Record tap-to-play-attempt latency and whether iOS accepts or rejects playback after the asynchronous request chain.
+5. Before calling `audioPlayer.play()`, check `lifecycle.isActive.value`. If the app became inactive during the asynchronous preparation, skip autoplay and transition to `ready` with the prepared pronunciation instead of playing.
+6. When still active, immediately call `audioPlayer.play()` in the continuation of the original tap.
+7. Record tap-to-play-attempt latency and whether iOS accepts or rejects playback after the asynchronous request chain.
 
-Failure of this asynchronous first-tap play is not by itself an HTML-audio rejection. The diagnostic may enter `ready` and complete acceptance through a direct second tap.
+Failure of this asynchronous first-tap play is not by itself an HTML-audio rejection. The diagnostic may enter `ready` and complete acceptance through a direct second tap. Deactivation during preparation produces the same `ready` state with no autoplay attempt, so a backgrounded first tap never starts playback.
 
 ### Tap from `ready` or `interrupted`
 
@@ -906,6 +908,8 @@ When the app becomes inactive:
 - call `audioPlayer.interruptActive('background')`;
 - do not attempt background playback; and
 - preserve the prepared URL only while it remains within its local TTL.
+
+When the app becomes inactive during an asynchronous first-tap preparation (before `audioPlayer.play()` is called), the preparation completes but the controller checks `lifecycle.isActive.value` before invoking playback. If inactive, it transitions to `ready` with the prepared pronunciation and skips autoplay entirely. The resulting state is `ready`, not `playing`, so no background playback is attempted.
 
 When the app becomes active:
 

--- a/docs/superpowers/specs/2026-07-31-mobile-authenticated-tts-pronunciation-design.md
+++ b/docs/superpowers/specs/2026-07-31-mobile-authenticated-tts-pronunciation-design.md
@@ -10,11 +10,12 @@
 
 Prove that a restored, signed-in Vela user can request and repeatedly play one Japanese pronunciation inside the Capacitor iOS application using the existing authenticated TTS backend and presigned S3 audio flow.
 
-The implementation must answer one explicit architecture question:
+The implementation must answer two related architecture questions:
 
-> Is an `HTMLAudioElement` adapter reliable enough for the iOS MVP, or must the next mobile milestone introduce a native Capacitor audio adapter?
+1. Is `HTMLAudioElement` playback reliable enough for the iOS MVP?
+2. Which native follow-up, if any, is required: app-level `AVAudioSession` configuration while retaining HTML playback, or replacement of the player with a native Capacitor audio adapter?
 
-This is a production-shaped validation slice, not the final pronunciation experience. It establishes stable boundaries for authenticated TTS requests, expiring audio URLs, playback ownership, user-visible state, and future native replacement without importing the web TTS settings page or exposing Cognito tokens to feature code.
+This is a production-shaped validation slice, not the final pronunciation experience. It establishes stable boundaries for authenticated TTS requests, expiring audio URLs, playback ownership, user-visible state, audio-session evidence, and future native replacement without importing the web TTS settings page or exposing Cognito tokens to feature code.
 
 ## Current state
 
@@ -37,7 +38,7 @@ The existing web TTS service currently combines six responsibilities:
 2. TTS settings retrieval;
 3. authenticated TTS generation and existing-audio lookup;
 4. a 14-minute in-memory presigned-URL cache;
-5. same-key in-flight request deduplication; and
+5. settings-derived same-key in-flight request deduplication; and
 6. direct `HTMLAudioElement` playback.
 
 Its useful cache and concurrency semantics should be preserved, but the module itself must not be imported into mobile because it owns web authentication and mixes transport with playback.
@@ -50,7 +51,9 @@ The backend already provides:
 
 `POST /api/tts/generate` checks the user-scoped S3 cache before invoking the configured provider, stores generated audio privately, and returns a presigned URL valid for 900 seconds. The backend derives the provider credential from the authenticated user's server-side TTS settings. No provider API key is returned to or bundled in the mobile application.
 
-The Capacitor application does not currently install a native audio plugin.
+The Capacitor application does not currently install a native audio plugin or configure `AVAudioSession`.
+
+Apple documents that an iOS app's default audio session is silenced by the Ring/Silent switch, while the `.playback` category continues playing with the switch set to silent. `HTMLAudioElement` cannot configure that native category itself. Device evidence therefore must treat silent-switch behavior as a product gate, not merely an observation. See [AVAudioSession](https://developer.apple.com/documentation/avfaudio/avaudiosession) and [AVAudioSession.Category.playback](https://developer.apple.com/documentation/avfaudio/avaudiosession/category-swift.struct/playback).
 
 ## Approved decisions
 
@@ -61,15 +64,18 @@ The Capacitor application does not currently install a native audio plugin.
 | API flow | Check settings, then call `POST tts/generate`; do not require `GET tts/audio/:id` first |
 | Shared code | Share validated request/response/settings/error contracts, not the web service or page |
 | Auth ownership | All TTS requests use the existing coordinator-owned mobile API client |
-| API client | Add authenticated JSON POST and structured HTTP error details without changing due-count behavior |
+| API client | Add authenticated JSON POST and structured HTTP errors; intentionally classify deterministic non-401/403 4xx responses as `client` |
+| Due-count migration | Keep its retry rule (`network`/`server` only), while intentionally stopping retries for 4xx responses that previously collapsed to `server` |
 | Playback seam | `MobileAudioPlayer` interface with an initial `HtmlAudioPlayer` implementation |
-| Native plugin | Do not install one unless device evidence fails the HTML-audio decision gate |
-| Concurrency | One preparation request and one active playback per controller; same-key service requests share work |
+| Silent-switch product rule | Foreground pronunciation initiated by an explicit tap must be audible when the hardware Ring/Silent switch is on and media volume is nonzero |
+| Native integration | Do not preselect a plugin; if HTML-only playback fails silent-mode or session-control gates, create a native audio-session follow-up before considering full player replacement |
+| Concurrency | One preparation request and one active playback per controller; service deduplication uses the full settings-derived cache key |
 | URL cache | User/settings/vocabulary-scoped in-memory cache, 14-minute TTL, bounded size |
-| Replay | Reuse the prepared URL and restart from the beginning; never overlap playback |
-| First-tap gesture | Attempt playback after async preparation and record whether iOS permits it |
+| Replay | Reuse a still-live prepared URL and restart from the beginning; never overlap playback |
+| First-tap gesture | Attempt playback after asynchronous preparation and record whether iOS permits it |
 | Gesture fallback | If rejected, retain the prepared URL and require a second direct tap |
-| Expired URL | Invalidate, refresh, and require another tap; do not autoplay after async recovery |
+| Proactive expiry | A ready tap checks `expiresAt` before playback; an expired item refreshes instead of intentionally attempting a stale URL |
+| Media failure | Still refresh once because sleep, revocation, clock changes, or transport behavior can invalidate a nominally live URL |
 | Background behavior | Stop active audio and classify it as interrupted; background audio remains unsupported |
 | Diagnostic exposure | Development-only route under More, but still behind `MobileAuthGate` |
 | Provider configuration | Test account is configured on the web; mobile only reports configuration status |
@@ -85,15 +91,16 @@ HPA-208 includes:
 - stable TTS backend error codes while preserving existing `error` messages;
 - authenticated JSON POST support in the mobile API client;
 - structured HTTP status and server-detail preservation for feature services;
-- a mobile TTS service with settings validation, URL caching, and same-key single-flight preparation;
+- the intentional mobile 4xx classification migration and pinned due-count retry behavior;
+- a mobile TTS service with settings validation, URL caching, and settings-derived same-key single-flight preparation;
 - a replaceable mobile audio interface;
 - an `HTMLAudioElement` implementation owning one active playback;
-- a pronunciation controller with explicit state transitions and concurrency rules;
+- a pronunciation controller with explicit state transitions, proactive expiry, and concurrency rules;
 - an authenticated development-only diagnostic page for one known word;
-- lifecycle and interruption observation;
-- unit/component/infrastructure coverage;
+- lifecycle, interruption, silent-switch, decode, and audibility observation;
+- unit/component/backend/infrastructure coverage;
 - Simulator and physical-iPhone verification; and
-- a written HTML-audio versus native-adapter conclusion.
+- a written HTML-only, native-session, or native-player conclusion.
 
 ## Non-goals
 
@@ -106,7 +113,8 @@ HPA-208 includes:
 - offline audio downloads or persistent audio storage;
 - background playback;
 - lock-screen controls, Now Playing integration, or remote transport controls;
-- Bluetooth route selection or advanced `AVAudioSession` policy;
+- Bluetooth route selection, recording policy, or advanced `AVAudioSession` routing/mixing policy;
+- implementing native audio-session or player integration before device evidence identifies which layer is necessary;
 - Android validation;
 - proactively adopting a native audio plugin; and
 - redesigning the backend's invariant that one vocabulary ID represents one canonical pronunciation text.
@@ -129,10 +137,13 @@ MobileTtsService.preparePronunciation(...)
 MobileApiClient GET tts/settings
         |
         v
-MobileAuthCoordinator adds current Cognito ID token
+Settings-derived cache/pending key
         |
         v
 MobileApiClient POST tts/generate
+        |
+        v
+MobileAuthCoordinator adds current Cognito ID token
         |
         v
 Backend checks user TTS settings and S3 object cache
@@ -144,7 +155,10 @@ Provider generation when needed -> private S3 object
 Validated { audioUrl, cached } response
         |
         v
-Controller attempts MobileAudioPlayer.play(audioUrl)
+Controller checks local expiresAt
+        |
+        v
+Controller calls MobileAudioPlayer.play(audioUrl)
         |
         v
 HtmlAudioPlayer owns exactly one HTMLAudioElement
@@ -158,23 +172,25 @@ HtmlAudioPlayer owns exactly one HTMLAudioElement
 
 #### Mobile API client
 
-`apps/vela-mobile/src/services/mobile-api-client.ts` owns authenticated JSON transport, execution deadlines, response-body consumption, and stable transport/HTTP error normalization. It does not understand TTS domain states.
+`apps/vela-mobile/src/services/mobile-api-client.ts` owns authenticated JSON transport, execution deadlines, JSON syntax/body consumption, and stable transport/HTTP error normalization. It does not understand TTS domain states.
 
 #### Mobile TTS service
 
-`apps/vela-mobile/src/services/mobile-tts.ts` owns TTS settings interpretation, generate-request construction, response parsing, URL-cache semantics, and TTS-specific error normalization. It does not create or control audio elements.
+`apps/vela-mobile/src/services/mobile-tts.ts` owns TTS settings interpretation, generate-request construction, structural response validation, URL-cache semantics, settings-derived pending-work identity, and TTS-specific error normalization. It does not create or control audio elements.
 
 #### Mobile audio player
 
 `apps/vela-mobile/src/audio/mobile-audio-contract.ts` defines the replaceable playback boundary. `apps/vela-mobile/src/audio/html-audio-player.ts` is the first implementation. No learning component or diagnostic page constructs `Audio` directly.
 
+Native app-level audio-session configuration, if required, remains outside `MobileAudioPlayer` unless it must coordinate directly with player lifecycle. A later native player can preserve the same learning-feature contract.
+
 #### Pronunciation controller
 
-`apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts` or an equivalent focused controller owns user intent, preparation/playback sequencing, state transitions, retry policy, lifecycle reactions, and teardown. It does not parse HTTP responses or own Cognito state.
+`apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts` or an equivalent focused controller owns user intent, preparation/playback sequencing, local expiry checks, state transitions, retry policy, lifecycle reactions, and teardown. It does not parse HTTP responses or own Cognito state.
 
 #### Diagnostic view
 
-The Vue page renders the controller state and exposes accessible controls. It contains no request, cache, or playback implementation logic.
+The Vue page renders controller state and exposes accessible controls. It contains no request, cache, or playback implementation logic.
 
 ## Shared TTS contracts
 
@@ -231,16 +247,24 @@ Validation requirements:
 - `audioUrl` is an absolute HTTPS URL;
 - request vocabulary ID and text are non-empty after trimming;
 - error parsing accepts the existing `{ error: string }` shape;
-- unknown response fields are ignored; and
-- invalid success bodies become `MobileApiError('invalid_response')` at the mobile service boundary.
+- unknown response fields are ignored;
+- invalid or empty JSON syntax/body is classified by `MobileApiClient` as `MobileApiError('invalid_response')`; and
+- a syntactically valid but structurally invalid TTS success body is caught by the shared parser and normalized by `MobileTtsService` to `MobileTtsError('invalid_response')`.
 
 The web service imports and re-exports the shared types and parsers while preserving its public API and behavior.
 
 ### Backend error compatibility
 
-TTS routes add stable `code` fields to their existing JSON error responses. The existing human-readable `error` strings remain unchanged so current web behavior and tests remain valid.
+TTS routes add stable `code` fields to their existing JSON error responses. Existing human-readable `error` strings and HTTP statuses remain unchanged so current web behavior and tests remain valid.
 
-Mobile maps by stable code first. During mixed-version deployment or local development, it falls back to status plus the existing error string for the two configuration messages. This fallback is compatibility behavior, not the primary long-term contract.
+Mobile maps by stable code first. During mixed-version deployment or local development, only these exact legacy fallbacks are recognized:
+
+| HTTP status | Exact legacy message | Mobile mapping |
+| --- | --- | --- |
+| 400 | `TTS API key not configured. Please configure in Settings.` | `not_configured` |
+| 400 | `Invalid TTS provider configuration` | `generation_failed` |
+
+Every other uncoded 4xx/5xx response maps through the normal status and TTS error rules. String matching is compatibility behavior, not the primary long-term contract, and has explicit tests.
 
 ## Mobile API client extension
 
@@ -269,7 +293,7 @@ Both methods use one private `requestJson()` implementation.
 
 ### Error contract
 
-Extend `MobileApiError` with optional HTTP detail while preserving all existing codes and behavior:
+Extend `MobileApiError` with optional HTTP detail while preserving existing construction with `{ cause }`:
 
 ```ts
 export type MobileApiErrorCode =
@@ -295,9 +319,12 @@ export class MobileApiError extends Error {
     } = {},
   ) {
     super(code, { cause: details.cause });
+    this.name = 'MobileApiError';
   }
 }
 ```
+
+Existing call sites passing `{ cause }` remain valid, and the resulting `Error.cause` chain must be preserved and tested.
 
 Response mapping:
 
@@ -312,7 +339,15 @@ Response mapping:
 | Transport rejection/deadline | Existing `network` or session-recovery behavior |
 | Caller abort | Preserve `AbortError` |
 
-The due-count query continues retrying only `network` and `server`; the new `client` code is deterministic and is not retried.
+### Intentional due-count behavior migration
+
+Today, every non-2xx response other than 401/403 collapses to `server`, so an unexpected SRS 400 is eligible for the due-count query's existing `network`/`server` retry rule. After this change, the same response becomes deterministic `client` and is not retried.
+
+This is intentional. The retry predicate itself remains unchanged, but its input classification becomes more precise. Tests pin all three cases:
+
+- due-count `400` -> `client` -> no retry;
+- due-count `500` -> `server` -> retry under the existing limit; and
+- network failure -> `network` -> retry under the existing limit.
 
 Error-body consumption is bounded by the existing request deadline. JSON is preferred when the response content type or body supports it; otherwise retain a bounded text message. Malformed error bodies do not replace the correct HTTP classification.
 
@@ -353,6 +388,7 @@ export class MobileTtsError extends Error {
     options?: { cause?: unknown },
   ) {
     super(code, options);
+    this.name = 'MobileTtsError';
   }
 }
 
@@ -372,18 +408,20 @@ export type MobileTtsService = {
 For one logical preparation:
 
 1. Validate non-empty `userId`, `vocabularyId`, and `text`.
-2. Join an existing pending preparation for the same user, vocabulary ID, and text when present.
-3. Fetch and validate `GET tts/settings` through `MobileApiClient`.
-4. If `hasApiKey` is false, throw `MobileTtsError('not_configured')` without calling generation.
-5. Construct the final cache key from user ID, vocabulary ID, provider, voice, and model.
-6. Return a live URL from the in-memory cache when present.
+2. Fetch and validate `GET tts/settings` through `MobileApiClient`.
+3. If `hasApiKey` is false, throw `MobileTtsError('not_configured')` without calling generation.
+4. Construct the full key from user ID, vocabulary ID, provider, voice, and model.
+5. Return a live URL from the in-memory cache when present.
+6. Join an existing pending generation for that full settings-derived key when present.
 7. Call `POST tts/generate` with exactly `{ vocabularyId, text }`.
 8. Validate the response.
 9. Cache the URL for 14 minutes from receipt.
 10. Return source `server-cache` when the backend says `cached: true`; otherwise return `generated`.
 11. Remove the pending record in `finally` if it still owns the key.
 
-The test word follows the backend's current invariant: `vocabularyId` identifies immutable canonical pronunciation text. HPA-208 does not support sending alternate text for the same vocabulary ID.
+This ordering intentionally matches the web service's concurrency identity. Concurrent callers may each read settings, but generation is shared only after the provider/voice/model partition is known. A settings change cannot cause a caller to join work for the previous settings key.
+
+The test word follows the backend's current invariant: `vocabularyId` identifies immutable canonical pronunciation text. HPA-208 does not support sending alternate text for the same vocabulary ID, so text is validated but is not an additional cache-key component.
 
 ### URL cache
 
@@ -407,7 +445,7 @@ The cache never stores provider API keys, bearer tokens, or complete settings re
 
 ### Same-key pending work and cancellation
 
-The service shares the underlying preparation promise for identical logical requests. A caller abort detaches that caller but does not cancel work still useful to another caller.
+The service shares the underlying generation promise for identical full keys. A caller abort detaches that caller but does not cancel work still useful to another caller.
 
 The service maintains a per-user invalidation generation:
 
@@ -424,12 +462,13 @@ The service maintains a per-user invalidation generation:
 | --- | --- |
 | Settings says `hasApiKey: false` | `not_configured` |
 | Backend code `tts_not_configured` | `not_configured` |
-| Invalid provider configuration | `generation_failed` with actionable diagnostic detail |
+| Exact legacy 400 API-key message | `not_configured` |
+| Invalid provider configuration code or exact legacy message | `generation_failed` with diagnostic detail |
 | HTTP/network deadline | `network` unless API client identifies session recovery |
 | 503/audio service unavailable | `service_unavailable` |
 | 504/provider timeout | `generation_timeout` |
 | Other generation/storage/signing failure | `generation_failed` |
-| Invalid success body | `invalid_response` |
+| Structurally invalid TTS success body | `invalid_response` |
 | Auth/session control errors | Preserve equivalent mobile TTS code |
 
 Provider names and non-secret settings may be shown in the development diagnostic. Provider keys, tokens, signed URL query parameters, and raw server bodies are not logged.
@@ -455,6 +494,7 @@ export class MobileAudioError extends Error {
     options?: { cause?: unknown },
   ) {
     super(code, options);
+    this.name = 'MobileAudioError';
   }
 }
 
@@ -489,7 +529,15 @@ The HTML implementation:
 - resets `currentTime`, clears `src`, and releases the element during stop/dispose where safe; and
 - settles each handle exactly once.
 
-It must not set `crossOrigin` unless device evidence demonstrates a need and the bucket policy is changed accordingly.
+Required ordering invariant for restart, explicit stop, and dispose:
+
+1. Mark the current handle settled with the intended stopped outcome.
+2. Remove or disable the `pause` listener and clear active ownership.
+3. Only then call `audio.pause()`, reset `currentTime`, or clear `src`.
+
+The synchronous `pause` event caused by the adapter's own cleanup must never be reclassified as an external interruption. Tests must exercise synchronous pause dispatch and prove restart/stop/dispose retain their intended outcome.
+
+The adapter must not set `crossOrigin` unless device evidence demonstrates a need and the bucket policy is changed accordingly.
 
 ## Pronunciation controller
 
@@ -513,7 +561,7 @@ export type PronunciationDiagnosticState =
     };
 ```
 
-The controller keeps the prepared URL while it is valid, including after a gesture-required failure, interruption, or explicit stop.
+The controller keeps the prepared URL while it is locally live, including after a gesture-required failure, interruption, or explicit stop.
 
 ### Tap behavior
 
@@ -527,11 +575,16 @@ The controller keeps the prepared URL while it is valid, including after a gestu
 
 #### Tap from `ready` or `interrupted`
 
-Call `audioPlayer.play()` synchronously using the prepared URL. This is the direct-user-gesture control path.
+1. Compare `Date.now()` with `pronunciation.expiresAt` before creating an audio element.
+2. If the URL is still live, call `audioPlayer.play()` synchronously. This is the direct-user-gesture control path.
+3. If the URL is expired, invalidate and prepare a fresh URL instead of intentionally attempting stale playback.
+4. After asynchronous refresh, attempt playback once and retain the normal gesture-required second-tap fallback.
+
+Proactive expiry avoids a predictable media failure in the local 14-minute boundary and after long idle periods. Failure-driven refresh remains necessary because device sleep, clock changes, server revocation, network intermediaries, or media-layer behavior can invalidate a URL before the local `expiresAt` value.
 
 #### Tap during `preparing`
 
-Ignore the tap and keep the control disabled. The service additionally protects against duplicate preparation requests.
+Ignore the tap and keep the control disabled. The service additionally protects against duplicate generation requests.
 
 #### Tap during `playing`
 
@@ -543,8 +596,8 @@ Stop the active handle with reason `restart`, seek to the beginning through the 
 | --- | --- |
 | Ended | Return to `ready`; increment completed-play count |
 | Restart/user stop | Return to `ready` unless a replacement already owns the state |
-| Background interruption | Enter `interrupted`; retain URL |
-| External interruption | Enter `interrupted`; retain URL |
+| Background interruption | Enter `interrupted`; retain locally live URL |
+| External interruption | Enter `interrupted`; retain locally live URL |
 | Gesture required | Enter `ready` with “Audio is prepared. Tap again to play.” |
 | Media unavailable | Invalidate URL and enter recoverable expired/media state |
 | Other playback failure | Enter recoverable error retaining URL only when safe |
@@ -557,7 +610,7 @@ Stop the active handle with reason `restart`, seek to the beginning through the 
 2. Invalidate the user/vocabulary URL cache entry.
 3. Refresh the pronunciation through `MobileTtsService` once.
 4. Enter `ready` with “Audio was refreshed. Tap to play again.”
-5. Do not autoplay after refresh, because the asynchronous recovery may no longer carry user activation.
+5. Do not autoplay after failure-driven refresh, because the asynchronous recovery may no longer carry user activation.
 
 If refresh fails, show the mapped TTS error. The controller performs at most one automatic URL refresh per tap; further attempts require explicit user retry.
 
@@ -569,15 +622,31 @@ When the app becomes inactive:
 
 - call `audioPlayer.interruptActive('background')`;
 - do not attempt background playback; and
-- preserve the prepared URL when still within its local TTL.
+- preserve the prepared URL only while it remains within its local TTL.
 
 When the app becomes active:
 
 - do not auto-resume;
 - display the interrupted state; and
-- allow an explicit replay tap.
+- allow an explicit replay tap, applying the proactive expiry check first.
 
 Component unmount stops active playback with reason `dispose` and aborts/detaches preparation owned by the component.
+
+## Silent-switch and native audio-session decision
+
+Pronunciation is core learning content, not incidental UI feedback. The MVP product rule is therefore:
+
+> While the app is foregrounded, an explicit pronunciation tap must produce audible output when media volume is nonzero, even when the iPhone Ring/Silent switch is set to silent.
+
+Background playback remains out of scope. This requirement concerns only foreground user-initiated pronunciation.
+
+The physical-device matrix determines one of three outcomes:
+
+1. **HTML-only accepted:** `HtmlAudioPlayer` meets all playback, silent-switch, interruption, and resource gates without native audio-session work.
+2. **Native audio-session integration required:** HTML decoding/playback remains reliable, but the app must configure an appropriate `AVAudioSession` category such as `.playback`. The follow-up should preserve `HtmlAudioPlayer` unless evidence shows player replacement is also necessary.
+3. **Native player adapter required:** HTML media remains unreliable after correct CORS and audio-session configuration, or required interruption/player controls cannot be implemented while retaining the adapter.
+
+Silent-mode inaudibility automatically rejects the HTML-only outcome. It does not by itself prove that a full native player is required.
 
 ## Diagnostic surface
 
@@ -648,8 +717,9 @@ A collapsed development section may provide:
 - invalidate the current in-memory URL;
 - simulate one invalid URL by replacing only the current diagnostic copy with a known-unreachable HTTPS URL;
 - clear diagnostic counters;
-- show preparation count, backend source, playback attempts, completed plays, gesture rejections, interruptions, URL refreshes, and last classified error; and
-- show current app active state.
+- show preparation count, backend source, playback attempts, completed plays, gesture rejections, interruptions, URL refreshes, and last classified error;
+- show current app active state; and
+- show the observed native audio-session category when safely available, without making that observation a player dependency.
 
 Never render the complete presigned URL because its query string contains temporary credentials. Display only the URL host and a redacted path suffix when needed for debugging.
 
@@ -664,6 +734,7 @@ The invalid-URL control provides deterministic expired-URL recovery evidence wit
 | Playing | “Playing 水…” |
 | Completed | “Pronunciation completed.” Replay available |
 | Gesture rejected | “Audio is prepared. Tap again to play.” |
+| Locally expired | “Refreshing expired audio…” then normal play or second-tap fallback |
 | Interrupted | “Playback was interrupted. Tap to replay.” |
 | TTS not configured | “Pronunciation is not configured for this account. Configure TTS in Vela web settings.” |
 | Session unavailable | Allow auth gate/coordinator recovery; no raw token error |
@@ -672,6 +743,7 @@ The invalid-URL control provides deterministic expired-URL recovery evidence wit
 | Service unavailable | “Pronunciation is temporarily unavailable. Try again.” |
 | URL refreshed | “Audio was refreshed. Tap to play again.” |
 | Playback failure | “Vela couldn’t play this pronunciation. Try again.” |
+| Silent-mode failure | Diagnostic records native audio-session integration as required; do not misreport completion as audible success |
 
 The diagnostic may mention that configuration is managed on the web. It does not deep-link to or embed the web settings page in this milestone.
 
@@ -719,10 +791,11 @@ Cover:
 - HTTPS URL validation;
 - cached true/false;
 - existing error-only responses;
-- coded error responses; and
+- coded error responses;
+- exact legacy fallback messages and statuses; and
 - unknown-field tolerance.
 
-### API-client tests
+### API-client and due-count regression tests
 
 Cover:
 
@@ -735,8 +808,11 @@ Cover:
 - 2xx JSON success;
 - 4xx `client` classification with parsed JSON and text detail;
 - 5xx `server` classification with detail;
-- malformed success JSON; and
-- unchanged due-count retry behavior.
+- malformed success JSON;
+- existing `{ cause }` call sites preserve `Error.cause` and `MobileApiError.name`;
+- due-count 400 is classified `client` and is not retried;
+- due-count 500 remains `server` and is retried under the existing limit; and
+- due-count network failure remains retryable under the existing limit.
 
 ### Mobile TTS service tests
 
@@ -746,11 +822,13 @@ Cover:
 - exact generation request body;
 - user ID absent from the request body;
 - not-configured settings short-circuit;
-- coded and compatibility-fallback errors;
-- response validation;
+- coded and exact compatibility-fallback errors;
+- JSON-syntax versus structural-response error attribution;
 - 14-minute cache TTL;
 - per-user, provider, voice, model, and vocabulary isolation;
-- same-key pending request sharing;
+- settings fetched before full-key pending lookup;
+- same-full-key pending generation sharing;
+- settings change creates a distinct pending/cache key;
 - distinct-key independence;
 - failed pending-request cleanup;
 - bounded LRU eviction;
@@ -771,6 +849,8 @@ Cover:
 - unexplained pause interruption;
 - restart stops the previous element;
 - explicit stop and dispose;
+- synchronous pause generated by restart/stop/dispose is ignored after settlement;
+- external pause before settlement remains an interruption;
 - listener cleanup;
 - exactly-once settlement; and
 - one active element invariant.
@@ -783,9 +863,12 @@ Cover:
 - asynchronous first-tap playback attempt;
 - gesture fallback retaining URL;
 - direct second-tap playback;
+- ready direct tap with live URL;
+- ready direct tap with expired URL refreshes before creating an audio element;
+- proactive refresh gesture rejection retains the fresh URL for a second tap;
 - rapid taps during preparation;
 - rapid taps during playback causing restart without overlap;
-- cached replay without another prepare request;
+- cached replay without another generate request;
 - background interruption and explicit replay;
 - external interruption;
 - media failure, one URL refresh, and no autoplay;
@@ -822,7 +905,7 @@ Only if CORS changes are required, add tests proving:
 
 ## Verification matrix
 
-Run the matrix on at least one current iOS Simulator and one physical development iPhone.
+Run the applicable matrix on at least one current iOS Simulator and one physical development iPhone.
 
 | Scenario | Simulator | Physical iPhone | Required evidence |
 | --- | --- | --- | --- |
@@ -830,47 +913,65 @@ Run the matrix on at least one current iOS Simulator and one physical developmen
 | Account has configured TTS | Required | Required | Settings reports configured; no key shown |
 | First server-cache or generation request | Required | Required | Source and timing recorded |
 | One-tap async prepare-and-play | Required | Required | Accepted or gesture-rejected result recorded |
-| Prepared direct-tap playback | Required | Required | Audible Japanese pronunciation |
+| Prepared direct-tap playback | Required | Required | Audible expected Japanese pronunciation |
+| Normal media volume, Ring/Silent off | Required | Required | `水` decodes and is audibly pronounced as expected without media error |
+| Ring/Silent on, media volume nonzero | Not applicable | Required | Audible/inaudible result and native-integration conclusion recorded |
 | Ten consecutive replays | Required | Required | Success/failure count |
-| Rapid taps while preparing | Required | Required | One preparation request |
+| Rapid taps while preparing | Required | Required | One settings-derived generation request |
 | Rapid taps while playing | Required | Required | No overlap; deterministic restart |
+| Locally expired ready item | Required | Required | Refresh occurs before stale audio element creation |
 | Network disabled before prepare | Required | Required | Actionable error and successful retry |
-| Invalid/expired URL simulation | Required | Required | Refresh then explicit replay succeeds |
+| Invalid/expired URL simulation | Required | Required | Failure-driven refresh then explicit replay succeeds |
 | Background during preparation | Required | Required | No stuck state |
 | Background during playback | Required | Required | Interrupted, no background continuation, replay succeeds |
 | External/system audio interruption | Best effort | Required | Outcome and limitation recorded |
 | Sign-out while ready | Required | Required | User cache cleared; route inaccessible |
 | Sign-out while playing | Required | Required | Playback stops and state clears |
 | Relaunch and replay | Required | Required | Auth restoration plus new successful playback |
-| Silent mode and volume behavior | Record | Record | Expected iOS media behavior documented |
 
 Use a test account already configured through the web application. Record provider and non-secret voice/model identifiers, but never record the provider key, bearer token, or complete signed URL.
 
-## HTML audio acceptance gate
+## HTML and native-audio acceptance gates
 
-HTML audio is acceptable for the MVP when physical-device evidence shows all of the following:
+### HTML-only accepted
 
-1. A prepared direct tap reliably produces audible Japanese pronunciation.
-2. Ten consecutive replays succeed without intermittent stuck or silent states.
-3. Rapid taps never create overlapping audio.
-4. Rapid taps never create duplicate generation requests.
-5. Invalid/expired URLs recover through refresh and an explicit replay tap.
-6. Backgrounding and foregrounding leave the controller in a recoverable state.
-7. A normal external interruption leaves the controller replayable.
-8. Sign-out and teardown stop playback and clear user-scoped cached URLs.
-9. No provider key or Cognito token is present in the bundle, logs, or diagnostic UI.
-10. Any one-tap gesture limitation is acceptable to product flows through prefetch or a documented prepare-then-play interaction.
+HTML-only playback is acceptable for the MVP only when physical-device evidence shows all of the following:
 
-A native Capacitor audio follow-up is required when physical evidence shows one or more of:
+1. A valid backend audio object decodes without media error and audibly produces the expected Japanese pronunciation at normal media volume.
+2. A prepared direct tap reliably produces audible Japanese pronunciation.
+3. Foreground pronunciation remains audible with the hardware Ring/Silent switch on and media volume nonzero.
+4. Ten consecutive replays succeed without intermittent stuck or silent states.
+5. Rapid taps never create overlapping audio.
+6. Rapid taps never create duplicate settings-derived generation requests.
+7. Proactively expired and invalid URLs recover without a stale-loop or stuck state.
+8. Backgrounding and foregrounding leave the controller in a recoverable state.
+9. A normal external interruption leaves the controller replayable.
+10. Sign-out and teardown stop playback and clear user-scoped cached URLs.
+11. No provider key or Cognito token is present in the bundle, logs, or diagnostic UI.
+12. Any one-tap gesture limitation is acceptable to product flows through prefetch or a documented prepare-then-play interaction.
 
-- prepared direct-tap playback remains intermittent;
+### Native audio-session integration required
+
+A native iOS audio-session follow-up is required when HTML decoding and player lifecycle are otherwise reliable, but one or more of these hold:
+
+- playback is inaudible with Ring/Silent on;
+- the app needs an audio-session category or interruption policy unavailable to JavaScript; or
+- the observed default session behavior conflicts with the foreground pronunciation product rule.
+
+The first follow-up should configure and verify the minimal app-level audio-session behavior while preserving `MobileAudioPlayer` and `HtmlAudioPlayer`. It must not add background modes merely to satisfy foreground silent-switch playback.
+
+### Native player adapter required
+
+A native player follow-up is required when physical evidence shows one or more of:
+
+- prepared direct-tap playback remains intermittent after correct audio-session configuration;
 - valid presigned URLs cannot be loaded reliably after correct CORS configuration;
 - interruption leaves the HTML element permanently unusable;
 - repeated playback leaks or accumulates active media elements;
-- required MVP behavior needs audio-session category, route, or interruption controls unavailable through HTML audio; or
-- the product cannot tolerate the demonstrated user-gesture interaction.
+- required player or route controls cannot be expressed through the current interface and HTML implementation; or
+- the product cannot tolerate the demonstrated user-gesture interaction and native playback demonstrably resolves it.
 
-The follow-up issue must identify the failed criterion and preserve the `MobileAudioPlayer` interface. HPA-208 does not select a plugin without that evidence.
+Every follow-up must identify the failed criterion and preserve the `MobileAudioPlayer` consumer contract unless evidence requires a contract revision. HPA-208 does not select a plugin without that evidence.
 
 ## Verification record
 
@@ -887,10 +988,12 @@ The record contains:
 - test account configuration status without secrets;
 - the completed matrix;
 - first-tap gesture result;
+- normal-volume decode/audibility result;
+- Ring/Silent-switch result;
 - URL-expiration and interruption observations;
 - any required CORS correction;
 - known limitations;
-- final `HTML audio accepted` or `native adapter required` decision; and
+- final `HTML-only accepted`, `native audio-session integration required`, or `native player adapter required` decision; and
 - links to any follow-up Linear issues.
 
 HPA-210 consumes this record during the Milestone 1 architecture review.
@@ -899,14 +1002,18 @@ HPA-210 consumes this record during the Milestone 1 architecture review.
 
 | HPA-208 criterion | Design evidence |
 | --- | --- |
-| Signed-in user hears one Japanese pronunciation on physical iPhone | Authenticated diagnostic, known `水` item, physical matrix |
-| Repeated playback has no duplicate request or accidental overlap | Service single-flight, controller tap rules, one-active-element adapter |
+| Signed-in user hears one Japanese pronunciation on physical iPhone | Authenticated diagnostic, known `水` item, normal-volume physical matrix |
+| Repeated playback has no duplicate request or accidental overlap | Settings-derived service single-flight, controller tap rules, one-active-element adapter |
 | Auth, generation, expiration, and playback failures are actionable | Structured API/TTS/audio errors and explicit view states |
 | No provider key bundled | Server-side settings only; secret scan and redacted diagnostics |
 | Web TTS unchanged | Shared contract re-export and additive backend error codes only |
-| HTML versus native conclusion recorded | Objective physical-device decision gate and verification record |
+| HTML versus native conclusion recorded | Physical silent-switch/session/player gates and verification record |
 
 ## Risks and mitigations
+
+### Silent switch and default audio session
+
+The default iOS audio session is silenced by the Ring/Silent switch. Silent-mode audibility is an explicit product requirement, so HTML-only acceptance is impossible if device evidence confirms the default behavior. The design distinguishes minimal native session configuration from full native player replacement rather than conflating them.
 
 ### Asynchronous user activation
 
@@ -914,11 +1021,19 @@ A network request may consume the original tap's user-activation window. The con
 
 ### Presigned URL expiry
 
-The local TTL expires one minute before the server URL. Media failures also invalidate and refresh once because device sleep or clock behavior can outlive the local assumption.
+The local TTL expires one minute before the server URL. The controller checks `expiresAt` before ready playback. Media failures still invalidate and refresh once because device sleep, clock behavior, or external invalidation can outlive the local assumption.
 
 ### Ambiguous media errors
 
 HTML media errors do not reliably identify HTTP status. Recovery treats the first media error as possibly stale, refreshes once, then surfaces a playback error rather than looping.
+
+### Self-generated pause events
+
+`pause()` may dispatch synchronously. The adapter settles and detaches interruption listeners before invoking cleanup methods, preventing its own restart/stop/dispose path from being misclassified as an external interruption.
+
+### Mobile API classification migration
+
+Adding `client` intentionally changes unexpected 4xx handling for existing consumers. Due-count regression tests pin 400 as non-retryable while retaining existing 5xx/network retries.
 
 ### Cross-user leakage
 
@@ -937,14 +1052,14 @@ The route is development-only and uses a fixed word. Final product integration r
 The implementation plan should sequence work approximately as follows:
 
 1. Shared TTS contracts and additive backend error codes.
-2. Mobile API POST and structured HTTP errors.
-3. Mobile TTS service, cache, concurrency, and auth isolation.
-4. Audio contract and HTML adapter.
-5. Controller state machine and lifecycle integration.
+2. Mobile API POST, structured HTTP errors, and due-count 4xx regression pinning.
+3. Mobile TTS service, settings-derived cache/concurrency, and auth isolation.
+4. Audio contract and HTML adapter with pause-ordering invariants.
+5. Controller state machine, proactive expiry, and lifecycle integration.
 6. Authenticated development diagnostic and production exclusion checks.
 7. Automated verification.
 8. Simulator matrix.
-9. Physical-iPhone matrix and architecture record.
-10. CORS correction or native-audio follow-up only when evidence requires it.
+9. Physical-iPhone normal-volume, silent-switch, interruption, and replay matrix.
+10. CORS correction, native audio-session follow-up, or native-player follow-up only when evidence requires it.
 
-No implementation begins until this design is reviewed and approved.
+No implementation begins until this revised design is reviewed and approved.

--- a/docs/superpowers/specs/2026-07-31-mobile-authenticated-tts-pronunciation-design.md
+++ b/docs/superpowers/specs/2026-07-31-mobile-authenticated-tts-pronunciation-design.md
@@ -53,11 +53,13 @@ The backend already provides:
 
 All three server-side providers enforce a 30-second provider-request timeout. After provider success, the route may still need to consume the audio body, upload it to S3, and create the signed URL. The API Lambda timeout is 60 seconds.
 
-The mobile API client's current eight-second overall feature deadline and the coordinator's independent 15-second physical-fetch timeout are both too short for a cold TTS generation request. HPA-208 must add a bounded per-request timeout override rather than changing the existing defaults globally.
+The mobile API client's current eight-second overall feature deadline and the coordinator's independent 15-second physical-fetch timeout are both too short for a cold TTS generation request. HPA-208 therefore adds bounded per-request timeout overrides without changing the existing defaults globally.
 
 The Capacitor application does not currently install a native audio plugin or configure `AVAudioSession`.
 
-Apple documents that an iOS app's default audio session is silenced by the Ring/Silent switch, while the `.playback` category continues playing with the switch set to silent. `HTMLAudioElement` cannot configure that native category itself. Device evidence therefore must treat silent-switch behavior as a product gate, not merely an observation. See [AVAudioSession](https://developer.apple.com/documentation/avfaudio/avaudiosession) and [AVAudioSession.Category.playback](https://developer.apple.com/documentation/avfaudio/avaudiosession/category-swift.struct/playback).
+Apple documents that an iOS app's default audio session is silenced by the Ring/Silent switch, while the `.playback` category continues playing with the switch set to silent. `HTMLAudioElement` cannot configure that native category itself. Device evidence therefore treats silent-switch behavior as a product gate, not merely an observation.
+
+The existing development diagnostic route collection contains only authentication-bypass pages, and its tests assert that every route in that collection has `meta.bypassMobileAuth === true`. HPA-208 adds an authenticated diagnostic and must preserve that guard by separating bypass and authenticated diagnostic route collections rather than deleting the assertion.
 
 ## Approved decisions
 
@@ -66,36 +68,43 @@ Apple documents that an iOS app's default audio session is silenced by the Ring/
 | Product scope | One authenticated known-word pronunciation diagnostic |
 | Test word | Fixed diagnostic word `水` / `みず` / `water`, using identifier `水:ミズ` |
 | Vocabulary dependency | The backend treats `vocabularyId` as an opaque TTS cache partition; the diagnostic does not require a vocabulary-table lookup or seeded database row |
+| Text/cache convention | The backend cache key omits `text`; HPA-208 uses one fixed canonical pair as an explicit client precondition, not an enforced backend invariant |
 | API flow | Check settings, then call `POST tts/generate`; do not require `GET tts/audio/:id` first |
 | Shared code | Share validated request/response/settings/error contracts, not the web service or page |
 | Web adoption | Web uses shared parsers for settings and generate success bodies; valid-response and existing error behavior remain unchanged, while malformed success responses intentionally fail validation |
 | Auth ownership | All TTS requests use the existing coordinator-owned mobile API client |
-| API client | Add authenticated JSON POST, structured HTTP errors, and a bounded per-request timeout option |
+| API client | Add authenticated JSON POST, structured bounded HTTP errors, and a bounded per-request timeout option |
 | Default deadline | Keep eight seconds for due-count, settings, and other ordinary mobile JSON requests |
 | TTS generation deadline | Use a 45-second overall deadline for `POST tts/generate` |
 | Coordinator timeout | Add a validated per-request transport timeout so TTS can exceed the current 15-second default without weakening other requests |
+| POST replay | `postJson()` serializes once to an immutable string so a coordinator 401 recovery can replay the identical body exactly once |
 | Due-count migration | Keep its retry rule (`network`/`server` only), while intentionally stopping retries for 4xx responses that previously collapsed to `server` |
-| Prepare retry | Do not automatically retry network, provider, or server failures; expose an explicit Retry control |
-| Auth control-race retry | Permit one same-user recovery attempt for the narrow session handoff/recovery cases established by HPA-207 |
+| Validator errors | An uncoded generate HTTP 400, including the Zod validator response shape, maps to `invalid_input` and is not retried |
+| Prepare retry | Do not automatically retry network, provider, client, or server failures; expose an explicit Retry control |
+| Auth control-race retry | Permit one same-user recovery attempt for narrow session handoff/recovery cases established by HPA-207 |
 | Playback seam | `MobileAudioPlayer` interface with an initial `HtmlAudioPlayer` implementation |
-| Silent-switch product rule | A prepared, direct pronunciation tap must be audible while foregrounded when Ring/Silent is on and media volume is nonzero |
+| Silent-switch product rule | A prepared direct pronunciation tap must be audible while foregrounded when Ring/Silent is on and media volume is nonzero |
 | Native integration | Do not preselect a plugin; if HTML-only playback fails silent-mode or session-control gates, create a native audio-session follow-up before considering full player replacement |
 | Concurrency | One preparation operation and one active playback per controller; service generation deduplication uses the full settings-derived cache key |
 | URL cache | User/settings/vocabulary-scoped in-memory cache, 14-minute TTL, bounded size |
 | Invalidation | Invalidating one user/vocabulary pair affects every provider/voice/model partition and prevents stale pending work from being rejoined or cached |
-| Replay | Reuse a still-live prepared URL and restart from the beginning; never overlap playback |
-| Settings reads | Every new preparation reads current settings; replay from `ready` with a live URL performs no settings request |
+| Settings reads | Every new preparation reads server-authoritative settings; no settings cache is introduced in HPA-208 |
+| Latency evidence | Record settings, generation, and tap-to-play-attempt latency separately so user-activation findings are attributable |
+| Replay | Reuse a still-live prepared URL and restart from the beginning; ready replay performs no settings request and never overlaps playback |
 | First-tap gesture | Attempt playback after asynchronous preparation and record whether iOS permits it |
 | Gesture fallback | If rejected, retain the prepared URL and require a second direct tap |
-| Audibility gate | Acceptance may use prepare -> Ready -> direct second tap; silent-switch acceptance is measured on the prepared direct-tap path, not necessarily one-gesture generation-and-play |
+| Audibility gate | Acceptance may use prepare → Ready → direct second tap; silent-switch acceptance is measured on the prepared direct-tap path, not necessarily one-gesture generation-and-play |
 | Proactive expiry | A ready tap checks `expiresAt` before playback; an expired item refreshes instead of intentionally attempting a stale URL |
 | Media failure | Still refresh once because sleep, revocation, clock changes, or transport behavior can invalidate a nominally live URL |
 | Background behavior | Stop active audio and classify it as interrupted; background audio remains unsupported |
 | Diagnostic route | Use `/diagnostics/tts-pronunciation`, following the existing diagnostic route convention |
+| Route collections | Preserve the all-bypass invariant on existing routes by separating bypass and authenticated development diagnostic arrays |
 | Diagnostic exposure | Development-only entry under More, but the route remains behind `MobileAuthGate` and has no auth-bypass metadata |
 | Provider configuration | Test account is configured on the web; mobile only reports configuration status |
 | Device evidence | Simulator checks are merge gates; a physical iPhone is the closure and architecture-decision gate |
 | Audibility evidence | Human-observed audio on a physical device speaker; audibility is not claimed from unit tests or media events alone |
+| Error details | Bounded server details are internal-only, non-enumerable, never rendered, never logged, and never included in diagnostic serialization |
+| Lifecycle source | The existing `boot/capacitor-lifecycle.ts` `appStateChange` listener feeds shared lifecycle state; no third listener is added |
 | Infrastructure | Do not broaden S3 CORS preemptively; change it only if device evidence proves it necessary |
 | Web behavior | Preserve valid web TTS request/cache/playback/settings behavior and existing user-facing errors |
 
@@ -106,17 +115,19 @@ HPA-208 includes:
 - shared runtime-validated TTS contracts;
 - stable TTS backend error codes while preserving existing `error` messages and statuses;
 - shared parser adoption for web settings and generation success responses;
-- authenticated JSON POST support in the mobile API client;
+- authenticated JSON POST support with replayable serialized bodies;
 - bounded per-request overall and coordinator transport timeout overrides;
-- structured HTTP status and server-detail preservation for feature services;
+- bounded, redacted HTTP status and server-detail preservation for feature services;
 - the intentional mobile 4xx classification migration and pinned due-count retry behavior;
-- a complete ordered API-to-TTS error mapping;
+- a complete ordered API-to-TTS error mapping, including uncoded validator 400s;
 - a mobile TTS service with settings validation, URL caching, full-key single-flight generation, and all-partition invalidation;
+- separate settings/generation/user-activation timing evidence;
 - a replaceable mobile audio interface;
 - an `HTMLAudioElement` implementation owning one active playback;
 - a pronunciation controller with explicit state transitions, manual retry policy, auth-race recovery, proactive expiry, and concurrency rules;
-- a named active/inactive lifecycle API;
-- an authenticated development-only diagnostic page for one known word;
+- a named active/inactive lifecycle API fed by the existing Capacitor lifecycle boot listener;
+- separate bypass and authenticated development diagnostic route collections;
+- an authenticated development-only diagnostic page for one fixed word;
 - lifecycle, interruption, silent-switch, decode, and audibility observation;
 - unit/component/backend/infrastructure coverage;
 - Simulator and physical-iPhone verification; and
@@ -127,17 +138,19 @@ HPA-208 includes:
 - final Review, Learn, Words, or settings integration;
 - allowing provider keys to be entered on mobile;
 - changing provider selection, voice selection, or model selection;
+- a persistent or long-lived mobile TTS settings cache;
 - speech-to-text or microphone capture;
 - AI buddy conversation audio;
 - free-form TTS text entry;
+- alternate pronunciation text for an existing vocabulary ID;
+- redesigning the backend TTS cache key to include text or enforcing a canonical vocabulary/text mapping server-side;
 - offline audio downloads or persistent audio storage;
 - background playback;
 - lock-screen controls, Now Playing integration, or remote transport controls;
 - Bluetooth route selection, recording policy, or advanced `AVAudioSession` routing/mixing policy;
 - implementing native audio-session or player integration before device evidence identifies which layer is necessary;
-- Android validation;
-- proactively adopting a native audio plugin; and
-- redesigning the backend's invariant that one vocabulary ID represents one canonical pronunciation text.
+- Android validation; and
+- proactively adopting a native audio plugin.
 
 ## Architecture
 
@@ -163,8 +176,9 @@ Settings-derived cache/pending key
 MobileApiClient POST tts/generate (45s overall)
         |
         v
-MobileAuthCoordinator adds current Cognito ID token
-and applies bounded per-request transport timeout
+MobileAuthCoordinator adds current Cognito ID token,
+applies bounded transport timeout, and may replay the
+same serialized request once after successful 401 recovery
         |
         v
 Backend checks user TTS settings and S3 object cache
@@ -198,13 +212,35 @@ HtmlAudioPlayer owns exactly one HTMLAudioElement
 
 `MobileAuthCoordinator` remains the only owner of Cognito token material and physical authenticated fetch attempts. It accepts a validated optional transport timeout for a feature request while retaining its existing 15-second default and auth-recovery rules.
 
+It may retry an authenticated request once after successful 401 recovery. This retry reuses the original request object, so feature request bodies must be replayable. HPA-208 satisfies that constraint by permitting only an already-serialized JSON string body through `postJson()`.
+
 #### Mobile API client
 
-`apps/vela-mobile/src/services/mobile-api-client.ts` owns authenticated JSON transport, the caller's overall deadline across auth recovery, transport, and body consumption, JSON syntax/body consumption, and stable transport/HTTP error normalization. It does not understand TTS domain states.
+`apps/vela-mobile/src/services/mobile-api-client.ts` owns:
+
+- authenticated JSON transport;
+- the caller's overall deadline across auth recovery, transport, replay, and body consumption;
+- replayable JSON body construction;
+- bounded response-body consumption;
+- JSON syntax handling; and
+- stable transport/HTTP error normalization.
+
+It does not understand TTS domain states.
 
 #### Mobile TTS service
 
-`apps/vela-mobile/src/services/mobile-tts.ts` owns TTS settings interpretation, generate-request construction, structural response validation, URL-cache semantics, full-key pending-work identity, all-partition invalidation, and TTS-specific error normalization. It does not create or control audio elements.
+`apps/vela-mobile/src/services/mobile-tts.ts` owns:
+
+- TTS settings interpretation;
+- settings and generation timing measurement;
+- generate-request construction;
+- structural response validation;
+- URL-cache semantics;
+- full-key pending-work identity;
+- all-partition invalidation; and
+- TTS-specific error normalization.
+
+It does not create or control audio elements.
 
 #### Mobile audio player
 
@@ -214,7 +250,7 @@ Native app-level audio-session configuration, if required, remains outside `Mobi
 
 #### Pronunciation controller
 
-`apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts` or an equivalent focused controller owns user intent, preparation/playback sequencing, local expiry checks, manual retry, same-user auth-race recovery, state transitions, lifecycle reactions, and teardown. It does not parse HTTP responses or own Cognito state.
+`apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts` or an equivalent focused controller owns user intent, preparation/playback sequencing, local expiry checks, manual retry, same-user auth-race recovery, state transitions, tap-to-play timing, lifecycle reactions, and teardown. It does not parse HTTP responses or own Cognito state.
 
 #### Diagnostic view
 
@@ -222,7 +258,7 @@ The Vue page renders controller state and exposes accessible controls. It contai
 
 ## Shared TTS contracts
 
-Create and export the following from `@vela/common`:
+Create and export:
 
 ```ts
 export type TtsProvider = 'elevenlabs' | 'openai' | 'gemini';
@@ -288,7 +324,7 @@ The web service imports and re-exports the shared types. It also uses:
 
 This preserves valid backend responses, request construction, cache behavior, and existing error-body handling. It intentionally changes only malformed 2xx success payloads from loosely accepted data into explicit validation failures. Existing web tests remain, and new parser-regression tests prove valid response behavior is unchanged.
 
-`GET tts/audio/:id` is not used by this mobile slice and remains outside parser migration unless a dedicated shared response parser is added deliberately in implementation.
+`GET tts/audio/:id` is not used by this mobile slice and remains outside parser migration unless a dedicated shared response parser is added deliberately.
 
 ## Backend error compatibility
 
@@ -296,7 +332,7 @@ TTS routes add stable `code` fields to their existing JSON error responses. Exis
 
 Mobile uses one ordered normalization algorithm:
 
-1. Parse the server body as `TtsApiErrorResponse` when available.
+1. Parse the bounded server body as `TtsApiErrorResponse` when available.
 2. Prefer a recognized stable `code`.
 3. If no code is present, apply the exact legacy 400-message compatibility table.
 4. Preserve API-client auth/session/network classifications.
@@ -332,14 +368,16 @@ Mobile uses one ordered normalization algorithm:
 | `unauthorized` | `unauthorized` |
 | `forbidden` | `forbidden` |
 | `network` | `network` |
+| `client` with status 400 and no recognized TTS code/message | `invalid_input` |
+| Other `client` result | `generation_failed` |
 | `server` with status 503 | `service_unavailable` |
 | `server` with status 504 | `generation_timeout` |
-| Other `client` or `server` result | `generation_failed` |
+| Other `server` result | `generation_failed` |
 | Structurally invalid successful TTS body | `invalid_response` |
 
 Status is sufficient for uncoded 503 and 504 responses; implementation must not require their human-readable strings. Existing uncoded 500 messages, including generation, upload, signing, or missing-bucket failures, map to `generation_failed`.
 
-Provider names and non-secret settings may be shown in the development diagnostic. Provider keys, tokens, signed URL query parameters, and raw server bodies are not logged.
+An uncoded Zod-validator 400 body is intentionally mapped by status to `invalid_input`, even though it is not shaped as `{ error: string }`. Because the mobile service validates the fixed request before dispatch, this state indicates a client/backend contract defect rather than a recoverable provider failure.
 
 ## Mobile request deadlines
 
@@ -376,7 +414,7 @@ Both methods use one private `requestJson()` implementation. `timeoutMs` is an o
 
 - current-session selection;
 - shared 401 recovery;
-- the permitted authenticated retry;
+- the permitted authenticated replay;
 - physical fetch;
 - error-body consumption; and
 - success-body consumption.
@@ -384,6 +422,18 @@ Both methods use one private `requestJson()` implementation. `timeoutMs` is an o
 Omitting `timeoutMs` retains the existing eight-second default.
 
 `GET tts/settings` uses the default. `POST tts/generate` passes `MOBILE_TTS_GENERATE_TIMEOUT_MS`.
+
+### Replayable `postJson()` invariant
+
+`postJson()` must:
+
+1. Validate and serialize the supplied value with `JSON.stringify()` before dispatch.
+2. Store the resulting immutable string in `RequestInit.body`.
+3. Use the same serialized string for the initial authenticated attempt and the one permitted post-refresh replay.
+4. Set `Content-Type: application/json` identically on both attempts.
+5. Reject serialization failure as `invalid_request` before contacting the coordinator.
+
+This client does not expose streaming bodies, `ReadableStream`, `Blob`, or `FormData`. A future API for non-replayable bodies must define its own 401/retry policy rather than silently reusing this contract.
 
 ### Coordinator request contract
 
@@ -402,12 +452,13 @@ The coordinator:
 - defaults to `MOBILE_AUTH_NETWORK_TIMEOUT_MS` for callers without an override;
 - accepts only a finite positive integer no greater than `MOBILE_AUTH_MAX_FEATURE_NETWORK_TIMEOUT_MS`;
 - rejects invalid values as `invalid_request_timeout`, mapped by `MobileApiClient` to `invalid_request`;
-- applies the timeout independently to each physical fetch attempt; and
+- applies the timeout independently to each physical fetch attempt;
+- replays the same string body once after successful 401 recovery; and
 - remains subject to the API client's outer abort signal, so auth recovery and retries cannot exceed the overall deadline.
 
 `MobileApiClient` passes the effective request timeout as `transportTimeoutMs`. If auth recovery consumes part of the overall budget, the outer signal still aborts any later attempt at the original deadline.
 
-`postJson()` sets `Content-Type: application/json` and serializes the supplied body. Authorization remains exclusively owned by `MobileAuthCoordinator`; callers cannot supply or override it.
+Authorization remains exclusively owned by `MobileAuthCoordinator`; callers cannot supply or override it.
 
 ### Deadline outcomes
 
@@ -418,9 +469,9 @@ The coordinator:
 
 ## Mobile API error contract
 
-Extend `MobileApiError` with optional HTTP detail while preserving existing construction with `{ cause }`:
-
 ```ts
+export const MOBILE_API_MAX_ERROR_BODY_BYTES = 16_384;
+
 export type MobileApiErrorCode =
   | 'invalid_request'
   | 'session_unavailable'
@@ -433,34 +484,62 @@ export type MobileApiErrorCode =
   | 'server'
   | 'invalid_response';
 
+export type MobileApiErrorDetails = {
+  status?: number;
+  serverBody?: unknown;
+  serverMessage?: string;
+  cause?: unknown;
+};
+
 export class MobileApiError extends Error {
-  constructor(
-    readonly code: MobileApiErrorCode,
-    readonly details: {
-      status?: number;
-      serverBody?: unknown;
-      serverMessage?: string;
-      cause?: unknown;
-    } = {},
-  ) {
-    super(code, { cause: details.cause });
+  readonly details: MobileApiErrorDetails;
+
+  constructor(code: MobileApiErrorCode, details: MobileApiErrorDetails = {}) {
+    super(code, details.cause === undefined ? undefined : { cause: details.cause });
     this.name = 'MobileApiError';
+    Object.defineProperty(this, 'details', {
+      value: details,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
   }
 }
 ```
 
-Existing call sites passing `{ cause }` remain valid, and the resulting `Error.cause` chain must be preserved and tested.
+The conditional `ErrorOptions` preserves today's behavior: an error created without a cause does not gain an own `cause` property, while existing call sites passing `{ cause }` preserve the chain.
 
-Response mapping:
+### Error-body bounds and redaction
+
+Every non-2xx body is consumed through one bounded reader before JSON parsing:
+
+- read no more than `MOBILE_API_MAX_ERROR_BODY_BYTES` of UTF-8 payload;
+- apply the same byte limit to JSON and text responses;
+- parse JSON only from the bounded payload;
+- retain a bounded/truncated `serverMessage` when JSON parsing is unavailable;
+- preserve HTTP classification even when the body is malformed or exceeds the limit; and
+- never retain the unread remainder.
+
+`details.serverBody` and `details.serverMessage` are domain-internal inspection data. They must never be:
+
+- rendered in a component;
+- included in telemetry or diagnostics;
+- logged directly or through `console.error(error)`;
+- spread into another object; or
+- serialized as part of the verification record.
+
+Callers log only an explicit safe summary containing the stable error code and HTTP status. Tests prove details are non-enumerable, bounded, and absent from safe diagnostics.
+
+### Response mapping
 
 | Result | Mobile API result |
 | --- | --- |
 | 2xx with valid JSON | Return parsed value |
 | 2xx with invalid/empty required JSON | `invalid_response` |
-| 400–499 except 401/403 | `client`, retaining status and parsed body/text |
+| 400–499 except 401/403 | `client`, retaining bounded internal detail |
 | 401 | Existing `unauthorized` behavior after coordinator recovery rules |
 | 403 | Existing `forbidden` behavior |
-| 500–599 | `server`, retaining status and parsed body/text |
+| 500–599 | `server`, retaining bounded internal detail |
 | Transport rejection/deadline | Existing `network` or session-recovery behavior |
 | Caller abort | Preserve `AbortError` |
 
@@ -468,13 +547,11 @@ Response mapping:
 
 Today, every non-2xx response other than 401/403 collapses to `server`, so an unexpected SRS 400 is eligible for the due-count query's existing `network`/`server` retry rule. After this change, the same response becomes deterministic `client` and is not retried.
 
-This is intentional. The retry predicate itself remains unchanged, but its input classification becomes more precise. Tests pin all three cases:
+This is intentional. The retry predicate itself remains unchanged, but its input classification becomes more precise. Tests pin:
 
-- due-count `400` -> `client` -> no retry;
-- due-count `500` -> `server` -> retry under the existing limit; and
-- network failure -> `network` -> retry under the existing limit.
-
-Error-body consumption is bounded by the selected overall request deadline. JSON is preferred when the response content type or body supports it; otherwise retain a bounded text message. Malformed error bodies do not replace the correct HTTP classification.
+- due-count `400` → `client` → no retry;
+- due-count `500` → `server` → retry under the existing limit; and
+- network failure → `network` → retry under the existing limit.
 
 ## Mobile TTS service
 
@@ -487,10 +564,16 @@ export type MobilePronunciationInput = {
   text: string;
 };
 
+export type PreparationTimings = {
+  settingsMs: number;
+  generateMs: number;
+};
+
 export type PreparedPronunciation = {
   audioUrl: string;
   source: 'memory-cache' | 'server-cache' | 'generated';
   expiresAt: number;
+  timings: PreparationTimings;
 };
 
 export type MobileTtsErrorCode =
@@ -528,27 +611,54 @@ export type MobileTtsService = {
 };
 ```
 
-`PreparedPronunciation.source` is diagnostic metadata only. It must not become final learner-facing product copy without UX review.
+`PreparedPronunciation.source` and `timings` are diagnostic metadata only. They must not become final learner-facing product copy or telemetry without UX/privacy review.
+
+### Settings-read decision
+
+Every new logical preparation reads `GET tts/settings` before selecting a settings-partitioned URL or pending generation. HPA-208 deliberately does not add a settings cache because settings are server-authoritative and may change through the web app. A stale settings cache could label or retain generated audio under an obsolete client partition while the backend has already switched provider, voice, or model.
+
+This extra round trip can consume user-activation time. The diagnostic therefore records separately:
+
+- settings request latency;
+- generation/cache response latency;
+- total tap-to-`audioPlayer.play()` invocation latency; and
+- whether WebKit accepted that asynchronous play attempt.
+
+The prepared direct-tap path remains the audibility and HTML-player acceptance gate, so a slow settings request cannot falsely reject the playback adapter itself. HPA-210 can still use the separate timing evidence to decide whether later product screens should prefetch or version TTS settings.
 
 ### Preparation algorithm
 
 For one logical preparation:
 
 1. Validate non-empty `userId`, `vocabularyId`, and `text`.
-2. Fetch and validate `GET tts/settings` through `MobileApiClient` using the default eight-second deadline.
-3. If `hasApiKey` is false, throw `MobileTtsError('not_configured')` without calling generation.
-4. Construct the full key from user ID, vocabulary ID, provider, voice, and model.
-5. Return a live URL from the in-memory cache when present.
-6. Join an existing pending generation for that full settings-derived key when present.
-7. Call `POST tts/generate` with exactly `{ vocabularyId, text }` and the 45-second deadline.
-8. Validate the response.
-9. Cache the URL for 14 minutes from receipt when invalidation generations still match.
-10. Return source `server-cache` when the backend says `cached: true`; otherwise return `generated`.
-11. Remove the pending record in `finally` if it still owns the key.
+2. Start settings timing.
+3. Fetch and validate `GET tts/settings` through `MobileApiClient` using the default eight-second deadline.
+4. Record settings timing.
+5. If `hasApiKey` is false, throw `MobileTtsError('not_configured')` without calling generation.
+6. Construct the full key from user ID, vocabulary ID, provider, voice, and model.
+7. Return a live URL from the in-memory cache when present, with `generateMs: 0`.
+8. Join an existing pending generation for that full settings-derived key when present.
+9. Start generation timing for the owning caller.
+10. Call `POST tts/generate` with exactly `{ vocabularyId, text }` and the 45-second deadline.
+11. Validate the response and record generation timing.
+12. Cache the URL for 14 minutes from receipt when invalidation generations still match.
+13. Return source `server-cache` when the backend says `cached: true`; otherwise return `generated`.
+14. Remove the pending record in `finally` if it still owns the key.
 
-This ordering intentionally matches the web service's concurrency identity. Concurrent callers may each read settings, but generation is shared only after the provider/voice/model partition is known. A settings change cannot cause a caller to join work for the previous settings key.
+Concurrent callers may each read settings, but generation is shared only after the provider/voice/model partition is known. A settings change cannot cause a caller to join work for the previous settings key.
 
-The backend does not verify that `vocabularyId` exists in the vocabulary table. The fixed `水:ミズ` identifier follows the seed convention for recognizability but does not require seed data to be present. HPA-208 does not support sending alternate text for the same vocabulary ID, so text is validated but is not an additional cache-key component.
+### Backend text/cache precondition
+
+The backend does not verify that `vocabularyId` exists in the vocabulary table, and its S3 key includes user, vocabulary ID, and settings hash—but not `text`. Consequently, two requests using the same user/vocabulary/settings tuple with different text can return silently incorrect cached audio.
+
+HPA-208 does not call this a backend invariant. It establishes an explicit client precondition:
+
+- the diagnostic always sends the fixed pair `水:ミズ` → `水`;
+- the mobile service's client cache identity mirrors the backend identity and therefore also excludes text;
+- no HPA-208 surface accepts arbitrary or alternate text; and
+- any future feature that may vary text for one vocabulary ID must first redesign or validate the backend cache identity.
+
+Including text only in the client key would not fix the server collision, so HPA-208 keeps both identities aligned and documents the limitation.
 
 ### URL cache
 
@@ -557,7 +667,7 @@ Use the established web semantics:
 - TTL: 14 minutes, one minute shorter than the backend presigned URL;
 - maximum entries: 300;
 - LRU-style refresh on access;
-- periodic expired-entry sweep plus per-key expiration check;
+- periodic five-minute expired-entry sweep plus per-key expiration check;
 - key components encoded before joining;
 - user and TTS-setting isolation; and
 - no persistent storage.
@@ -591,15 +701,13 @@ Pending work captures both generations. A result may populate the cache only if 
 4. Not forcibly abort underlying work still needed by existing callers.
 5. Prevent any detached stale completion from repopulating the cache.
 
-This guarantees that failure-driven URL recovery obtains a new signed URL even if settings changed or multiple historical settings partitions exist.
-
 `clearUser(userId)` increments the user generation, removes all of that user's cache entries, and removes their pending records from the join index. `clearAll()` is reserved for application disposal and tests. Normal auth cleanup is user-scoped.
 
 ## Pronunciation preparation retry policy
 
-Network, provider, 4xx, 5xx, and client deadline failures are manual-only. The controller shows an enabled Retry control after the current attempt settles. There is no exponential backoff and no automatic repeat of a potentially expensive or ambiguously completed generation request.
+Network, provider, uncoded validator, other 4xx, 5xx, and client deadline failures are manual-only. The controller shows an enabled Retry control after the current attempt settles. There is no exponential backoff and no automatic repeat of a potentially expensive or ambiguously completed generation request.
 
-The following auth-control cases are exceptions because they represent coordinator state transitions rather than product transport retries:
+The following auth-control cases are exceptions because they represent coordinator state transitions rather than product transport retries.
 
 ### Same-user control race
 
@@ -689,7 +797,7 @@ Required ordering invariant for restart, explicit stop, and dispose:
 2. Remove or disable the `pause` listener and clear active ownership.
 3. Only then call `audio.pause()`, reset `currentTime`, or clear `src`.
 
-The synchronous `pause` event caused by the adapter's own cleanup must never be reclassified as an external interruption. Tests must exercise synchronous pause dispatch and prove restart/stop/dispose retain their intended outcome.
+The synchronous `pause` event caused by the adapter's own cleanup must never be reclassified as an external interruption. Tests exercise synchronous pause dispatch and prove restart/stop/dispose retain their intended outcome.
 
 The adapter must not set `crossOrigin` unless device evidence demonstrates a need and the bucket policy is changed accordingly.
 
@@ -719,11 +827,12 @@ The controller keeps the prepared URL while it is locally live, including after 
 
 ### Tap from `idle`
 
-1. Transition to `preparing`.
-2. Prepare pronunciation under the retry policy above.
-3. Save the returned pronunciation.
-4. Immediately call `audioPlayer.play()` in the continuation of the original tap.
-5. Record whether iOS accepts or rejects playback after the asynchronous request chain.
+1. Capture the tap timestamp.
+2. Transition to `preparing`.
+3. Prepare pronunciation under the retry policy above.
+4. Save the returned pronunciation.
+5. Immediately call `audioPlayer.play()` in the continuation of the original tap.
+6. Record tap-to-play-attempt latency and whether iOS accepts or rejects playback after the asynchronous request chain.
 
 Failure of this asynchronous first-tap play is not by itself an HTML-audio rejection. The diagnostic may enter `ready` and complete acceptance through a direct second tap.
 
@@ -734,7 +843,7 @@ Failure of this asynchronous first-tap play is not by itself an HTML-audio rejec
 3. If the URL is expired, invalidate all settings partitions for the user/vocabulary pair and prepare a fresh URL instead of intentionally attempting stale playback.
 4. After asynchronous refresh, attempt playback once and retain the normal gesture-required second-tap fallback.
 
-Proactive expiry avoids a predictable media failure after long idle periods. Failure-driven refresh remains necessary because device sleep, clock changes, server revocation, network intermediaries, or media-layer behavior can invalidate a URL before local `expiresAt`.
+Ready replay with a live URL performs no settings or generate request.
 
 ### Tap during `preparing`
 
@@ -758,7 +867,7 @@ Stop the active handle with reason `restart`, seek to the beginning through the 
 
 ### Expired or invalid URL recovery
 
-`HTMLMediaElement` does not reliably expose the HTTP status causing a load failure. A media failure is therefore treated as a possibly expired or invalid URL:
+`HTMLMediaElement` does not reliably expose the HTTP status causing a load failure. A media failure is treated as a possibly expired or invalid URL:
 
 1. Stop and discard the failed element.
 2. Invalidate all user/vocabulary URL-cache partitions.
@@ -786,9 +895,11 @@ export function recordAppStateChange(isActive: boolean, at = Date.now()): void;
 export function recordAppResume(at = Date.now()): void;
 ```
 
-The Capacitor `appStateChange` listener calls `recordAppStateChange(event.isActive)` and then updates TanStack's `focusManager`. The existing `resume` listener continues calling `recordAppResume()`; state changes do not increment the resume counter, avoiding double counting.
+The existing `appStateChange` listener in `apps/vela-mobile/src/boot/capacitor-lifecycle.ts` calls `recordAppStateChange(event.isActive)` and then updates TanStack's `focusManager`. The existing `resume` listener in the same boot file continues calling `recordAppResume()`; state changes do not increment the resume counter, avoiding double counting.
 
-The pronunciation controller observes `mobileLifecycleState.isActive`; it does not register a competing native lifecycle listener.
+`apps/vela-mobile/src/services/mobile-auth.ts` already owns a separate auth-private `appStateChange` listener for refresh/session behavior. It remains auth-private and does not also write shared lifecycle state. HPA-208 adds no third native lifecycle listener.
+
+The pronunciation controller observes `mobileLifecycleState.isActive`.
 
 When the app becomes inactive:
 
@@ -810,8 +921,6 @@ Pronunciation is core learning content, not incidental UI feedback. The MVP prod
 
 > While the app is foregrounded, a prepared direct pronunciation tap must produce audible output when media volume is nonzero, even when the iPhone Ring/Silent switch is set to silent.
 
-Background playback remains out of scope. This requirement concerns only foreground user-initiated pronunciation.
-
 The asynchronous initial tap may prepare audio without producing sound when WebKit no longer considers the continuation user-activated. That is acceptable when the diagnostic reaches `ready` and a direct second tap plays audibly. Silent-switch and normal-audibility gates are measured on that prepared direct-tap path.
 
 The physical-device matrix determines one of three outcomes:
@@ -824,21 +933,40 @@ Silent-mode inaudibility automatically rejects the HTML-only outcome. It does no
 
 ## Diagnostic surface
 
-### Route placement
+### Route construction and authentication invariants
 
-Add a development-only child route:
+Use the existing path convention:
 
 ```text
 /diagnostics/tts-pronunciation
 ```
 
-This follows the existing `/diagnostics/ios-interactions` convention. The More page provides the entry, but the URL is not nested under `/more`. The route must **not** set `meta.bypassMobileAuth`; it is rendered only inside the authenticated mobile shell.
+The More page provides the entry, but the URL is not nested under `/more`. The route is rendered inside the authenticated mobile shell and must not set `meta.bypassMobileAuth`.
 
-Production builds must contain neither the route nor the entry. Extend the production-diagnostics verification script and route tests to prove their absence.
+Preserve the current bypass-route safety test by splitting route declarations:
+
+```ts
+export const bypassDevelopmentDiagnosticRoutes: RouteRecordRaw[] = [
+  // Existing iOS interaction root and detail routes.
+  // Every entry explicitly sets meta.bypassMobileAuth = true.
+];
+
+export const authenticatedDevelopmentDiagnosticRoutes: RouteRecordRaw[] = [
+  // TTS pronunciation route.
+  // No entry may set meta.bypassMobileAuth = true.
+];
+
+export const developmentDiagnosticRoutes: RouteRecordRaw[] = [
+  ...bypassDevelopmentDiagnosticRoutes,
+  ...authenticatedDevelopmentDiagnosticRoutes,
+];
+```
+
+`buildMobileChildRoutes()` still accepts the combined collection. Tests retain a meaningful `every(... === true)` assertion on `bypassDevelopmentDiagnosticRoutes`, add the inverse assertion on `authenticatedDevelopmentDiagnosticRoutes`, and verify the combined development route list contains both groups. The implementation must not simply delete the existing bypass guard.
+
+Production builds contain neither the route nor the More entry. Extend the production-diagnostics scanner and route tests to prove their absence.
 
 ### Known word
-
-Use:
 
 ```ts
 const DIAGNOSTIC_WORD = {
@@ -849,7 +977,7 @@ const DIAGNOSTIC_WORD = {
 } as const;
 ```
 
-The identifier follows the standard seed convention, but the TTS backend does not query the vocabulary table. The page does not query vocabulary APIs and does not allow arbitrary text, keeping the spike deterministic and free of unrelated dependencies.
+The identifier follows the standard seed convention, but the TTS backend does not query the vocabulary table. The page does not query vocabulary APIs and does not allow arbitrary text.
 
 ### Presentation
 
@@ -865,11 +993,14 @@ Pronunciation diagnostics
 
 State: Ready
 Source: memory cache / server cache / generated
+Settings latency: …
+Generation latency: …
+Tap-to-play attempt: …
 Playback adapter: HTML audio
 Last outcome: Completed
 ```
 
-`Source` is diagnostic-only metadata and is not approved learner-facing product copy.
+`Source` and latency fields are diagnostic-only metadata and are not approved learner-facing product copy.
 
 Expose accessible states through `role="status"`, `aria-live="polite"`, and `role="alert"` where appropriate. The control label reflects state:
 
@@ -886,13 +1017,13 @@ A collapsed development section may provide:
 - invalidate the current user/vocabulary across all settings partitions;
 - simulate one invalid URL by replacing only the current diagnostic copy with a known-unreachable HTTPS URL;
 - clear diagnostic counters;
-- show preparation count, backend source, playback attempts, completed plays, gesture rejections, interruptions, URL refreshes, and last classified error;
+- show preparation count, backend source, settings latency, generation latency, tap-to-play latency, playback attempts, completed plays, gesture rejections, interruptions, URL refreshes, and last classified error;
 - show current app active state; and
 - show the observed native audio-session category when safely available, without making that observation a player dependency.
 
 Never render the complete presigned URL because its query string contains temporary credentials. Display only the URL host and a redacted path suffix when needed for debugging.
 
-The invalid-URL control provides deterministic expired-URL recovery evidence without waiting 15 minutes or mutating server storage.
+Never display or log `MobileApiError.details.serverBody` or `serverMessage`.
 
 ## User-facing states
 
@@ -907,14 +1038,13 @@ The invalid-URL control provides deterministic expired-URL recovery evidence wit
 | Locally expired | “Refreshing expired audio…” then normal play or second-tap fallback |
 | Interrupted | “Playback was interrupted. Tap to replay.” |
 | TTS not configured | “Pronunciation is not configured for this account. Configure TTS in Vela web settings.” |
+| Invalid request contract | “Vela couldn’t prepare this pronunciation.” No automatic retry |
 | Network/deadline failure | “Vela couldn’t load pronunciation. Check your connection and try again.” Manual Retry |
 | Provider timeout response | “Pronunciation generation timed out. Try again.” Manual Retry |
 | Service unavailable | “Pronunciation is temporarily unavailable. Try again.” Manual Retry |
 | URL refreshed | “Audio was refreshed. Tap to play again.” |
 | Playback failure | “Vela couldn’t play this pronunciation. Try again.” |
 | Silent-mode failure | Diagnostic records native audio-session integration as required; do not misreport completion as audible success |
-
-The diagnostic may mention that configuration is managed on the web. It does not deep-link to or embed the web settings page in this milestone.
 
 ## Authentication and user isolation
 
@@ -924,8 +1054,8 @@ The controller passes the current authenticated user ID to `MobileTtsService` so
 
 Install a focused TTS auth-isolation watcher or equivalent service hook:
 
-- identity replacement clears only the previous user’s TTS cache/pending index and stops current audio;
-- sign-out clears only the previous user’s TTS cache/pending index and stops current audio;
+- identity replacement clears only the previous user's TTS cache/pending index and stops current audio;
+- sign-out clears only the previous user's TTS cache/pending index and stops current audio;
 - unusable session recovery detaches/aborts the current diagnostic operation without globally clearing successor state;
 - stale pending completion cannot cache after targeted or user invalidation; and
 - a null-to-user transition performs no cleanup.
@@ -947,7 +1077,7 @@ Therefore:
 5. Preserve current web origins and infrastructure tests.
 6. Never use `*` as the allowed origin.
 
-A required bucket-policy correction remains within HPA-208 because it is necessary for the existing presigned-audio architecture to function. A native plugin adopted solely to bypass a correctable bucket CORS policy is not the preferred outcome.
+A required bucket-policy correction remains within HPA-208. A native plugin adopted solely to bypass a correctable bucket CORS policy is not the preferred outcome.
 
 ## Testing
 
@@ -973,22 +1103,29 @@ Cover:
 Cover:
 
 - POST method and JSON body;
+- JSON serialization failure before dispatch;
 - coordinator-owned Authorization;
 - rejection of caller Authorization remains intact;
-- caller abort;
 - default eight-second overall deadline;
 - accepted 45-second request override;
 - invalid, zero, non-integer, and over-maximum timeout rejection;
 - coordinator default 15-second physical timeout retained;
 - coordinator per-request transport override;
 - outer deadline still caps auth recovery plus retried transport;
+- caller abort;
 - total deadline across transport and body consumption;
+- initial POST returns 401, refresh succeeds, and one replay uses the identical method, content type, and serialized body;
+- no empty, consumed, or reserialized body on replay;
+- no second replay after the retried request;
 - session recovery mappings;
 - 2xx JSON success;
-- 4xx `client` classification with parsed JSON and text detail;
-- 5xx `server` classification with detail;
+- 4xx `client` classification with bounded JSON and text detail;
+- 5xx `server` classification with bounded detail;
+- JSON and text payloads exceeding the error-body byte limit are truncated/discarded safely;
+- details are non-enumerable and absent from safe diagnostic serialization;
 - malformed success JSON;
 - existing `{ cause }` call sites preserve `Error.cause` and `MobileApiError.name`;
+- no own `cause` property when cause is omitted;
 - due-count 400 is classified `client` and is not retried;
 - due-count 500 remains `server` and is retried under the existing limit; and
 - due-count network failure remains retryable under the existing limit.
@@ -1007,10 +1144,13 @@ Cover:
 - user ID absent from the request body;
 - not-configured settings short-circuit;
 - ordered stable-code, legacy-message, API-code, and status mapping;
+- uncoded Zod-validator-shaped 400 maps to `invalid_input`;
 - status-only 503 and 504 mapping without message matching;
 - uncoded 500 generation/upload/signing messages map to `generation_failed`;
 - JSON-syntax versus structural-response error attribution;
-- 14-minute cache TTL;
+- no raw server detail is rendered or logged;
+- settings and generation timings are recorded separately;
+- 14-minute cache TTL and five-minute sweep;
 - per-user, provider, voice, model, and vocabulary isolation;
 - settings fetched before full-key pending lookup;
 - same-full-key pending generation sharing;
@@ -1022,6 +1162,7 @@ Cover:
 - targeted invalidation removes all settings partitions;
 - targeted invalidation prevents new callers joining stale pending work;
 - stale pending completion cannot repopulate after invalidation;
+- fixed diagnostic pair is used consistently;
 - sign-out generation guard; and
 - redaction/no-secret logging.
 
@@ -1050,13 +1191,14 @@ Cover:
 
 - idle to preparing to playing to ready;
 - asynchronous first-tap playback attempt;
+- separate settings, generate, and tap-to-play timing recording;
 - gesture fallback retaining URL;
 - direct second-tap playback;
 - same-user `session_changed`/`session_unavailable` control race retries once;
 - second control race remains visible;
 - `session_recovery_pending` retries once when the same user becomes usable;
 - identity change cancels pending recovery continuation;
-- network/provider/server failure has no automatic retry;
+- network/provider/server/invalid-input failure has no automatic retry;
 - explicit Retry starts one new preparation;
 - ready direct tap with live URL;
 - ready replay does not fetch settings;
@@ -1073,8 +1215,9 @@ Cover:
 - identity change and sign-out;
 - component teardown;
 - stale asynchronous completion unable to overwrite successor state;
-- `recordAppStateChange()` updates active state and timestamps without incrementing resume count; and
-- Capacitor lifecycle boot uses the canonical lifecycle API.
+- `recordAppStateChange()` updates active state and timestamps without incrementing resume count;
+- `boot/capacitor-lifecycle.ts` feeds shared lifecycle state exactly once per event; and
+- the auth-private listener does not duplicate shared lifecycle updates.
 
 ### Component and route tests
 
@@ -1084,7 +1227,10 @@ Cover:
 - accessible control labels and live regions;
 - counters and redaction;
 - authenticated `/diagnostics/tts-pronunciation` behavior;
-- no auth bypass metadata;
+- no auth bypass metadata on authenticated diagnostic routes;
+- all existing bypass routes remain explicitly marked;
+- the all-bypass `every(...)` assertion remains on `bypassDevelopmentDiagnosticRoutes`;
+- combined development route construction includes both route groups;
 - development-only More entry;
 - development-only route registration; and
 - production build exclusion.
@@ -1107,13 +1253,13 @@ Run the applicable matrix on at least one current iOS Simulator and one physical
 | --- | --- | --- | --- |
 | Restored authenticated session | Required | Required | User reaches diagnostic without sign-in prompt while session valid |
 | Account has configured TTS | Required | Required | Settings reports configured; no key shown |
-| First server-cache request | Required | Required | Source and timing recorded |
-| First uncached generation | Required | Required | Completes inside 45-second client budget or produces classified failure |
-| One-tap async prepare-and-play | Required | Required | Accepted or gesture-rejected result recorded; not itself the silent-mode gate |
+| First server-cache request | Required | Required | Settings latency, generate/cache latency, and source recorded |
+| First uncached generation | Required | Required | Separate settings and generation timing; completes inside 45-second budget or produces classified failure |
+| One-tap async prepare-and-play | Required | Required | Tap-to-play-attempt latency and accepted/gesture-rejected result recorded; not itself the silent-mode gate |
 | Prepared direct-tap playback | Required | Required | Audible expected Japanese pronunciation |
 | Normal media volume, Ring/Silent off | Required | Required | `水` decodes and is audibly pronounced as expected without media error |
 | Ring/Silent on, media volume nonzero | Not applicable | Required | Prepared direct tap is human-observed as audible/inaudible on device speaker; native-integration conclusion recorded |
-| Ten consecutive prepared replays | Required | Required | Success/failure count |
+| Ten consecutive prepared replays | Required | Required | Success/failure count; no settings requests during live replay |
 | Rapid taps while preparing | Required | Required | One settings-derived generation request |
 | Rapid taps while playing | Required | Required | No overlap; deterministic restart |
 | Locally expired ready item | Required | Required | Refresh occurs before stale audio element creation |
@@ -1130,7 +1276,7 @@ Run the applicable matrix on at least one current iOS Simulator and one physical
 
 Audibility is a manual physical observation. Media `play`, `playing`, and `ended` events demonstrate element state but do not prove that a person heard sound. Record whether evidence used the built-in speaker; optional headphone or Bluetooth observations are separate and do not replace the speaker silent-switch test.
 
-Use a test account already configured through the web application. Record provider and non-secret voice/model identifiers, but never record the provider key, bearer token, or complete signed URL.
+Use a test account already configured through the web application. Record provider and non-secret voice/model identifiers, but never record the provider key, bearer token, complete signed URL, or bounded internal server body.
 
 ## HTML and native-audio acceptance gates
 
@@ -1148,7 +1294,7 @@ HTML-only playback is acceptable for the MVP only when physical-device evidence 
 8. Backgrounding and foregrounding leave the controller in a recoverable state.
 9. A normal external interruption leaves the controller replayable.
 10. Sign-out and teardown stop playback and clear user-scoped cached URLs.
-11. No provider key or Cognito token is present in the bundle, logs, or diagnostic UI.
+11. No provider key, Cognito token, signed URL, or raw server error detail is present in the bundle, logs, or diagnostic UI.
 12. Any asynchronous first-tap gesture limitation is acceptable through a documented prepare-then-direct-play interaction.
 
 ### Native audio-session integration required
@@ -1188,14 +1334,17 @@ The record contains:
 - Xcode, iOS, Quasar, Capacitor, and device versions;
 - test account configuration status without secrets;
 - the completed matrix;
-- first server-cache and uncached-generation timing;
+- settings latency;
+- server-cache/generation latency;
+- total tap-to-play-attempt latency;
+- first uncached-generation timing;
 - first-tap gesture result;
 - prepared direct-tap normal-volume audibility result;
 - Ring/Silent-switch prepared direct-tap result;
 - human-observation output route;
 - URL-expiration and interruption observations;
 - any required CORS correction;
-- known limitations;
+- known limitations, including the unenforced vocabulary ID/text cache convention;
 - final `HTML-only accepted`, `native audio-session integration required`, or `native player adapter required` decision; and
 - links to any follow-up Linear issues.
 
@@ -1207,7 +1356,7 @@ HPA-210 consumes this record during the Milestone 1 architecture review.
 | --- | --- |
 | Signed-in user hears one Japanese pronunciation on physical iPhone | Authenticated diagnostic, fixed `水` item, prepared direct-tap human audibility matrix |
 | Repeated playback has no duplicate request or accidental overlap | Settings-derived service single-flight, controller tap rules, one-active-element adapter |
-| Auth, generation, expiration, and playback failures are actionable | Structured API/TTS/audio errors, bounded deadlines, manual retry, and explicit view states |
+| Auth, generation, expiration, and playback failures are actionable | Structured API/TTS/audio errors, bounded deadlines/details, manual retry, and explicit view states |
 | No provider key bundled | Server-side settings only; secret scan and redacted diagnostics |
 | Web TTS remains compatible | Shared parser adoption with valid-response regression tests and unchanged non-2xx messages/statuses |
 | HTML versus native conclusion recorded | Physical silent-switch/session/player gates and verification record |
@@ -1222,13 +1371,33 @@ All providers may run for 30 seconds before the backend returns 504, and S3 work
 
 A backend 504 proves the provider timed out and maps to `generation_timeout`. A client-side abort before an HTTP response cannot prove provider outcome and maps to `network`; no automatic repeat risks duplicating expensive or ambiguously completed work.
 
+### Replayable POST dependency
+
+The coordinator may replay an authenticated request after 401 recovery. `postJson()` serializes to a stable string before dispatch, making the body replayable. HPA-208 does not generalize this behavior to streams or multipart bodies.
+
+### Validator response shape
+
+Hono/Zod validation failures do not necessarily use the TTS `{ error }` contract. An uncoded generate 400 therefore maps by status to `invalid_input`, and tests use the validator-shaped body rather than assuming a TTS error message.
+
+### Settings latency and user activation
+
+A settings request before generation increases the asynchronous gap after the first tap. HPA-208 keeps settings server-authoritative, records settings and generation latency separately, and uses the prepared direct-tap path to judge playback reliability. A later product slice may add prefetch or versioned settings caching using this evidence.
+
+### Unenforced vocabulary ID/text convention
+
+The backend cache key omits text. HPA-208 is safe only because it sends one fixed identifier/text pair. Future alternate-text use requires a backend cache-contract change; adding text only to the mobile key is insufficient.
+
+### Error-detail leakage
+
+The API client retains only a bounded internal server payload, marks details non-enumerable, and forbids rendering or wholesale error logging. Safe diagnostics contain stable code and status only.
+
 ### Silent switch and default audio session
 
-The default iOS audio session is silenced by Ring/Silent. Silent-mode audibility is an explicit product requirement, so HTML-only acceptance is impossible if prepared direct-tap evidence confirms the default behavior. The design distinguishes minimal native session configuration from full native player replacement rather than conflating them.
+The default iOS audio session is silenced by Ring/Silent. Silent-mode audibility is an explicit product requirement, so HTML-only acceptance is impossible if prepared direct-tap evidence confirms the default behavior. The design distinguishes minimal native session configuration from full native player replacement.
 
 ### Asynchronous user activation
 
-A network request may consume the original tap's user-activation window. The controller attempts one-tap playback, records the result, and supports a prepared second tap without repeating generation. Audibility and silent-switch gates use the prepared direct-tap path.
+A network request may consume the original tap's user-activation window. The controller attempts one-tap playback, records attributable timing, and supports a prepared second tap without repeating generation. Audibility and silent-switch gates use the prepared direct-tap path.
 
 ### Presigned URL expiry
 
@@ -1241,6 +1410,14 @@ HTML media errors do not reliably identify HTTP status. Recovery treats the firs
 ### Self-generated pause events
 
 `pause()` may dispatch synchronously. The adapter settles and detaches interruption listeners before invoking cleanup methods, preventing its own restart/stop/dispose path from being misclassified as an external interruption.
+
+### Diagnostic authentication regression
+
+Existing route tests assert that every route in the bypass collection is explicitly bypassed. HPA-208 preserves that assertion by adding a separate authenticated diagnostic collection and testing both collections independently.
+
+### Lifecycle listener duplication
+
+The existing Capacitor lifecycle boot listener feeds shared state; the auth coordinator keeps its auth-private listener. The pronunciation controller observes shared state and adds no third native listener.
 
 ### Mobile API classification migration
 
@@ -1262,15 +1439,15 @@ The route is development-only and uses a fixed word. Final product integration r
 
 The implementation plan should sequence work approximately as follows:
 
-1. Shared TTS contracts, web parser adoption, and additive backend error codes.
-2. Mobile API POST, structured HTTP errors, per-request overall/coordinator timeout APIs, and due-count 4xx regression pinning.
-3. Mobile TTS service, ordered error mapping, settings-derived cache/concurrency, all-partition invalidation, and auth isolation.
+1. Shared TTS contracts, web parser adoption, additive backend error codes, and validator-400 coverage.
+2. Mobile API POST with replayable string bodies, structured bounded HTTP errors, per-request overall/coordinator timeout APIs, and due-count 4xx regression pinning.
+3. Mobile TTS service with ordered error mapping, attributable timings, settings-derived cache/concurrency, all-partition invalidation, canonical-text precondition, and auth isolation.
 4. Audio contract and HTML adapter with pause-ordering invariants.
-5. Controller state machine, manual retry, same-user auth recovery, proactive expiry, and lifecycle integration through `recordAppStateChange()`.
-6. Authenticated `/diagnostics/tts-pronunciation` page and production exclusion checks.
-7. Automated verification, including cold-generation timeout behavior.
+5. Controller state machine, manual retry, same-user auth recovery, proactive expiry, attributable tap timing, and lifecycle integration through the existing `boot/capacitor-lifecycle.ts` listener and `recordAppStateChange()`.
+6. Split bypass/authenticated diagnostic route collections, add authenticated `/diagnostics/tts-pronunciation`, and extend production exclusion checks.
+7. Automated verification, including cold-generation timeout, validator 400, POST 401 replay, body bounds, redaction, route guards, and lifecycle-listener ownership.
 8. Simulator matrix.
-9. Physical-iPhone normal-volume, prepared direct-tap silent-switch, interruption, and replay matrix with human audibility evidence.
+9. Physical-iPhone normal-volume, prepared direct-tap silent-switch, interruption, and replay matrix with human audibility evidence and separate latency records.
 10. CORS correction, native audio-session follow-up, or native-player follow-up only when evidence requires it.
 
 No implementation begins until this revised design is reviewed and approved.

--- a/docs/superpowers/specs/2026-07-31-mobile-authenticated-tts-pronunciation-design.md
+++ b/docs/superpowers/specs/2026-07-31-mobile-authenticated-tts-pronunciation-design.md
@@ -1,0 +1,950 @@
+# HPA-208: Authenticated TTS Pronunciation Playback on iOS
+
+**Date:** 2026-07-31
+
+**Linear:** [HPA-208](https://linear.app/cwchanap/issue/HPA-208/mobile-mvpm1-validate-authenticated-tts-pronunciation-playback-on-ios)
+
+**Parent:** HPA-194 — Mobile MVP M1
+
+## Goal
+
+Prove that a restored, signed-in Vela user can request and repeatedly play one Japanese pronunciation inside the Capacitor iOS application using the existing authenticated TTS backend and presigned S3 audio flow.
+
+The implementation must answer one explicit architecture question:
+
+> Is an `HTMLAudioElement` adapter reliable enough for the iOS MVP, or must the next mobile milestone introduce a native Capacitor audio adapter?
+
+This is a production-shaped validation slice, not the final pronunciation experience. It establishes stable boundaries for authenticated TTS requests, expiring audio URLs, playback ownership, user-visible state, and future native replacement without importing the web TTS settings page or exposing Cognito tokens to feature code.
+
+## Current state
+
+HPA-204 established the absolute native API URL and approved `capacitor://localhost` for the Vela API CORS policy.
+
+HPA-206 established the mobile Cognito session owner. ID and access tokens remain private to `MobileAuthCoordinator`; feature code calls `requestAuthenticatedApi()` instead of reading tokens.
+
+HPA-207 established:
+
+- a coordinator-owned authenticated feature-request boundary;
+- bounded request execution and current-generation 401 recovery;
+- `MobileApiClient.getJson()`;
+- a mobile service registry;
+- user-scoped feature state and sign-out isolation patterns; and
+- an authenticated Home vertical slice.
+
+The existing web TTS service currently combines six responsibilities:
+
+1. Amplify session access;
+2. TTS settings retrieval;
+3. authenticated TTS generation and existing-audio lookup;
+4. a 14-minute in-memory presigned-URL cache;
+5. same-key in-flight request deduplication; and
+6. direct `HTMLAudioElement` playback.
+
+Its useful cache and concurrency semantics should be preserved, but the module itself must not be imported into mobile because it owns web authentication and mixes transport with playback.
+
+The backend already provides:
+
+- `GET /api/tts/settings`;
+- `POST /api/tts/generate`; and
+- `GET /api/tts/audio/:vocabularyId`.
+
+`POST /api/tts/generate` checks the user-scoped S3 cache before invoking the configured provider, stores generated audio privately, and returns a presigned URL valid for 900 seconds. The backend derives the provider credential from the authenticated user's server-side TTS settings. No provider API key is returned to or bundled in the mobile application.
+
+The Capacitor application does not currently install a native audio plugin.
+
+## Approved decisions
+
+| Area | Decision |
+| --- | --- |
+| Product scope | One authenticated known-word pronunciation diagnostic |
+| Test word | Seeded vocabulary item `水` / `みず` / `water`, deterministic ID `水:ミズ` |
+| API flow | Check settings, then call `POST tts/generate`; do not require `GET tts/audio/:id` first |
+| Shared code | Share validated request/response/settings/error contracts, not the web service or page |
+| Auth ownership | All TTS requests use the existing coordinator-owned mobile API client |
+| API client | Add authenticated JSON POST and structured HTTP error details without changing due-count behavior |
+| Playback seam | `MobileAudioPlayer` interface with an initial `HtmlAudioPlayer` implementation |
+| Native plugin | Do not install one unless device evidence fails the HTML-audio decision gate |
+| Concurrency | One preparation request and one active playback per controller; same-key service requests share work |
+| URL cache | User/settings/vocabulary-scoped in-memory cache, 14-minute TTL, bounded size |
+| Replay | Reuse the prepared URL and restart from the beginning; never overlap playback |
+| First-tap gesture | Attempt playback after async preparation and record whether iOS permits it |
+| Gesture fallback | If rejected, retain the prepared URL and require a second direct tap |
+| Expired URL | Invalidate, refresh, and require another tap; do not autoplay after async recovery |
+| Background behavior | Stop active audio and classify it as interrupted; background audio remains unsupported |
+| Diagnostic exposure | Development-only route under More, but still behind `MobileAuthGate` |
+| Provider configuration | Test account is configured on the web; mobile only reports configuration status |
+| Device evidence | Simulator checks are merge gates; a physical iPhone is the closure and architecture-decision gate |
+| Infrastructure | Do not broaden S3 CORS preemptively; change it only if device evidence proves it necessary |
+| Web behavior | Preserve existing web TTS request, cache, playback, and settings behavior |
+
+## Scope
+
+HPA-208 includes:
+
+- shared runtime-validated TTS contracts;
+- stable TTS backend error codes while preserving existing `error` messages;
+- authenticated JSON POST support in the mobile API client;
+- structured HTTP status and server-detail preservation for feature services;
+- a mobile TTS service with settings validation, URL caching, and same-key single-flight preparation;
+- a replaceable mobile audio interface;
+- an `HTMLAudioElement` implementation owning one active playback;
+- a pronunciation controller with explicit state transitions and concurrency rules;
+- an authenticated development-only diagnostic page for one known word;
+- lifecycle and interruption observation;
+- unit/component/infrastructure coverage;
+- Simulator and physical-iPhone verification; and
+- a written HTML-audio versus native-adapter conclusion.
+
+## Non-goals
+
+- final Review, Learn, Words, or settings integration;
+- allowing provider keys to be entered on mobile;
+- changing provider selection, voice selection, or model selection;
+- speech-to-text or microphone capture;
+- AI buddy conversation audio;
+- free-form TTS text entry;
+- offline audio downloads or persistent audio storage;
+- background playback;
+- lock-screen controls, Now Playing integration, or remote transport controls;
+- Bluetooth route selection or advanced `AVAudioSession` policy;
+- Android validation;
+- proactively adopting a native audio plugin; and
+- redesigning the backend's invariant that one vocabulary ID represents one canonical pronunciation text.
+
+## Architecture
+
+### End-to-end flow
+
+```text
+Authenticated development diagnostic page
+                    |
+                    v
+Pronunciation controller receives direct tap
+                    |
+                    v
+MobileTtsService.preparePronunciation(...)
+        |                       |
+        |                       +--> 14-minute user/settings URL cache
+        v
+MobileApiClient GET tts/settings
+        |
+        v
+MobileAuthCoordinator adds current Cognito ID token
+        |
+        v
+MobileApiClient POST tts/generate
+        |
+        v
+Backend checks user TTS settings and S3 object cache
+        |
+        v
+Provider generation when needed -> private S3 object
+        |
+        v
+Validated { audioUrl, cached } response
+        |
+        v
+Controller attempts MobileAudioPlayer.play(audioUrl)
+        |
+        v
+HtmlAudioPlayer owns exactly one HTMLAudioElement
+```
+
+### Responsibility boundaries
+
+#### Shared contracts
+
+`packages/common/src/contracts/tts.ts` owns platform-neutral data contracts and parsers. It has no fetch, auth, Vue, browser-audio, or provider implementation dependencies.
+
+#### Mobile API client
+
+`apps/vela-mobile/src/services/mobile-api-client.ts` owns authenticated JSON transport, execution deadlines, response-body consumption, and stable transport/HTTP error normalization. It does not understand TTS domain states.
+
+#### Mobile TTS service
+
+`apps/vela-mobile/src/services/mobile-tts.ts` owns TTS settings interpretation, generate-request construction, response parsing, URL-cache semantics, and TTS-specific error normalization. It does not create or control audio elements.
+
+#### Mobile audio player
+
+`apps/vela-mobile/src/audio/mobile-audio-contract.ts` defines the replaceable playback boundary. `apps/vela-mobile/src/audio/html-audio-player.ts` is the first implementation. No learning component or diagnostic page constructs `Audio` directly.
+
+#### Pronunciation controller
+
+`apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts` or an equivalent focused controller owns user intent, preparation/playback sequencing, state transitions, retry policy, lifecycle reactions, and teardown. It does not parse HTTP responses or own Cognito state.
+
+#### Diagnostic view
+
+The Vue page renders the controller state and exposes accessible controls. It contains no request, cache, or playback implementation logic.
+
+## Shared TTS contracts
+
+Create and export the following from `@vela/common`:
+
+```ts
+export type TtsProvider = 'elevenlabs' | 'openai' | 'gemini';
+
+export interface TtsSettings {
+  provider: TtsProvider;
+  voiceId: string | null;
+  model: string | null;
+  hasApiKey: boolean;
+}
+
+export interface GeneratePronunciationRequest {
+  vocabularyId: string;
+  text: string;
+}
+
+export interface GeneratePronunciationResponse {
+  audioUrl: string;
+  cached: boolean;
+}
+
+export type TtsApiErrorCode =
+  | 'tts_not_configured'
+  | 'tts_invalid_provider_configuration'
+  | 'tts_audio_service_unavailable'
+  | 'tts_generation_timeout'
+  | 'tts_generation_failed'
+  | 'tts_audio_storage_failed'
+  | 'tts_audio_access_failed';
+
+export interface TtsApiErrorResponse {
+  error: string;
+  code?: TtsApiErrorCode;
+}
+```
+
+Add runtime parsers:
+
+```ts
+parseTtsSettings(value: unknown): TtsSettings;
+parseGeneratePronunciationResponse(value: unknown): GeneratePronunciationResponse;
+parseTtsApiErrorResponse(value: unknown): TtsApiErrorResponse | null;
+```
+
+Validation requirements:
+
+- provider is one of the supported values;
+- `voiceId` and `model` are strings or null;
+- `hasApiKey` and `cached` are booleans;
+- `audioUrl` is an absolute HTTPS URL;
+- request vocabulary ID and text are non-empty after trimming;
+- error parsing accepts the existing `{ error: string }` shape;
+- unknown response fields are ignored; and
+- invalid success bodies become `MobileApiError('invalid_response')` at the mobile service boundary.
+
+The web service imports and re-exports the shared types and parsers while preserving its public API and behavior.
+
+### Backend error compatibility
+
+TTS routes add stable `code` fields to their existing JSON error responses. The existing human-readable `error` strings remain unchanged so current web behavior and tests remain valid.
+
+Mobile maps by stable code first. During mixed-version deployment or local development, it falls back to status plus the existing error string for the two configuration messages. This fallback is compatibility behavior, not the primary long-term contract.
+
+## Mobile API client extension
+
+### Public contract
+
+Extend the client without exposing a generic arbitrary-header escape hatch:
+
+```ts
+export type MobileApiClient = {
+  getJson(path: string, options?: MobileApiRequestOptions): Promise<unknown>;
+  postJson(
+    path: string,
+    body: unknown,
+    options?: MobileApiRequestOptions,
+  ): Promise<unknown>;
+};
+
+type MobileApiRequestOptions = {
+  signal?: AbortSignal;
+};
+```
+
+Both methods use one private `requestJson()` implementation.
+
+`postJson()` sets `Content-Type: application/json` and serializes the supplied body. Authorization remains exclusively owned by `MobileAuthCoordinator`; callers cannot supply or override it.
+
+### Error contract
+
+Extend `MobileApiError` with optional HTTP detail while preserving all existing codes and behavior:
+
+```ts
+export type MobileApiErrorCode =
+  | 'invalid_request'
+  | 'session_unavailable'
+  | 'session_changed'
+  | 'session_recovery_pending'
+  | 'unauthorized'
+  | 'forbidden'
+  | 'client'
+  | 'network'
+  | 'server'
+  | 'invalid_response';
+
+export class MobileApiError extends Error {
+  constructor(
+    readonly code: MobileApiErrorCode,
+    readonly details: {
+      status?: number;
+      serverBody?: unknown;
+      serverMessage?: string;
+      cause?: unknown;
+    } = {},
+  ) {
+    super(code, { cause: details.cause });
+  }
+}
+```
+
+Response mapping:
+
+| Result | Mobile API result |
+| --- | --- |
+| 2xx with valid JSON | Return parsed value |
+| 2xx with invalid/empty required JSON | `invalid_response` |
+| 400–499 except 401/403 | `client`, retaining status and parsed body/text |
+| 401 | Existing `unauthorized` behavior after coordinator recovery rules |
+| 403 | Existing `forbidden` behavior |
+| 500–599 | `server`, retaining status and parsed body/text |
+| Transport rejection/deadline | Existing `network` or session-recovery behavior |
+| Caller abort | Preserve `AbortError` |
+
+The due-count query continues retrying only `network` and `server`; the new `client` code is deterministic and is not retried.
+
+Error-body consumption is bounded by the existing request deadline. JSON is preferred when the response content type or body supports it; otherwise retain a bounded text message. Malformed error bodies do not replace the correct HTTP classification.
+
+## Mobile TTS service
+
+### Public contract
+
+```ts
+export type MobilePronunciationInput = {
+  userId: string;
+  vocabularyId: string;
+  text: string;
+};
+
+export type PreparedPronunciation = {
+  audioUrl: string;
+  source: 'memory-cache' | 'server-cache' | 'generated';
+  expiresAt: number;
+};
+
+export type MobileTtsErrorCode =
+  | 'invalid_input'
+  | 'not_configured'
+  | 'session_unavailable'
+  | 'session_changed'
+  | 'session_recovery_pending'
+  | 'unauthorized'
+  | 'forbidden'
+  | 'network'
+  | 'service_unavailable'
+  | 'generation_timeout'
+  | 'generation_failed'
+  | 'invalid_response';
+
+export class MobileTtsError extends Error {
+  constructor(
+    readonly code: MobileTtsErrorCode,
+    options?: { cause?: unknown },
+  ) {
+    super(code, options);
+  }
+}
+
+export type MobileTtsService = {
+  preparePronunciation(
+    input: MobilePronunciationInput,
+    options?: { signal?: AbortSignal },
+  ): Promise<PreparedPronunciation>;
+  invalidatePronunciation(userId: string, vocabularyId: string): void;
+  clearUser(userId: string): void;
+  clearAll(): void;
+};
+```
+
+### Preparation algorithm
+
+For one logical preparation:
+
+1. Validate non-empty `userId`, `vocabularyId`, and `text`.
+2. Join an existing pending preparation for the same user, vocabulary ID, and text when present.
+3. Fetch and validate `GET tts/settings` through `MobileApiClient`.
+4. If `hasApiKey` is false, throw `MobileTtsError('not_configured')` without calling generation.
+5. Construct the final cache key from user ID, vocabulary ID, provider, voice, and model.
+6. Return a live URL from the in-memory cache when present.
+7. Call `POST tts/generate` with exactly `{ vocabularyId, text }`.
+8. Validate the response.
+9. Cache the URL for 14 minutes from receipt.
+10. Return source `server-cache` when the backend says `cached: true`; otherwise return `generated`.
+11. Remove the pending record in `finally` if it still owns the key.
+
+The test word follows the backend's current invariant: `vocabularyId` identifies immutable canonical pronunciation text. HPA-208 does not support sending alternate text for the same vocabulary ID.
+
+### URL cache
+
+Use the established web semantics:
+
+- TTL: 14 minutes, one minute shorter than the backend presigned URL;
+- maximum entries: 300;
+- LRU-style refresh on access;
+- periodic expired-entry sweep plus per-key expiration check;
+- key components encoded before joining;
+- user and TTS-setting isolation; and
+- no persistent storage.
+
+Cache key:
+
+```text
+userId | vocabularyId | provider | voiceId | model
+```
+
+The cache never stores provider API keys, bearer tokens, or complete settings records.
+
+### Same-key pending work and cancellation
+
+The service shares the underlying preparation promise for identical logical requests. A caller abort detaches that caller but does not cancel work still useful to another caller.
+
+The service maintains a per-user invalidation generation:
+
+- `clearUser(userId)` increments that user's generation and removes their cache entries;
+- pending work captures the generation at start;
+- a result may populate the cache only if the captured generation still matches; and
+- stale completion after sign-out or identity replacement is returned only to a still-live original caller and is never retained.
+
+`clearAll()` is reserved for application disposal and tests. Normal auth cleanup is user-scoped.
+
+### TTS error normalization
+
+| Source | Mobile TTS error |
+| --- | --- |
+| Settings says `hasApiKey: false` | `not_configured` |
+| Backend code `tts_not_configured` | `not_configured` |
+| Invalid provider configuration | `generation_failed` with actionable diagnostic detail |
+| HTTP/network deadline | `network` unless API client identifies session recovery |
+| 503/audio service unavailable | `service_unavailable` |
+| 504/provider timeout | `generation_timeout` |
+| Other generation/storage/signing failure | `generation_failed` |
+| Invalid success body | `invalid_response` |
+| Auth/session control errors | Preserve equivalent mobile TTS code |
+
+Provider names and non-secret settings may be shown in the development diagnostic. Provider keys, tokens, signed URL query parameters, and raw server bodies are not logged.
+
+## Mobile audio boundary
+
+### Contract
+
+```ts
+export type MobileAudioPlaybackOutcome =
+  | { kind: 'ended' }
+  | { kind: 'stopped'; reason: 'restart' | 'user' | 'dispose' }
+  | { kind: 'interrupted'; reason: 'background' | 'external' };
+
+export type MobileAudioErrorCode =
+  | 'gesture_required'
+  | 'media_unavailable'
+  | 'playback_failed';
+
+export class MobileAudioError extends Error {
+  constructor(
+    readonly code: MobileAudioErrorCode,
+    options?: { cause?: unknown },
+  ) {
+    super(code, options);
+  }
+}
+
+export type MobileAudioPlaybackHandle = {
+  finished: Promise<MobileAudioPlaybackOutcome>;
+  stop(reason?: 'restart' | 'user' | 'dispose'): void;
+};
+
+export type MobileAudioPlayer = {
+  play(url: string): MobileAudioPlaybackHandle;
+  interruptActive(reason: 'background' | 'external'): void;
+  dispose(): void;
+};
+```
+
+This interface deliberately excludes browser types. A later native implementation can preserve the same learning-feature contract.
+
+### `HtmlAudioPlayer`
+
+The HTML implementation:
+
+- owns at most one active `HTMLAudioElement`;
+- stops and settles the previous playback as `restart` before starting another;
+- creates an element with the presigned URL and `preload = 'auto'`;
+- invokes `play()` immediately in `play()`;
+- maps `NotAllowedError` to `gesture_required`;
+- maps media element errors to `media_unavailable`;
+- maps other `play()` rejection to `playback_failed`;
+- maps `ended` to successful completion;
+- treats an unexplained `pause` while active as an external interruption;
+- removes all listeners when settled;
+- resets `currentTime`, clears `src`, and releases the element during stop/dispose where safe; and
+- settles each handle exactly once.
+
+It must not set `crossOrigin` unless device evidence demonstrates a need and the bucket policy is changed accordingly.
+
+## Pronunciation controller
+
+### State model
+
+```ts
+export type PronunciationDiagnosticState =
+  | { kind: 'idle' }
+  | { kind: 'preparing'; attempt: number }
+  | { kind: 'ready'; pronunciation: PreparedPronunciation; notice: ReadyNotice | null }
+  | { kind: 'playing'; pronunciation: PreparedPronunciation }
+  | {
+      kind: 'interrupted';
+      pronunciation: PreparedPronunciation;
+      reason: 'background' | 'external';
+    }
+  | {
+      kind: 'error';
+      error: PronunciationDiagnosticError;
+      pronunciation: PreparedPronunciation | null;
+    };
+```
+
+The controller keeps the prepared URL while it is valid, including after a gesture-required failure, interruption, or explicit stop.
+
+### Tap behavior
+
+#### Tap from `idle`
+
+1. Transition to `preparing`.
+2. Prepare pronunciation.
+3. Save the returned pronunciation.
+4. Immediately call `audioPlayer.play()` in the continuation of the original tap.
+5. Record whether iOS accepts or rejects playback after the asynchronous request chain.
+
+#### Tap from `ready` or `interrupted`
+
+Call `audioPlayer.play()` synchronously using the prepared URL. This is the direct-user-gesture control path.
+
+#### Tap during `preparing`
+
+Ignore the tap and keep the control disabled. The service additionally protects against duplicate preparation requests.
+
+#### Tap during `playing`
+
+Stop the active handle with reason `restart`, seek to the beginning through the adapter, and start one replacement playback. Audio never overlaps.
+
+### Playback results
+
+| Result | Controller behavior |
+| --- | --- |
+| Ended | Return to `ready`; increment completed-play count |
+| Restart/user stop | Return to `ready` unless a replacement already owns the state |
+| Background interruption | Enter `interrupted`; retain URL |
+| External interruption | Enter `interrupted`; retain URL |
+| Gesture required | Enter `ready` with “Audio is prepared. Tap again to play.” |
+| Media unavailable | Invalidate URL and enter recoverable expired/media state |
+| Other playback failure | Enter recoverable error retaining URL only when safe |
+
+### Expired or invalid URL recovery
+
+`HTMLMediaElement` does not reliably expose the HTTP status causing a load failure. A media failure is therefore treated as a possibly expired or invalid URL:
+
+1. Stop and discard the failed element.
+2. Invalidate the user/vocabulary URL cache entry.
+3. Refresh the pronunciation through `MobileTtsService` once.
+4. Enter `ready` with “Audio was refreshed. Tap to play again.”
+5. Do not autoplay after refresh, because the asynchronous recovery may no longer carry user activation.
+
+If refresh fails, show the mapped TTS error. The controller performs at most one automatic URL refresh per tap; further attempts require explicit user retry.
+
+### Lifecycle behavior
+
+Extend the existing mobile lifecycle state with current active/inactive status and transition timestamps while preserving the current resume counter.
+
+When the app becomes inactive:
+
+- call `audioPlayer.interruptActive('background')`;
+- do not attempt background playback; and
+- preserve the prepared URL when still within its local TTL.
+
+When the app becomes active:
+
+- do not auto-resume;
+- display the interrupted state; and
+- allow an explicit replay tap.
+
+Component unmount stops active playback with reason `dispose` and aborts/detaches preparation owned by the component.
+
+## Diagnostic surface
+
+### Route placement
+
+Add a development-only route such as:
+
+```text
+/more/diagnostics/tts-pronunciation
+```
+
+The route is a sibling to the existing iOS interaction diagnostics, but it must **not** set `meta.bypassMobileAuth`. It is rendered only inside the authenticated mobile shell.
+
+The More page includes a development-only lazy entry:
+
+```text
+Pronunciation diagnostics
+Authenticated TTS, expiring URLs, and iOS playback
+```
+
+Production builds must contain neither the route nor the entry. Extend the production-diagnostics verification script and route tests to prove their absence.
+
+### Known word
+
+Use the deterministic seeded item:
+
+```ts
+const DIAGNOSTIC_WORD = {
+  vocabularyId: '水:ミズ',
+  text: '水',
+  reading: 'みず',
+  translation: 'water',
+} as const;
+```
+
+The page does not query vocabulary APIs and does not allow arbitrary text, keeping the spike deterministic and free of unrelated dependencies.
+
+### Presentation
+
+Minimum visible content:
+
+```text
+Pronunciation diagnostics
+
+水
+みず · water
+
+[Play pronunciation]
+
+State: Ready
+Source: memory cache / server cache / generated
+Playback adapter: HTML audio
+Last outcome: Completed
+```
+
+Expose accessible states through `role="status"`, `aria-live="polite"`, and `role="alert"` where appropriate. The control label reflects state:
+
+- Prepare and play pronunciation;
+- Preparing pronunciation;
+- Replay pronunciation;
+- Restart pronunciation; or
+- Retry pronunciation.
+
+### Development controls and counters
+
+A collapsed development section may provide:
+
+- invalidate the current in-memory URL;
+- simulate one invalid URL by replacing only the current diagnostic copy with a known-unreachable HTTPS URL;
+- clear diagnostic counters;
+- show preparation count, backend source, playback attempts, completed plays, gesture rejections, interruptions, URL refreshes, and last classified error; and
+- show current app active state.
+
+Never render the complete presigned URL because its query string contains temporary credentials. Display only the URL host and a redacted path suffix when needed for debugging.
+
+The invalid-URL control provides deterministic expired-URL recovery evidence without waiting 15 minutes or mutating server storage.
+
+## User-facing states
+
+| Condition | Message/action |
+| --- | --- |
+| Initial | “Tap to prepare and play 水.” |
+| Preparing | “Preparing pronunciation…” |
+| Playing | “Playing 水…” |
+| Completed | “Pronunciation completed.” Replay available |
+| Gesture rejected | “Audio is prepared. Tap again to play.” |
+| Interrupted | “Playback was interrupted. Tap to replay.” |
+| TTS not configured | “Pronunciation is not configured for this account. Configure TTS in Vela web settings.” |
+| Session unavailable | Allow auth gate/coordinator recovery; no raw token error |
+| Network failure | “Vela couldn’t load pronunciation. Check your connection and try again.” |
+| Provider timeout | “Pronunciation generation timed out. Try again.” |
+| Service unavailable | “Pronunciation is temporarily unavailable. Try again.” |
+| URL refreshed | “Audio was refreshed. Tap to play again.” |
+| Playback failure | “Vela couldn’t play this pronunciation. Try again.” |
+
+The diagnostic may mention that configuration is managed on the web. It does not deep-link to or embed the web settings page in this milestone.
+
+## Authentication and user isolation
+
+The page is enabled only while the feature-session selector reports a usable authenticated session.
+
+The controller passes the current authenticated user ID to `MobileTtsService` solely for client-side cache partitioning. The user ID is never sent in the request body; the backend derives identity from the verified Cognito token.
+
+Install a focused TTS auth-isolation watcher or equivalent service hook:
+
+- identity replacement clears only the previous user’s TTS cache and stops current audio;
+- sign-out clears only the previous user’s TTS cache and stops current audio;
+- unusable session recovery detaches/aborts the current diagnostic operation without globally clearing successor state; and
+- a null-to-user transition performs no cleanup.
+
+Do not call `queryClient.clear()` or expose token material to the TTS service.
+
+## S3 and WebKit CORS decision
+
+The Vela API already permits `capacitor://localhost`. The TTS audio bucket currently permits configured web frontend origins and local web development origins, but not necessarily the Capacitor origin.
+
+Ordinary media-element loading may work without an explicit CORS grant because the page does not read media bytes or draw them to a canvas. WKWebView behavior must be measured rather than assumed.
+
+Therefore:
+
+1. Do not modify the bucket CORS policy before device testing.
+2. Test a valid presigned URL in Simulator and on a physical iPhone.
+3. Record console/native evidence if loading fails.
+4. Only when evidence identifies origin/CORS rejection, add the exact approved Capacitor origin to GET/HEAD CORS.
+5. Preserve current web origins and infrastructure tests.
+6. Never use `*` as the allowed origin.
+
+A required bucket-policy correction remains within HPA-208 because it is necessary for the existing presigned-audio architecture to function. A native plugin adopted solely to bypass a correctable bucket CORS policy is not the preferred outcome.
+
+## Testing
+
+### Shared-contract tests
+
+Cover:
+
+- all supported providers;
+- null voice/model;
+- missing and invalid fields;
+- HTTPS URL validation;
+- cached true/false;
+- existing error-only responses;
+- coded error responses; and
+- unknown-field tolerance.
+
+### API-client tests
+
+Cover:
+
+- POST method and JSON body;
+- coordinator-owned Authorization;
+- rejection of caller Authorization remains intact;
+- caller abort;
+- total deadline across transport and body consumption;
+- session recovery mappings;
+- 2xx JSON success;
+- 4xx `client` classification with parsed JSON and text detail;
+- 5xx `server` classification with detail;
+- malformed success JSON; and
+- unchanged due-count retry behavior.
+
+### Mobile TTS service tests
+
+Cover:
+
+- exact settings and generate paths;
+- exact generation request body;
+- user ID absent from the request body;
+- not-configured settings short-circuit;
+- coded and compatibility-fallback errors;
+- response validation;
+- 14-minute cache TTL;
+- per-user, provider, voice, model, and vocabulary isolation;
+- same-key pending request sharing;
+- distinct-key independence;
+- failed pending-request cleanup;
+- bounded LRU eviction;
+- targeted invalidation;
+- sign-out generation guard; and
+- redaction/no-secret logging.
+
+### Audio-adapter tests
+
+Use an injected audio-element factory rather than replacing global behavior throughout the suite.
+
+Cover:
+
+- successful end;
+- `NotAllowedError` gesture rejection;
+- media error;
+- generic play rejection;
+- unexplained pause interruption;
+- restart stops the previous element;
+- explicit stop and dispose;
+- listener cleanup;
+- exactly-once settlement; and
+- one active element invariant.
+
+### Controller tests
+
+Cover:
+
+- idle to preparing to playing to ready;
+- asynchronous first-tap playback attempt;
+- gesture fallback retaining URL;
+- direct second-tap playback;
+- rapid taps during preparation;
+- rapid taps during playback causing restart without overlap;
+- cached replay without another prepare request;
+- background interruption and explicit replay;
+- external interruption;
+- media failure, one URL refresh, and no autoplay;
+- refresh failure;
+- not-configured state;
+- network and server retries;
+- session change;
+- identity change and sign-out;
+- component teardown; and
+- stale asynchronous completion unable to overwrite successor state.
+
+### Component and route tests
+
+Cover:
+
+- every visible state and message;
+- accessible control labels and live regions;
+- counters and redaction;
+- authenticated route behavior;
+- no auth bypass metadata;
+- development-only More entry;
+- development-only route registration; and
+- production build exclusion.
+
+### Backend and infrastructure tests
+
+Cover stable TTS error codes while preserving existing messages and statuses.
+
+Only if CORS changes are required, add tests proving:
+
+- exact Capacitor origin allowed for TTS GET/HEAD;
+- existing web origins remain allowed; and
+- arbitrary origins remain rejected.
+
+## Verification matrix
+
+Run the matrix on at least one current iOS Simulator and one physical development iPhone.
+
+| Scenario | Simulator | Physical iPhone | Required evidence |
+| --- | --- | --- | --- |
+| Restored authenticated session | Required | Required | User reaches diagnostic without sign-in prompt while session valid |
+| Account has configured TTS | Required | Required | Settings reports configured; no key shown |
+| First server-cache or generation request | Required | Required | Source and timing recorded |
+| One-tap async prepare-and-play | Required | Required | Accepted or gesture-rejected result recorded |
+| Prepared direct-tap playback | Required | Required | Audible Japanese pronunciation |
+| Ten consecutive replays | Required | Required | Success/failure count |
+| Rapid taps while preparing | Required | Required | One preparation request |
+| Rapid taps while playing | Required | Required | No overlap; deterministic restart |
+| Network disabled before prepare | Required | Required | Actionable error and successful retry |
+| Invalid/expired URL simulation | Required | Required | Refresh then explicit replay succeeds |
+| Background during preparation | Required | Required | No stuck state |
+| Background during playback | Required | Required | Interrupted, no background continuation, replay succeeds |
+| External/system audio interruption | Best effort | Required | Outcome and limitation recorded |
+| Sign-out while ready | Required | Required | User cache cleared; route inaccessible |
+| Sign-out while playing | Required | Required | Playback stops and state clears |
+| Relaunch and replay | Required | Required | Auth restoration plus new successful playback |
+| Silent mode and volume behavior | Record | Record | Expected iOS media behavior documented |
+
+Use a test account already configured through the web application. Record provider and non-secret voice/model identifiers, but never record the provider key, bearer token, or complete signed URL.
+
+## HTML audio acceptance gate
+
+HTML audio is acceptable for the MVP when physical-device evidence shows all of the following:
+
+1. A prepared direct tap reliably produces audible Japanese pronunciation.
+2. Ten consecutive replays succeed without intermittent stuck or silent states.
+3. Rapid taps never create overlapping audio.
+4. Rapid taps never create duplicate generation requests.
+5. Invalid/expired URLs recover through refresh and an explicit replay tap.
+6. Backgrounding and foregrounding leave the controller in a recoverable state.
+7. A normal external interruption leaves the controller replayable.
+8. Sign-out and teardown stop playback and clear user-scoped cached URLs.
+9. No provider key or Cognito token is present in the bundle, logs, or diagnostic UI.
+10. Any one-tap gesture limitation is acceptable to product flows through prefetch or a documented prepare-then-play interaction.
+
+A native Capacitor audio follow-up is required when physical evidence shows one or more of:
+
+- prepared direct-tap playback remains intermittent;
+- valid presigned URLs cannot be loaded reliably after correct CORS configuration;
+- interruption leaves the HTML element permanently unusable;
+- repeated playback leaks or accumulates active media elements;
+- required MVP behavior needs audio-session category, route, or interruption controls unavailable through HTML audio; or
+- the product cannot tolerate the demonstrated user-gesture interaction.
+
+The follow-up issue must identify the failed criterion and preserve the `MobileAudioPlayer` interface. HPA-208 does not select a plugin without that evidence.
+
+## Verification record
+
+Implementation creates or updates:
+
+```text
+apps/vela-mobile/docs/tts-pronunciation-ios.md
+```
+
+The record contains:
+
+- tested app commit;
+- Xcode, iOS, Quasar, Capacitor, and device versions;
+- test account configuration status without secrets;
+- the completed matrix;
+- first-tap gesture result;
+- URL-expiration and interruption observations;
+- any required CORS correction;
+- known limitations;
+- final `HTML audio accepted` or `native adapter required` decision; and
+- links to any follow-up Linear issues.
+
+HPA-210 consumes this record during the Milestone 1 architecture review.
+
+## Acceptance-criteria mapping
+
+| HPA-208 criterion | Design evidence |
+| --- | --- |
+| Signed-in user hears one Japanese pronunciation on physical iPhone | Authenticated diagnostic, known `水` item, physical matrix |
+| Repeated playback has no duplicate request or accidental overlap | Service single-flight, controller tap rules, one-active-element adapter |
+| Auth, generation, expiration, and playback failures are actionable | Structured API/TTS/audio errors and explicit view states |
+| No provider key bundled | Server-side settings only; secret scan and redacted diagnostics |
+| Web TTS unchanged | Shared contract re-export and additive backend error codes only |
+| HTML versus native conclusion recorded | Objective physical-device decision gate and verification record |
+
+## Risks and mitigations
+
+### Asynchronous user activation
+
+A network request may consume the original tap's user-activation window. The controller deliberately attempts one-tap playback, records the result, and supports a prepared second tap without repeating generation.
+
+### Presigned URL expiry
+
+The local TTL expires one minute before the server URL. Media failures also invalidate and refresh once because device sleep or clock behavior can outlive the local assumption.
+
+### Ambiguous media errors
+
+HTML media errors do not reliably identify HTTP status. Recovery treats the first media error as possibly stale, refreshes once, then surfaces a playback error rather than looping.
+
+### Cross-user leakage
+
+All cache keys include user ID, auth transitions clear only the previous user, stale completions are generation-guarded, and diagnostic state is destroyed on auth loss.
+
+### S3 CORS uncertainty
+
+The implementation measures first and changes only the exact bucket origin policy if evidence requires it.
+
+### Scope expansion into final settings or review UX
+
+The route is development-only and uses a fixed word. Final product integration remains a later milestone that consumes the service and audio interfaces.
+
+## Implementation shape
+
+The implementation plan should sequence work approximately as follows:
+
+1. Shared TTS contracts and additive backend error codes.
+2. Mobile API POST and structured HTTP errors.
+3. Mobile TTS service, cache, concurrency, and auth isolation.
+4. Audio contract and HTML adapter.
+5. Controller state machine and lifecycle integration.
+6. Authenticated development diagnostic and production exclusion checks.
+7. Automated verification.
+8. Simulator matrix.
+9. Physical-iPhone matrix and architecture record.
+10. CORS correction or native-audio follow-up only when evidence requires it.
+
+No implementation begins until this design is reviewed and approved.

--- a/docs/superpowers/specs/2026-07-31-mobile-authenticated-tts-pronunciation-design.md
+++ b/docs/superpowers/specs/2026-07-31-mobile-authenticated-tts-pronunciation-design.md
@@ -15,7 +15,7 @@ The implementation must answer two related architecture questions:
 1. Is `HTMLAudioElement` playback reliable enough for the iOS MVP?
 2. Which native follow-up, if any, is required: app-level `AVAudioSession` configuration while retaining HTML playback, or replacement of the player with a native Capacitor audio adapter?
 
-This is a production-shaped validation slice, not the final pronunciation experience. It establishes stable boundaries for authenticated TTS requests, expiring audio URLs, playback ownership, user-visible state, audio-session evidence, and future native replacement without importing the web TTS settings page or exposing Cognito tokens to feature code.
+This is a production-shaped validation slice, not the final pronunciation experience. It establishes stable boundaries for authenticated TTS requests, long-running generation, expiring audio URLs, playback ownership, user-visible state, audio-session evidence, and future native replacement without importing the web TTS settings page or exposing Cognito tokens to feature code.
 
 ## Current state
 
@@ -27,7 +27,7 @@ HPA-207 established:
 
 - a coordinator-owned authenticated feature-request boundary;
 - bounded request execution and current-generation 401 recovery;
-- `MobileApiClient.getJson()`;
+- `MobileApiClient.getJson()` with an eight-second overall deadline;
 - a mobile service registry;
 - user-scoped feature state and sign-out isolation patterns; and
 - an authenticated Home vertical slice.
@@ -51,6 +51,10 @@ The backend already provides:
 
 `POST /api/tts/generate` checks the user-scoped S3 cache before invoking the configured provider, stores generated audio privately, and returns a presigned URL valid for 900 seconds. The backend derives the provider credential from the authenticated user's server-side TTS settings. No provider API key is returned to or bundled in the mobile application.
 
+All three server-side providers enforce a 30-second provider-request timeout. After provider success, the route may still need to consume the audio body, upload it to S3, and create the signed URL. The API Lambda timeout is 60 seconds.
+
+The mobile API client's current eight-second overall feature deadline and the coordinator's independent 15-second physical-fetch timeout are both too short for a cold TTS generation request. HPA-208 must add a bounded per-request timeout override rather than changing the existing defaults globally.
+
 The Capacitor application does not currently install a native audio plugin or configure `AVAudioSession`.
 
 Apple documents that an iOS app's default audio session is silenced by the Ring/Silent switch, while the `.playback` category continues playing with the switch set to silent. `HTMLAudioElement` cannot configure that native category itself. Device evidence therefore must treat silent-switch behavior as a product gate, not merely an observation. See [AVAudioSession](https://developer.apple.com/documentation/avfaudio/avaudiosession) and [AVAudioSession.Category.playback](https://developer.apple.com/documentation/avfaudio/avaudiosession/category-swift.struct/playback).
@@ -60,42 +64,58 @@ Apple documents that an iOS app's default audio session is silenced by the Ring/
 | Area | Decision |
 | --- | --- |
 | Product scope | One authenticated known-word pronunciation diagnostic |
-| Test word | Seeded vocabulary item `水` / `みず` / `water`, deterministic ID `水:ミズ` |
+| Test word | Fixed diagnostic word `水` / `みず` / `water`, using identifier `水:ミズ` |
+| Vocabulary dependency | The backend treats `vocabularyId` as an opaque TTS cache partition; the diagnostic does not require a vocabulary-table lookup or seeded database row |
 | API flow | Check settings, then call `POST tts/generate`; do not require `GET tts/audio/:id` first |
 | Shared code | Share validated request/response/settings/error contracts, not the web service or page |
+| Web adoption | Web uses shared parsers for settings and generate success bodies; valid-response and existing error behavior remain unchanged, while malformed success responses intentionally fail validation |
 | Auth ownership | All TTS requests use the existing coordinator-owned mobile API client |
-| API client | Add authenticated JSON POST and structured HTTP errors; intentionally classify deterministic non-401/403 4xx responses as `client` |
+| API client | Add authenticated JSON POST, structured HTTP errors, and a bounded per-request timeout option |
+| Default deadline | Keep eight seconds for due-count, settings, and other ordinary mobile JSON requests |
+| TTS generation deadline | Use a 45-second overall deadline for `POST tts/generate` |
+| Coordinator timeout | Add a validated per-request transport timeout so TTS can exceed the current 15-second default without weakening other requests |
 | Due-count migration | Keep its retry rule (`network`/`server` only), while intentionally stopping retries for 4xx responses that previously collapsed to `server` |
+| Prepare retry | Do not automatically retry network, provider, or server failures; expose an explicit Retry control |
+| Auth control-race retry | Permit one same-user recovery attempt for the narrow session handoff/recovery cases established by HPA-207 |
 | Playback seam | `MobileAudioPlayer` interface with an initial `HtmlAudioPlayer` implementation |
-| Silent-switch product rule | Foreground pronunciation initiated by an explicit tap must be audible when the hardware Ring/Silent switch is on and media volume is nonzero |
+| Silent-switch product rule | A prepared, direct pronunciation tap must be audible while foregrounded when Ring/Silent is on and media volume is nonzero |
 | Native integration | Do not preselect a plugin; if HTML-only playback fails silent-mode or session-control gates, create a native audio-session follow-up before considering full player replacement |
-| Concurrency | One preparation request and one active playback per controller; service deduplication uses the full settings-derived cache key |
+| Concurrency | One preparation operation and one active playback per controller; service generation deduplication uses the full settings-derived cache key |
 | URL cache | User/settings/vocabulary-scoped in-memory cache, 14-minute TTL, bounded size |
+| Invalidation | Invalidating one user/vocabulary pair affects every provider/voice/model partition and prevents stale pending work from being rejoined or cached |
 | Replay | Reuse a still-live prepared URL and restart from the beginning; never overlap playback |
+| Settings reads | Every new preparation reads current settings; replay from `ready` with a live URL performs no settings request |
 | First-tap gesture | Attempt playback after asynchronous preparation and record whether iOS permits it |
 | Gesture fallback | If rejected, retain the prepared URL and require a second direct tap |
+| Audibility gate | Acceptance may use prepare -> Ready -> direct second tap; silent-switch acceptance is measured on the prepared direct-tap path, not necessarily one-gesture generation-and-play |
 | Proactive expiry | A ready tap checks `expiresAt` before playback; an expired item refreshes instead of intentionally attempting a stale URL |
 | Media failure | Still refresh once because sleep, revocation, clock changes, or transport behavior can invalidate a nominally live URL |
 | Background behavior | Stop active audio and classify it as interrupted; background audio remains unsupported |
-| Diagnostic exposure | Development-only route under More, but still behind `MobileAuthGate` |
+| Diagnostic route | Use `/diagnostics/tts-pronunciation`, following the existing diagnostic route convention |
+| Diagnostic exposure | Development-only entry under More, but the route remains behind `MobileAuthGate` and has no auth-bypass metadata |
 | Provider configuration | Test account is configured on the web; mobile only reports configuration status |
 | Device evidence | Simulator checks are merge gates; a physical iPhone is the closure and architecture-decision gate |
+| Audibility evidence | Human-observed audio on a physical device speaker; audibility is not claimed from unit tests or media events alone |
 | Infrastructure | Do not broaden S3 CORS preemptively; change it only if device evidence proves it necessary |
-| Web behavior | Preserve existing web TTS request, cache, playback, and settings behavior |
+| Web behavior | Preserve valid web TTS request/cache/playback/settings behavior and existing user-facing errors |
 
 ## Scope
 
 HPA-208 includes:
 
 - shared runtime-validated TTS contracts;
-- stable TTS backend error codes while preserving existing `error` messages;
+- stable TTS backend error codes while preserving existing `error` messages and statuses;
+- shared parser adoption for web settings and generation success responses;
 - authenticated JSON POST support in the mobile API client;
+- bounded per-request overall and coordinator transport timeout overrides;
 - structured HTTP status and server-detail preservation for feature services;
 - the intentional mobile 4xx classification migration and pinned due-count retry behavior;
-- a mobile TTS service with settings validation, URL caching, and settings-derived same-key single-flight preparation;
+- a complete ordered API-to-TTS error mapping;
+- a mobile TTS service with settings validation, URL caching, full-key single-flight generation, and all-partition invalidation;
 - a replaceable mobile audio interface;
 - an `HTMLAudioElement` implementation owning one active playback;
-- a pronunciation controller with explicit state transitions, proactive expiry, and concurrency rules;
+- a pronunciation controller with explicit state transitions, manual retry policy, auth-race recovery, proactive expiry, and concurrency rules;
+- a named active/inactive lifecycle API;
 - an authenticated development-only diagnostic page for one known word;
 - lifecycle, interruption, silent-switch, decode, and audibility observation;
 - unit/component/backend/infrastructure coverage;
@@ -134,22 +154,26 @@ MobileTtsService.preparePronunciation(...)
         |                       |
         |                       +--> 14-minute user/settings URL cache
         v
-MobileApiClient GET tts/settings
+MobileApiClient GET tts/settings (default 8s)
         |
         v
 Settings-derived cache/pending key
         |
         v
-MobileApiClient POST tts/generate
+MobileApiClient POST tts/generate (45s overall)
         |
         v
 MobileAuthCoordinator adds current Cognito ID token
+and applies bounded per-request transport timeout
         |
         v
 Backend checks user TTS settings and S3 object cache
         |
         v
-Provider generation when needed -> private S3 object
+Provider generation when needed (30s provider cap)
+        |
+        v
+Private S3 upload and presigned URL
         |
         v
 Validated { audioUrl, cached } response
@@ -170,13 +194,17 @@ HtmlAudioPlayer owns exactly one HTMLAudioElement
 
 `packages/common/src/contracts/tts.ts` owns platform-neutral data contracts and parsers. It has no fetch, auth, Vue, browser-audio, or provider implementation dependencies.
 
+#### Mobile auth coordinator
+
+`MobileAuthCoordinator` remains the only owner of Cognito token material and physical authenticated fetch attempts. It accepts a validated optional transport timeout for a feature request while retaining its existing 15-second default and auth-recovery rules.
+
 #### Mobile API client
 
-`apps/vela-mobile/src/services/mobile-api-client.ts` owns authenticated JSON transport, execution deadlines, JSON syntax/body consumption, and stable transport/HTTP error normalization. It does not understand TTS domain states.
+`apps/vela-mobile/src/services/mobile-api-client.ts` owns authenticated JSON transport, the caller's overall deadline across auth recovery, transport, and body consumption, JSON syntax/body consumption, and stable transport/HTTP error normalization. It does not understand TTS domain states.
 
 #### Mobile TTS service
 
-`apps/vela-mobile/src/services/mobile-tts.ts` owns TTS settings interpretation, generate-request construction, structural response validation, URL-cache semantics, settings-derived pending-work identity, and TTS-specific error normalization. It does not create or control audio elements.
+`apps/vela-mobile/src/services/mobile-tts.ts` owns TTS settings interpretation, generate-request construction, structural response validation, URL-cache semantics, full-key pending-work identity, all-partition invalidation, and TTS-specific error normalization. It does not create or control audio elements.
 
 #### Mobile audio player
 
@@ -186,7 +214,7 @@ Native app-level audio-session configuration, if required, remains outside `Mobi
 
 #### Pronunciation controller
 
-`apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts` or an equivalent focused controller owns user intent, preparation/playback sequencing, local expiry checks, state transitions, retry policy, lifecycle reactions, and teardown. It does not parse HTTP responses or own Cognito state.
+`apps/vela-mobile/src/composables/usePronunciationDiagnostic.ts` or an equivalent focused controller owns user intent, preparation/playback sequencing, local expiry checks, manual retry, same-user auth-race recovery, state transitions, lifecycle reactions, and teardown. It does not parse HTTP responses or own Cognito state.
 
 #### Diagnostic view
 
@@ -251,28 +279,89 @@ Validation requirements:
 - invalid or empty JSON syntax/body is classified by `MobileApiClient` as `MobileApiError('invalid_response')`; and
 - a syntactically valid but structurally invalid TTS success body is caught by the shared parser and normalized by `MobileTtsService` to `MobileTtsError('invalid_response')`.
 
-The web service imports and re-exports the shared types and parsers while preserving its public API and behavior.
+### Web parser adoption
 
-### Backend error compatibility
+The web service imports and re-exports the shared types. It also uses:
+
+- `parseTtsSettings()` for successful `GET tts/settings` responses; and
+- `parseGeneratePronunciationResponse()` for successful `POST tts/generate` responses.
+
+This preserves valid backend responses, request construction, cache behavior, and existing error-body handling. It intentionally changes only malformed 2xx success payloads from loosely accepted data into explicit validation failures. Existing web tests remain, and new parser-regression tests prove valid response behavior is unchanged.
+
+`GET tts/audio/:id` is not used by this mobile slice and remains outside parser migration unless a dedicated shared response parser is added deliberately in implementation.
+
+## Backend error compatibility
 
 TTS routes add stable `code` fields to their existing JSON error responses. Existing human-readable `error` strings and HTTP statuses remain unchanged so current web behavior and tests remain valid.
 
-Mobile maps by stable code first. During mixed-version deployment or local development, only these exact legacy fallbacks are recognized:
+Mobile uses one ordered normalization algorithm:
+
+1. Parse the server body as `TtsApiErrorResponse` when available.
+2. Prefer a recognized stable `code`.
+3. If no code is present, apply the exact legacy 400-message compatibility table.
+4. Preserve API-client auth/session/network classifications.
+5. For remaining HTTP errors, use status-based mapping.
+6. Treat structural success-parser failure separately as `invalid_response`.
+
+### Stable code mapping
+
+| Backend code | Mobile TTS mapping |
+| --- | --- |
+| `tts_not_configured` | `not_configured` |
+| `tts_invalid_provider_configuration` | `generation_failed` |
+| `tts_audio_service_unavailable` | `service_unavailable` |
+| `tts_generation_timeout` | `generation_timeout` |
+| `tts_generation_failed` | `generation_failed` |
+| `tts_audio_storage_failed` | `generation_failed` |
+| `tts_audio_access_failed` | `generation_failed` |
+
+### Exact legacy configuration fallback
 
 | HTTP status | Exact legacy message | Mobile mapping |
 | --- | --- | --- |
 | 400 | `TTS API key not configured. Please configure in Settings.` | `not_configured` |
 | 400 | `Invalid TTS provider configuration` | `generation_failed` |
 
-Every other uncoded 4xx/5xx response maps through the normal status and TTS error rules. String matching is compatibility behavior, not the primary long-term contract, and has explicit tests.
+### Status and API-client fallback
 
-## Mobile API client extension
+| API-client result | Mobile TTS mapping |
+| --- | --- |
+| `session_unavailable` | `session_unavailable` |
+| `session_changed` | `session_changed` |
+| `session_recovery_pending` | `session_recovery_pending` |
+| `unauthorized` | `unauthorized` |
+| `forbidden` | `forbidden` |
+| `network` | `network` |
+| `server` with status 503 | `service_unavailable` |
+| `server` with status 504 | `generation_timeout` |
+| Other `client` or `server` result | `generation_failed` |
+| Structurally invalid successful TTS body | `invalid_response` |
 
-### Public contract
+Status is sufficient for uncoded 503 and 504 responses; implementation must not require their human-readable strings. Existing uncoded 500 messages, including generation, upload, signing, or missing-bucket failures, map to `generation_failed`.
 
-Extend the client without exposing a generic arbitrary-header escape hatch:
+Provider names and non-secret settings may be shown in the development diagnostic. Provider keys, tokens, signed URL query parameters, and raw server bodies are not logged.
+
+## Mobile request deadlines
+
+### Constants
 
 ```ts
+export const MOBILE_API_DEFAULT_TIMEOUT_MS = 8_000;
+export const MOBILE_TTS_GENERATE_TIMEOUT_MS = 45_000;
+export const MOBILE_AUTH_NETWORK_TIMEOUT_MS = 15_000;
+export const MOBILE_AUTH_MAX_FEATURE_NETWORK_TIMEOUT_MS = 50_000;
+```
+
+The 45-second TTS budget covers the provider's 30-second cap plus response-body consumption, S3 upload, and URL signing while remaining below the 60-second Lambda timeout. The 50-second coordinator maximum prevents feature callers from disabling bounded transport while leaving a small margin before Lambda termination.
+
+### Public API-client contract
+
+```ts
+export type MobileApiRequestOptions = {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+};
+
 export type MobileApiClient = {
   getJson(path: string, options?: MobileApiRequestOptions): Promise<unknown>;
   postJson(
@@ -281,17 +370,53 @@ export type MobileApiClient = {
     options?: MobileApiRequestOptions,
   ): Promise<unknown>;
 };
+```
 
-type MobileApiRequestOptions = {
-  signal?: AbortSignal;
+Both methods use one private `requestJson()` implementation. `timeoutMs` is an overall caller deadline spanning:
+
+- current-session selection;
+- shared 401 recovery;
+- the permitted authenticated retry;
+- physical fetch;
+- error-body consumption; and
+- success-body consumption.
+
+Omitting `timeoutMs` retains the existing eight-second default.
+
+`GET tts/settings` uses the default. `POST tts/generate` passes `MOBILE_TTS_GENERATE_TIMEOUT_MS`.
+
+### Coordinator request contract
+
+Extend the coordinator request without placing nonstandard fields in `RequestInit`:
+
+```ts
+export type MobileAuthenticatedApiRequest = {
+  path: string;
+  init?: Omit<RequestInit, 'headers'> & { headers?: HeadersInit };
+  transportTimeoutMs?: number;
 };
 ```
 
-Both methods use one private `requestJson()` implementation.
+The coordinator:
+
+- defaults to `MOBILE_AUTH_NETWORK_TIMEOUT_MS` for callers without an override;
+- accepts only a finite positive integer no greater than `MOBILE_AUTH_MAX_FEATURE_NETWORK_TIMEOUT_MS`;
+- rejects invalid values as `invalid_request_timeout`, mapped by `MobileApiClient` to `invalid_request`;
+- applies the timeout independently to each physical fetch attempt; and
+- remains subject to the API client's outer abort signal, so auth recovery and retries cannot exceed the overall deadline.
+
+`MobileApiClient` passes the effective request timeout as `transportTimeoutMs`. If an auth recovery consumes part of the overall budget, the outer signal still aborts any later attempt at the original deadline.
 
 `postJson()` sets `Content-Type: application/json` and serializes the supplied body. Authorization remains exclusively owned by `MobileAuthCoordinator`; callers cannot supply or override it.
 
-### Error contract
+### Deadline outcomes
+
+- A backend 504 response is `MobileTtsError('generation_timeout')`.
+- A client/coordinator deadline that expires before an HTTP response is `MobileTtsError('network')`, because the client cannot prove the provider timed out.
+- Caller cancellation remains `AbortError`, not a timeout or TTS failure.
+- No automatic network retry occurs after a 45-second deadline.
+
+## Mobile API error contract
 
 Extend `MobileApiError` with optional HTTP detail while preserving existing construction with `{ cause }`:
 
@@ -349,7 +474,7 @@ This is intentional. The retry predicate itself remains unchanged, but its input
 - due-count `500` -> `server` -> retry under the existing limit; and
 - network failure -> `network` -> retry under the existing limit.
 
-Error-body consumption is bounded by the existing request deadline. JSON is preferred when the response content type or body supports it; otherwise retain a bounded text message. Malformed error bodies do not replace the correct HTTP classification.
+Error-body consumption is bounded by the selected overall request deadline. JSON is preferred when the response content type or body supports it; otherwise retain a bounded text message. Malformed error bodies do not replace the correct HTTP classification.
 
 ## Mobile TTS service
 
@@ -403,25 +528,27 @@ export type MobileTtsService = {
 };
 ```
 
+`PreparedPronunciation.source` is diagnostic metadata only. It must not become final learner-facing product copy without UX review.
+
 ### Preparation algorithm
 
 For one logical preparation:
 
 1. Validate non-empty `userId`, `vocabularyId`, and `text`.
-2. Fetch and validate `GET tts/settings` through `MobileApiClient`.
+2. Fetch and validate `GET tts/settings` through `MobileApiClient` using the default eight-second deadline.
 3. If `hasApiKey` is false, throw `MobileTtsError('not_configured')` without calling generation.
 4. Construct the full key from user ID, vocabulary ID, provider, voice, and model.
 5. Return a live URL from the in-memory cache when present.
 6. Join an existing pending generation for that full settings-derived key when present.
-7. Call `POST tts/generate` with exactly `{ vocabularyId, text }`.
+7. Call `POST tts/generate` with exactly `{ vocabularyId, text }` and the 45-second deadline.
 8. Validate the response.
-9. Cache the URL for 14 minutes from receipt.
+9. Cache the URL for 14 minutes from receipt when invalidation generations still match.
 10. Return source `server-cache` when the backend says `cached: true`; otherwise return `generated`.
 11. Remove the pending record in `finally` if it still owns the key.
 
 This ordering intentionally matches the web service's concurrency identity. Concurrent callers may each read settings, but generation is shared only after the provider/voice/model partition is known. A settings change cannot cause a caller to join work for the previous settings key.
 
-The test word follows the backend's current invariant: `vocabularyId` identifies immutable canonical pronunciation text. HPA-208 does not support sending alternate text for the same vocabulary ID, so text is validated but is not an additional cache-key component.
+The backend does not verify that `vocabularyId` exists in the vocabulary table. The fixed `水:ミズ` identifier follows the seed convention for recognizability but does not require seed data to be present. HPA-208 does not support sending alternate text for the same vocabulary ID, so text is validated but is not an additional cache-key component.
 
 ### URL cache
 
@@ -447,31 +574,58 @@ The cache never stores provider API keys, bearer tokens, or complete settings re
 
 The service shares the underlying generation promise for identical full keys. A caller abort detaches that caller but does not cancel work still useful to another caller.
 
-The service maintains a per-user invalidation generation:
+Maintain two invalidation generations:
 
-- `clearUser(userId)` increments that user's generation and removes their cache entries;
-- pending work captures the generation at start;
-- a result may populate the cache only if the captured generation still matches; and
-- stale completion after sign-out or identity replacement is returned only to a still-live original caller and is never retained.
+- a per-user generation for sign-out/identity cleanup; and
+- a per-user-and-vocabulary generation for targeted media invalidation.
 
-`clearAll()` is reserved for application disposal and tests. Normal auth cleanup is user-scoped.
+Pending work captures both generations. A result may populate the cache only if both still match.
 
-### TTS error normalization
+### Targeted invalidation semantics
 
-| Source | Mobile TTS error |
-| --- | --- |
-| Settings says `hasApiKey: false` | `not_configured` |
-| Backend code `tts_not_configured` | `not_configured` |
-| Exact legacy 400 API-key message | `not_configured` |
-| Invalid provider configuration code or exact legacy message | `generation_failed` with diagnostic detail |
-| HTTP/network deadline | `network` unless API client identifies session recovery |
-| 503/audio service unavailable | `service_unavailable` |
-| 504/provider timeout | `generation_timeout` |
-| Other generation/storage/signing failure | `generation_failed` |
-| Structurally invalid TTS success body | `invalid_response` |
-| Auth/session control errors | Preserve equivalent mobile TTS code |
+`invalidatePronunciation(userId, vocabularyId)` must:
 
-Provider names and non-secret settings may be shown in the development diagnostic. Provider keys, tokens, signed URL query parameters, and raw server bodies are not logged.
+1. Increment the user/vocabulary invalidation generation.
+2. Remove every cached entry for that user and vocabulary across all provider, voice, and model partitions.
+3. Remove every matching pending record from the deduplication index so new callers cannot join stale work.
+4. Not forcibly abort underlying work still needed by existing callers.
+5. Prevent any detached stale completion from repopulating the cache.
+
+This guarantees that failure-driven URL recovery obtains a new signed URL even if settings changed or multiple historical settings partitions exist.
+
+`clearUser(userId)` increments the user generation, removes all of that user's cache entries, and removes their pending records from the join index. `clearAll()` is reserved for application disposal and tests. Normal auth cleanup is user-scoped.
+
+## Pronunciation preparation retry policy
+
+Network, provider, 4xx, 5xx, and client deadline failures are manual-only. The controller shows an enabled Retry control after the current attempt settles. There is no exponential backoff and no automatic repeat of a potentially expensive or ambiguously completed generation request.
+
+The following auth-control cases are exceptions because they represent coordinator state transitions rather than product transport retries:
+
+### Same-user control race
+
+When preparation receives `session_changed` or `session_unavailable`, retry the complete logical preparation exactly once when all are true:
+
+- the caller signal is not aborted;
+- the current feature-session selector is usable;
+- the authenticated user ID is unchanged; and
+- no control-race retry has already been consumed for this user action.
+
+A second control error becomes visible and requires explicit retry.
+
+### Session recovery pending
+
+When preparation receives `session_recovery_pending`:
+
+- retain the same user/action identity;
+- present a recovering/preparing state rather than a hard network error;
+- wait for the same user's feature session to become usable; and
+- retry the logical preparation once.
+
+Identity replacement, sign-out, component teardown, or a second recovery failure cancels this continuation.
+
+### Separation from URL refresh
+
+The one automatic refresh after `media_unavailable` is an expiring-URL recovery rule, not a prepare transport retry. It has its own maximum of one refresh per tap. A network/provider failure during that refresh is shown immediately and is not automatically retried.
 
 ## Mobile audio boundary
 
@@ -546,7 +700,7 @@ The adapter must not set `crossOrigin` unless device evidence demonstrates a nee
 ```ts
 export type PronunciationDiagnosticState =
   | { kind: 'idle' }
-  | { kind: 'preparing'; attempt: number }
+  | { kind: 'preparing'; attempt: number; recoveringSession: boolean }
   | { kind: 'ready'; pronunciation: PreparedPronunciation; notice: ReadyNotice | null }
   | { kind: 'playing'; pronunciation: PreparedPronunciation }
   | {
@@ -563,30 +717,30 @@ export type PronunciationDiagnosticState =
 
 The controller keeps the prepared URL while it is locally live, including after a gesture-required failure, interruption, or explicit stop.
 
-### Tap behavior
-
-#### Tap from `idle`
+### Tap from `idle`
 
 1. Transition to `preparing`.
-2. Prepare pronunciation.
+2. Prepare pronunciation under the retry policy above.
 3. Save the returned pronunciation.
 4. Immediately call `audioPlayer.play()` in the continuation of the original tap.
 5. Record whether iOS accepts or rejects playback after the asynchronous request chain.
 
-#### Tap from `ready` or `interrupted`
+Failure of this asynchronous first-tap play is not by itself an HTML-audio rejection. The diagnostic may enter `ready` and complete acceptance through a direct second tap.
+
+### Tap from `ready` or `interrupted`
 
 1. Compare `Date.now()` with `pronunciation.expiresAt` before creating an audio element.
-2. If the URL is still live, call `audioPlayer.play()` synchronously. This is the direct-user-gesture control path.
-3. If the URL is expired, invalidate and prepare a fresh URL instead of intentionally attempting stale playback.
+2. If the URL is still live, call `audioPlayer.play()` synchronously. This is the prepared direct-user-gesture path used for audibility and silent-switch acceptance.
+3. If the URL is expired, invalidate all settings partitions for the user/vocabulary pair and prepare a fresh URL instead of intentionally attempting stale playback.
 4. After asynchronous refresh, attempt playback once and retain the normal gesture-required second-tap fallback.
 
-Proactive expiry avoids a predictable media failure in the local 14-minute boundary and after long idle periods. Failure-driven refresh remains necessary because device sleep, clock changes, server revocation, network intermediaries, or media-layer behavior can invalidate a URL before the local `expiresAt` value.
+Proactive expiry avoids a predictable media failure after long idle periods. Failure-driven refresh remains necessary because device sleep, clock changes, server revocation, network intermediaries, or media-layer behavior can invalidate a URL before local `expiresAt`.
 
-#### Tap during `preparing`
+### Tap during `preparing`
 
 Ignore the tap and keep the control disabled. The service additionally protects against duplicate generation requests.
 
-#### Tap during `playing`
+### Tap during `playing`
 
 Stop the active handle with reason `restart`, seek to the beginning through the adapter, and start one replacement playback. Audio never overlaps.
 
@@ -599,7 +753,7 @@ Stop the active handle with reason `restart`, seek to the beginning through the 
 | Background interruption | Enter `interrupted`; retain locally live URL |
 | External interruption | Enter `interrupted`; retain locally live URL |
 | Gesture required | Enter `ready` with “Audio is prepared. Tap again to play.” |
-| Media unavailable | Invalidate URL and enter recoverable expired/media state |
+| Media unavailable | Invalidate every user/vocabulary settings partition and enter recoverable expired/media state |
 | Other playback failure | Enter recoverable error retaining URL only when safe |
 
 ### Expired or invalid URL recovery
@@ -607,16 +761,34 @@ Stop the active handle with reason `restart`, seek to the beginning through the 
 `HTMLMediaElement` does not reliably expose the HTTP status causing a load failure. A media failure is therefore treated as a possibly expired or invalid URL:
 
 1. Stop and discard the failed element.
-2. Invalidate the user/vocabulary URL cache entry.
+2. Invalidate all user/vocabulary URL-cache partitions.
 3. Refresh the pronunciation through `MobileTtsService` once.
 4. Enter `ready` with “Audio was refreshed. Tap to play again.”
 5. Do not autoplay after failure-driven refresh, because the asynchronous recovery may no longer carry user activation.
 
 If refresh fails, show the mapped TTS error. The controller performs at most one automatic URL refresh per tap; further attempts require explicit user retry.
 
-### Lifecycle behavior
+## Lifecycle behavior
 
-Extend the existing mobile lifecycle state with current active/inactive status and transition timestamps while preserving the current resume counter.
+Extend `apps/vela-mobile/src/services/mobile-lifecycle.ts` with one canonical state-change API:
+
+```ts
+export const mobileLifecycleState = {
+  isActive: Readonly<Ref<boolean>>;
+  resumeCount: Readonly<Ref<number>>;
+  lastResumeAt: Readonly<Ref<number | null>>;
+  lastStateChangeAt: Readonly<Ref<number | null>>;
+  lastBecameActiveAt: Readonly<Ref<number | null>>;
+  lastBecameInactiveAt: Readonly<Ref<number | null>>;
+};
+
+export function recordAppStateChange(isActive: boolean, at = Date.now()): void;
+export function recordAppResume(at = Date.now()): void;
+```
+
+The Capacitor `appStateChange` listener calls `recordAppStateChange(event.isActive)` and then updates TanStack's `focusManager`. The existing `resume` listener continues calling `recordAppResume()`; state changes do not increment the resume counter, avoiding double counting.
+
+The pronunciation controller observes `mobileLifecycleState.isActive`; it does not register a competing native lifecycle listener.
 
 When the app becomes inactive:
 
@@ -634,15 +806,17 @@ Component unmount stops active playback with reason `dispose` and aborts/detache
 
 ## Silent-switch and native audio-session decision
 
-Pronunciation is core learning content, not incidental UI feedback. The MVP product rule is therefore:
+Pronunciation is core learning content, not incidental UI feedback. The MVP product rule is:
 
-> While the app is foregrounded, an explicit pronunciation tap must produce audible output when media volume is nonzero, even when the iPhone Ring/Silent switch is set to silent.
+> While the app is foregrounded, a prepared direct pronunciation tap must produce audible output when media volume is nonzero, even when the iPhone Ring/Silent switch is set to silent.
 
 Background playback remains out of scope. This requirement concerns only foreground user-initiated pronunciation.
 
+The asynchronous initial tap may prepare audio without producing sound when WebKit no longer considers the continuation user-activated. That is acceptable when the diagnostic reaches `ready` and a direct second tap plays audibly. Silent-switch and normal-audibility gates are measured on that prepared direct-tap path.
+
 The physical-device matrix determines one of three outcomes:
 
-1. **HTML-only accepted:** `HtmlAudioPlayer` meets all playback, silent-switch, interruption, and resource gates without native audio-session work.
+1. **HTML-only accepted:** `HtmlAudioPlayer` meets playback, silent-switch, interruption, and resource gates without native audio-session work.
 2. **Native audio-session integration required:** HTML decoding/playback remains reliable, but the app must configure an appropriate `AVAudioSession` category such as `.playback`. The follow-up should preserve `HtmlAudioPlayer` unless evidence shows player replacement is also necessary.
 3. **Native player adapter required:** HTML media remains unreliable after correct CORS and audio-session configuration, or required interruption/player controls cannot be implemented while retaining the adapter.
 
@@ -652,26 +826,19 @@ Silent-mode inaudibility automatically rejects the HTML-only outcome. It does no
 
 ### Route placement
 
-Add a development-only route such as:
+Add a development-only child route:
 
 ```text
-/more/diagnostics/tts-pronunciation
+/diagnostics/tts-pronunciation
 ```
 
-The route is a sibling to the existing iOS interaction diagnostics, but it must **not** set `meta.bypassMobileAuth`. It is rendered only inside the authenticated mobile shell.
-
-The More page includes a development-only lazy entry:
-
-```text
-Pronunciation diagnostics
-Authenticated TTS, expiring URLs, and iOS playback
-```
+This follows the existing `/diagnostics/ios-interactions` convention. The More page provides the entry, but the URL is not nested under `/more`. The route must **not** set `meta.bypassMobileAuth`; it is rendered only inside the authenticated mobile shell.
 
 Production builds must contain neither the route nor the entry. Extend the production-diagnostics verification script and route tests to prove their absence.
 
 ### Known word
 
-Use the deterministic seeded item:
+Use:
 
 ```ts
 const DIAGNOSTIC_WORD = {
@@ -682,7 +849,7 @@ const DIAGNOSTIC_WORD = {
 } as const;
 ```
 
-The page does not query vocabulary APIs and does not allow arbitrary text, keeping the spike deterministic and free of unrelated dependencies.
+The identifier follows the standard seed convention, but the TTS backend does not query the vocabulary table. The page does not query vocabulary APIs and does not allow arbitrary text, keeping the spike deterministic and free of unrelated dependencies.
 
 ### Presentation
 
@@ -702,6 +869,8 @@ Playback adapter: HTML audio
 Last outcome: Completed
 ```
 
+`Source` is diagnostic-only metadata and is not approved learner-facing product copy.
+
 Expose accessible states through `role="status"`, `aria-live="polite"`, and `role="alert"` where appropriate. The control label reflects state:
 
 - Prepare and play pronunciation;
@@ -714,7 +883,7 @@ Expose accessible states through `role="status"`, `aria-live="polite"`, and `rol
 
 A collapsed development section may provide:
 
-- invalidate the current in-memory URL;
+- invalidate the current user/vocabulary across all settings partitions;
 - simulate one invalid URL by replacing only the current diagnostic copy with a known-unreachable HTTPS URL;
 - clear diagnostic counters;
 - show preparation count, backend source, playback attempts, completed plays, gesture rejections, interruptions, URL refreshes, and last classified error;
@@ -731,16 +900,16 @@ The invalid-URL control provides deterministic expired-URL recovery evidence wit
 | --- | --- |
 | Initial | “Tap to prepare and play 水.” |
 | Preparing | “Preparing pronunciation…” |
+| Recovering session | “Refreshing your session…” |
 | Playing | “Playing 水…” |
 | Completed | “Pronunciation completed.” Replay available |
 | Gesture rejected | “Audio is prepared. Tap again to play.” |
 | Locally expired | “Refreshing expired audio…” then normal play or second-tap fallback |
 | Interrupted | “Playback was interrupted. Tap to replay.” |
 | TTS not configured | “Pronunciation is not configured for this account. Configure TTS in Vela web settings.” |
-| Session unavailable | Allow auth gate/coordinator recovery; no raw token error |
-| Network failure | “Vela couldn’t load pronunciation. Check your connection and try again.” |
-| Provider timeout | “Pronunciation generation timed out. Try again.” |
-| Service unavailable | “Pronunciation is temporarily unavailable. Try again.” |
+| Network/deadline failure | “Vela couldn’t load pronunciation. Check your connection and try again.” Manual Retry |
+| Provider timeout response | “Pronunciation generation timed out. Try again.” Manual Retry |
+| Service unavailable | “Pronunciation is temporarily unavailable. Try again.” Manual Retry |
 | URL refreshed | “Audio was refreshed. Tap to play again.” |
 | Playback failure | “Vela couldn’t play this pronunciation. Try again.” |
 | Silent-mode failure | Diagnostic records native audio-session integration as required; do not misreport completion as audible success |
@@ -755,9 +924,10 @@ The controller passes the current authenticated user ID to `MobileTtsService` so
 
 Install a focused TTS auth-isolation watcher or equivalent service hook:
 
-- identity replacement clears only the previous user’s TTS cache and stops current audio;
-- sign-out clears only the previous user’s TTS cache and stops current audio;
-- unusable session recovery detaches/aborts the current diagnostic operation without globally clearing successor state; and
+- identity replacement clears only the previous user’s TTS cache/pending index and stops current audio;
+- sign-out clears only the previous user’s TTS cache/pending index and stops current audio;
+- unusable session recovery detaches/aborts the current diagnostic operation without globally clearing successor state;
+- stale pending completion cannot cache after targeted or user invalidation; and
 - a null-to-user transition performs no cleanup.
 
 Do not call `queryClient.clear()` or expose token material to the TTS service.
@@ -781,7 +951,7 @@ A required bucket-policy correction remains within HPA-208 because it is necessa
 
 ## Testing
 
-### Shared-contract tests
+### Shared-contract and web-regression tests
 
 Cover:
 
@@ -792,10 +962,13 @@ Cover:
 - cached true/false;
 - existing error-only responses;
 - coded error responses;
-- exact legacy fallback messages and statuses; and
-- unknown-field tolerance.
+- exact legacy 400 fallback messages and statuses;
+- unknown-field tolerance;
+- web settings valid-response behavior through the shared parser;
+- web generate valid-response/cache behavior through the shared parser; and
+- malformed web success responses fail explicitly without changing existing non-2xx error handling.
 
-### API-client and due-count regression tests
+### API-client and coordinator tests
 
 Cover:
 
@@ -803,6 +976,12 @@ Cover:
 - coordinator-owned Authorization;
 - rejection of caller Authorization remains intact;
 - caller abort;
+- default eight-second overall deadline;
+- accepted 45-second request override;
+- invalid, zero, non-integer, and over-maximum timeout rejection;
+- coordinator default 15-second physical timeout retained;
+- coordinator per-request transport override;
+- outer deadline still caps auth recovery plus retried transport;
 - total deadline across transport and body consumption;
 - session recovery mappings;
 - 2xx JSON success;
@@ -818,21 +997,31 @@ Cover:
 
 Cover:
 
+- settings uses the default deadline;
+- generate uses the 45-second deadline;
+- successful cold generation under the raised budget;
+- deadline expiry mid-generate maps to `network`;
+- server 504 maps to `generation_timeout`;
 - exact settings and generate paths;
 - exact generation request body;
 - user ID absent from the request body;
 - not-configured settings short-circuit;
-- coded and exact compatibility-fallback errors;
+- ordered stable-code, legacy-message, API-code, and status mapping;
+- status-only 503 and 504 mapping without message matching;
+- uncoded 500 generation/upload/signing messages map to `generation_failed`;
 - JSON-syntax versus structural-response error attribution;
 - 14-minute cache TTL;
 - per-user, provider, voice, model, and vocabulary isolation;
 - settings fetched before full-key pending lookup;
 - same-full-key pending generation sharing;
 - settings change creates a distinct pending/cache key;
+- ready replay performs no settings request;
 - distinct-key independence;
 - failed pending-request cleanup;
 - bounded LRU eviction;
-- targeted invalidation;
+- targeted invalidation removes all settings partitions;
+- targeted invalidation prevents new callers joining stale pending work;
+- stale pending completion cannot repopulate after invalidation;
 - sign-out generation guard; and
 - redaction/no-secret logging.
 
@@ -855,7 +1044,7 @@ Cover:
 - exactly-once settlement; and
 - one active element invariant.
 
-### Controller tests
+### Controller and lifecycle tests
 
 Cover:
 
@@ -863,22 +1052,29 @@ Cover:
 - asynchronous first-tap playback attempt;
 - gesture fallback retaining URL;
 - direct second-tap playback;
+- same-user `session_changed`/`session_unavailable` control race retries once;
+- second control race remains visible;
+- `session_recovery_pending` retries once when the same user becomes usable;
+- identity change cancels pending recovery continuation;
+- network/provider/server failure has no automatic retry;
+- explicit Retry starts one new preparation;
 - ready direct tap with live URL;
+- ready replay does not fetch settings;
 - ready direct tap with expired URL refreshes before creating an audio element;
 - proactive refresh gesture rejection retains the fresh URL for a second tap;
 - rapid taps during preparation;
 - rapid taps during playback causing restart without overlap;
-- cached replay without another generate request;
 - background interruption and explicit replay;
 - external interruption;
 - media failure, one URL refresh, and no autoplay;
+- URL refresh is separate from transport retry and does not loop;
 - refresh failure;
 - not-configured state;
-- network and server retries;
-- session change;
 - identity change and sign-out;
-- component teardown; and
-- stale asynchronous completion unable to overwrite successor state.
+- component teardown;
+- stale asynchronous completion unable to overwrite successor state;
+- `recordAppStateChange()` updates active state and timestamps without incrementing resume count; and
+- Capacitor lifecycle boot uses the canonical lifecycle API.
 
 ### Component and route tests
 
@@ -887,7 +1083,7 @@ Cover:
 - every visible state and message;
 - accessible control labels and live regions;
 - counters and redaction;
-- authenticated route behavior;
+- authenticated `/diagnostics/tts-pronunciation` behavior;
 - no auth bypass metadata;
 - development-only More entry;
 - development-only route registration; and
@@ -911,16 +1107,19 @@ Run the applicable matrix on at least one current iOS Simulator and one physical
 | --- | --- | --- | --- |
 | Restored authenticated session | Required | Required | User reaches diagnostic without sign-in prompt while session valid |
 | Account has configured TTS | Required | Required | Settings reports configured; no key shown |
-| First server-cache or generation request | Required | Required | Source and timing recorded |
-| One-tap async prepare-and-play | Required | Required | Accepted or gesture-rejected result recorded |
+| First server-cache request | Required | Required | Source and timing recorded |
+| First uncached generation | Required | Required | Completes inside 45-second client budget or produces classified failure |
+| One-tap async prepare-and-play | Required | Required | Accepted or gesture-rejected result recorded; not itself the silent-mode gate |
 | Prepared direct-tap playback | Required | Required | Audible expected Japanese pronunciation |
 | Normal media volume, Ring/Silent off | Required | Required | `水` decodes and is audibly pronounced as expected without media error |
-| Ring/Silent on, media volume nonzero | Not applicable | Required | Audible/inaudible result and native-integration conclusion recorded |
-| Ten consecutive replays | Required | Required | Success/failure count |
+| Ring/Silent on, media volume nonzero | Not applicable | Required | Prepared direct tap is human-observed as audible/inaudible on device speaker; native-integration conclusion recorded |
+| Ten consecutive prepared replays | Required | Required | Success/failure count |
 | Rapid taps while preparing | Required | Required | One settings-derived generation request |
 | Rapid taps while playing | Required | Required | No overlap; deterministic restart |
 | Locally expired ready item | Required | Required | Refresh occurs before stale audio element creation |
-| Network disabled before prepare | Required | Required | Actionable error and successful retry |
+| Network disabled before prepare | Required | Required | Actionable error, no automatic retry, explicit retry succeeds |
+| Client deadline during generate | Automated | Best effort | Classified as network; no automatic repeat |
+| Backend provider timeout | Automated | Best effort | 504 classified as generation timeout |
 | Invalid/expired URL simulation | Required | Required | Failure-driven refresh then explicit replay succeeds |
 | Background during preparation | Required | Required | No stuck state |
 | Background during playback | Required | Required | Interrupted, no background continuation, replay succeeds |
@@ -928,6 +1127,8 @@ Run the applicable matrix on at least one current iOS Simulator and one physical
 | Sign-out while ready | Required | Required | User cache cleared; route inaccessible |
 | Sign-out while playing | Required | Required | Playback stops and state clears |
 | Relaunch and replay | Required | Required | Auth restoration plus new successful playback |
+
+Audibility is a manual physical observation. Media `play`, `playing`, and `ended` events demonstrate element state but do not prove that a person heard sound. Record whether evidence used the built-in speaker; optional headphone or Bluetooth observations are separate and do not replace the speaker silent-switch test.
 
 Use a test account already configured through the web application. Record provider and non-secret voice/model identifiers, but never record the provider key, bearer token, or complete signed URL.
 
@@ -939,7 +1140,7 @@ HTML-only playback is acceptable for the MVP only when physical-device evidence 
 
 1. A valid backend audio object decodes without media error and audibly produces the expected Japanese pronunciation at normal media volume.
 2. A prepared direct tap reliably produces audible Japanese pronunciation.
-3. Foreground pronunciation remains audible with the hardware Ring/Silent switch on and media volume nonzero.
+3. Foreground prepared direct-tap pronunciation remains audible with Ring/Silent on and media volume nonzero.
 4. Ten consecutive replays succeed without intermittent stuck or silent states.
 5. Rapid taps never create overlapping audio.
 6. Rapid taps never create duplicate settings-derived generation requests.
@@ -948,13 +1149,13 @@ HTML-only playback is acceptable for the MVP only when physical-device evidence 
 9. A normal external interruption leaves the controller replayable.
 10. Sign-out and teardown stop playback and clear user-scoped cached URLs.
 11. No provider key or Cognito token is present in the bundle, logs, or diagnostic UI.
-12. Any one-tap gesture limitation is acceptable to product flows through prefetch or a documented prepare-then-play interaction.
+12. Any asynchronous first-tap gesture limitation is acceptable through a documented prepare-then-direct-play interaction.
 
 ### Native audio-session integration required
 
 A native iOS audio-session follow-up is required when HTML decoding and player lifecycle are otherwise reliable, but one or more of these hold:
 
-- playback is inaudible with Ring/Silent on;
+- prepared direct-tap playback is inaudible with Ring/Silent on;
 - the app needs an audio-session category or interruption policy unavailable to JavaScript; or
 - the observed default session behavior conflicts with the foreground pronunciation product rule.
 
@@ -969,7 +1170,7 @@ A native player follow-up is required when physical evidence shows one or more o
 - interruption leaves the HTML element permanently unusable;
 - repeated playback leaks or accumulates active media elements;
 - required player or route controls cannot be expressed through the current interface and HTML implementation; or
-- the product cannot tolerate the demonstrated user-gesture interaction and native playback demonstrably resolves it.
+- the product cannot tolerate the demonstrated gesture interaction and native playback demonstrably resolves it.
 
 Every follow-up must identify the failed criterion and preserve the `MobileAudioPlayer` consumer contract unless evidence requires a contract revision. HPA-208 does not select a plugin without that evidence.
 
@@ -987,9 +1188,11 @@ The record contains:
 - Xcode, iOS, Quasar, Capacitor, and device versions;
 - test account configuration status without secrets;
 - the completed matrix;
+- first server-cache and uncached-generation timing;
 - first-tap gesture result;
-- normal-volume decode/audibility result;
-- Ring/Silent-switch result;
+- prepared direct-tap normal-volume audibility result;
+- Ring/Silent-switch prepared direct-tap result;
+- human-observation output route;
 - URL-expiration and interruption observations;
 - any required CORS correction;
 - known limitations;
@@ -1002,26 +1205,34 @@ HPA-210 consumes this record during the Milestone 1 architecture review.
 
 | HPA-208 criterion | Design evidence |
 | --- | --- |
-| Signed-in user hears one Japanese pronunciation on physical iPhone | Authenticated diagnostic, known `水` item, normal-volume physical matrix |
+| Signed-in user hears one Japanese pronunciation on physical iPhone | Authenticated diagnostic, fixed `水` item, prepared direct-tap human audibility matrix |
 | Repeated playback has no duplicate request or accidental overlap | Settings-derived service single-flight, controller tap rules, one-active-element adapter |
-| Auth, generation, expiration, and playback failures are actionable | Structured API/TTS/audio errors and explicit view states |
+| Auth, generation, expiration, and playback failures are actionable | Structured API/TTS/audio errors, bounded deadlines, manual retry, and explicit view states |
 | No provider key bundled | Server-side settings only; secret scan and redacted diagnostics |
-| Web TTS unchanged | Shared contract re-export and additive backend error codes only |
+| Web TTS remains compatible | Shared parser adoption with valid-response regression tests and unchanged non-2xx messages/statuses |
 | HTML versus native conclusion recorded | Physical silent-switch/session/player gates and verification record |
 
 ## Risks and mitigations
 
+### Cold generation exceeds ordinary mobile deadlines
+
+All providers may run for 30 seconds before the backend returns 504, and S3 work follows successful generation. The default eight-second client deadline and 15-second coordinator timeout remain for normal requests, while generate explicitly receives a 45-second overall and transport budget. Automated tests prove both layers honor the override.
+
+### Ambiguous client versus provider timeout
+
+A backend 504 proves the provider timed out and maps to `generation_timeout`. A client-side abort before an HTTP response cannot prove provider outcome and maps to `network`; no automatic repeat risks duplicating expensive or ambiguously completed work.
+
 ### Silent switch and default audio session
 
-The default iOS audio session is silenced by the Ring/Silent switch. Silent-mode audibility is an explicit product requirement, so HTML-only acceptance is impossible if device evidence confirms the default behavior. The design distinguishes minimal native session configuration from full native player replacement rather than conflating them.
+The default iOS audio session is silenced by Ring/Silent. Silent-mode audibility is an explicit product requirement, so HTML-only acceptance is impossible if prepared direct-tap evidence confirms the default behavior. The design distinguishes minimal native session configuration from full native player replacement rather than conflating them.
 
 ### Asynchronous user activation
 
-A network request may consume the original tap's user-activation window. The controller deliberately attempts one-tap playback, records the result, and supports a prepared second tap without repeating generation.
+A network request may consume the original tap's user-activation window. The controller attempts one-tap playback, records the result, and supports a prepared second tap without repeating generation. Audibility and silent-switch gates use the prepared direct-tap path.
 
 ### Presigned URL expiry
 
-The local TTL expires one minute before the server URL. The controller checks `expiresAt` before ready playback. Media failures still invalidate and refresh once because device sleep, clock behavior, or external invalidation can outlive the local assumption.
+The local TTL expires one minute before the server URL. The controller checks `expiresAt` before ready playback. Media failures still invalidate every settings partition and refresh once because device sleep, clock behavior, or external invalidation can outlive the local assumption.
 
 ### Ambiguous media errors
 
@@ -1035,9 +1246,9 @@ HTML media errors do not reliably identify HTTP status. Recovery treats the firs
 
 Adding `client` intentionally changes unexpected 4xx handling for existing consumers. Due-count regression tests pin 400 as non-retryable while retaining existing 5xx/network retries.
 
-### Cross-user leakage
+### Cross-user or stale-partition leakage
 
-All cache keys include user ID, auth transitions clear only the previous user, stale completions are generation-guarded, and diagnostic state is destroyed on auth loss.
+All cache keys include user ID. Targeted invalidation covers every settings partition, pending records are detached from the join index, auth transitions clear only the previous user, and stale completions are generation-guarded.
 
 ### S3 CORS uncertainty
 
@@ -1051,15 +1262,15 @@ The route is development-only and uses a fixed word. Final product integration r
 
 The implementation plan should sequence work approximately as follows:
 
-1. Shared TTS contracts and additive backend error codes.
-2. Mobile API POST, structured HTTP errors, and due-count 4xx regression pinning.
-3. Mobile TTS service, settings-derived cache/concurrency, and auth isolation.
+1. Shared TTS contracts, web parser adoption, and additive backend error codes.
+2. Mobile API POST, structured HTTP errors, per-request overall/coordinator timeout APIs, and due-count 4xx regression pinning.
+3. Mobile TTS service, ordered error mapping, settings-derived cache/concurrency, all-partition invalidation, and auth isolation.
 4. Audio contract and HTML adapter with pause-ordering invariants.
-5. Controller state machine, proactive expiry, and lifecycle integration.
-6. Authenticated development diagnostic and production exclusion checks.
-7. Automated verification.
+5. Controller state machine, manual retry, same-user auth recovery, proactive expiry, and lifecycle integration through `recordAppStateChange()`.
+6. Authenticated `/diagnostics/tts-pronunciation` page and production exclusion checks.
+7. Automated verification, including cold-generation timeout behavior.
 8. Simulator matrix.
-9. Physical-iPhone normal-volume, silent-switch, interruption, and replay matrix.
+9. Physical-iPhone normal-volume, prepared direct-tap silent-switch, interruption, and replay matrix with human audibility evidence.
 10. CORS correction, native audio-session follow-up, or native-player follow-up only when evidence requires it.
 
 No implementation begins until this revised design is reviewed and approved.

--- a/packages/common/src/contracts/tts.test.ts
+++ b/packages/common/src/contracts/tts.test.ts
@@ -3,6 +3,7 @@ import {
   parseGeneratePronunciationRequest,
   parseGeneratePronunciationResponse,
   parseTtsApiErrorResponse,
+  parseTtsAudioUrlResponse,
   parseTtsSettings,
 } from './tts';
 
@@ -56,6 +57,27 @@ describe('TTS contracts', () => {
         cached: false,
       }),
     ).toThrow('invalid_tts_generate_response:audioUrl');
+  });
+
+  it('rejects an unparseable audio URL with the stable generate-response code', () => {
+    expect(() =>
+      parseGeneratePronunciationResponse({ audioUrl: 'not-a-url', cached: false }),
+    ).toThrow('invalid_tts_generate_response:audioUrl');
+  });
+
+  it('parses a valid GET audio URL response', () => {
+    expect(parseTtsAudioUrlResponse({ audioUrl: HTTPS_AUDIO })).toEqual({
+      audioUrl: HTTPS_AUDIO,
+    });
+  });
+
+  it.each([
+    ['non-HTTPS audio URL', { audioUrl: 'http://audio.example.test/mizu.mp3' }],
+    ['unparseable audio URL', { audioUrl: 'not-a-url' }],
+    ['missing audio URL', {}],
+    ['non-string audio URL', { audioUrl: 1 }],
+  ])('rejects a GET audio response with %s', (_caseName, value) => {
+    expect(() => parseTtsAudioUrlResponse(value)).toThrow('invalid_tts_audio_response:audioUrl');
   });
 
   it('trims generation input', () => {

--- a/packages/common/src/contracts/tts.test.ts
+++ b/packages/common/src/contracts/tts.test.ts
@@ -110,6 +110,8 @@ describe('TTS contracts', () => {
     'tts_generation_failed',
     'tts_audio_storage_failed',
     'tts_audio_access_failed',
+    'tts_audio_bucket_not_configured',
+    'tts_unexpected_error',
   ])('parses the supported coded error %s', (code) => {
     expect(parseTtsApiErrorResponse({ error: 'TTS failed', code })).toEqual({
       error: 'TTS failed',

--- a/packages/common/src/contracts/tts.test.ts
+++ b/packages/common/src/contracts/tts.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseGeneratePronunciationRequest,
+  parseGeneratePronunciationResponse,
+  parseTtsApiErrorResponse,
+  parseTtsSettings,
+} from './tts';
+
+const HTTPS_AUDIO = 'https://audio.example.test/mizu.mp3';
+
+describe('TTS contracts', () => {
+  it('parses valid settings and ignores unknown fields', () => {
+    expect(
+      parseTtsSettings({
+        provider: 'openai',
+        voiceId: 'alloy',
+        model: 'tts-1',
+        hasApiKey: true,
+        ignored: 'value',
+      }),
+    ).toEqual({ provider: 'openai', voiceId: 'alloy', model: 'tts-1', hasApiKey: true });
+  });
+
+  it.each([
+    [
+      'unsupported provider',
+      { provider: 'other', voiceId: null, model: null, hasApiKey: true },
+      'provider',
+    ],
+    ['missing hasApiKey', { provider: 'openai', voiceId: null, model: null }, 'hasApiKey'],
+    [
+      'non-string voiceId',
+      { provider: 'openai', voiceId: 1, model: null, hasApiKey: true },
+      'voiceId',
+    ],
+    [
+      'non-string model',
+      { provider: 'openai', voiceId: null, model: false, hasApiKey: true },
+      'model',
+    ],
+  ])('rejects settings with %s', (_caseName, value, field) => {
+    expect(() => parseTtsSettings(value)).toThrow(`invalid_tts_settings:${field}`);
+  });
+
+  it('parses a valid generate response', () => {
+    expect(parseGeneratePronunciationResponse({ audioUrl: HTTPS_AUDIO, cached: false })).toEqual({
+      audioUrl: HTTPS_AUDIO,
+      cached: false,
+    });
+  });
+
+  it('rejects non-HTTPS audio URLs', () => {
+    expect(() =>
+      parseGeneratePronunciationResponse({
+        audioUrl: 'http://audio.example.test/mizu.mp3',
+        cached: false,
+      }),
+    ).toThrow('invalid_tts_generate_response:audioUrl');
+  });
+
+  it('trims generation input', () => {
+    expect(parseGeneratePronunciationRequest({ vocabularyId: ' 水:ミズ ', text: ' 水 ' })).toEqual({
+      vocabularyId: '水:ミズ',
+      text: '水',
+    });
+  });
+
+  it.each([
+    ['blank vocabularyId', { vocabularyId: ' ', text: '水' }, 'vocabularyId'],
+    ['blank text', { vocabularyId: '水:ミズ', text: '\t' }, 'text'],
+  ])('rejects generation input with %s', (_caseName, value, field) => {
+    expect(() => parseGeneratePronunciationRequest(value)).toThrow(
+      `invalid_tts_generate_request:${field}`,
+    );
+  });
+
+  it('accepts an uncoded legacy error body', () => {
+    expect(parseTtsApiErrorResponse({ error: 'Failed to generate TTS audio' })).toEqual({
+      error: 'Failed to generate TTS audio',
+    });
+  });
+
+  it.each([
+    'tts_not_configured',
+    'tts_invalid_provider_configuration',
+    'tts_audio_service_unavailable',
+    'tts_generation_timeout',
+    'tts_generation_failed',
+    'tts_audio_storage_failed',
+    'tts_audio_access_failed',
+  ])('parses the supported coded error %s', (code) => {
+    expect(parseTtsApiErrorResponse({ error: 'TTS failed', code })).toEqual({
+      error: 'TTS failed',
+      code,
+    });
+  });
+
+  it.each([
+    ['missing error', {}],
+    ['non-string error', { error: 1 }],
+    ['non-string code', { error: 'TTS failed', code: 1 }],
+    ['unknown code', { error: 'TTS failed', code: 'tts_unknown' }],
+  ])('rejects malformed error bodies with %s', (_caseName, value) => {
+    expect(() => parseTtsApiErrorResponse(value)).toThrow('invalid_tts_api_error');
+  });
+});

--- a/packages/common/src/contracts/tts.test.ts
+++ b/packages/common/src/contracts/tts.test.ts
@@ -121,6 +121,51 @@ describe('TTS contracts', () => {
     });
   });
 
+  it('parses effective settings in a GET audio URL response', () => {
+    expect(
+      parseTtsAudioUrlResponse({
+        audioUrl: HTTPS_AUDIO,
+        effectiveSettings: { provider: 'openai', voiceId: 'alloy', model: 'tts-1' },
+      }),
+    ).toEqual({
+      audioUrl: HTTPS_AUDIO,
+      effectiveSettings: { provider: 'openai', voiceId: 'alloy', model: 'tts-1' },
+    });
+  });
+
+  it('parses effective settings with null voice/model in a GET audio URL response', () => {
+    expect(
+      parseTtsAudioUrlResponse({
+        audioUrl: HTTPS_AUDIO,
+        effectiveSettings: { provider: 'elevenlabs', voiceId: null, model: null },
+      }),
+    ).toEqual({
+      audioUrl: HTTPS_AUDIO,
+      effectiveSettings: { provider: 'elevenlabs', voiceId: null, model: null },
+    });
+  });
+
+  it.each([
+    [
+      'unsupported provider',
+      { provider: 'other', voiceId: null, model: null },
+      'effectiveSettings:provider',
+    ],
+    ['non-record effectiveSettings', 'openai', 'effectiveSettings'],
+    [
+      'non-string voiceId',
+      { provider: 'openai', voiceId: 1, model: null },
+      'effectiveSettings:voiceId',
+    ],
+  ])(
+    'rejects a GET audio response effectiveSettings with %s',
+    (_caseName, effectiveSettings, field) => {
+      expect(() => parseTtsAudioUrlResponse({ audioUrl: HTTPS_AUDIO, effectiveSettings })).toThrow(
+        `invalid_tts_audio_response:${field}`,
+      );
+    },
+  );
+
   it.each([
     ['non-HTTPS audio URL', { audioUrl: 'http://audio.example.test/mizu.mp3' }],
     ['unparseable audio URL', { audioUrl: 'not-a-url' }],

--- a/packages/common/src/contracts/tts.test.ts
+++ b/packages/common/src/contracts/tts.test.ts
@@ -50,6 +50,56 @@ describe('TTS contracts', () => {
     });
   });
 
+  it('parses effective settings when the backend includes them', () => {
+    expect(
+      parseGeneratePronunciationResponse({
+        audioUrl: HTTPS_AUDIO,
+        cached: false,
+        effectiveSettings: { provider: 'openai', voiceId: 'alloy', model: 'tts-1' },
+      }),
+    ).toEqual({
+      audioUrl: HTTPS_AUDIO,
+      cached: false,
+      effectiveSettings: { provider: 'openai', voiceId: 'alloy', model: 'tts-1' },
+    });
+  });
+
+  it('parses effective settings with null voice/model', () => {
+    expect(
+      parseGeneratePronunciationResponse({
+        audioUrl: HTTPS_AUDIO,
+        cached: true,
+        effectiveSettings: { provider: 'elevenlabs', voiceId: null, model: null },
+      }),
+    ).toEqual({
+      audioUrl: HTTPS_AUDIO,
+      cached: true,
+      effectiveSettings: { provider: 'elevenlabs', voiceId: null, model: null },
+    });
+  });
+
+  it.each([
+    [
+      'unsupported provider',
+      { provider: 'other', voiceId: null, model: null },
+      'effectiveSettings:provider',
+    ],
+    ['non-record effectiveSettings', 'openai', 'effectiveSettings'],
+    [
+      'non-string voiceId',
+      { provider: 'openai', voiceId: 1, model: null },
+      'effectiveSettings:voiceId',
+    ],
+  ])('rejects effective settings with %s', (_caseName, effectiveSettings, field) => {
+    expect(() =>
+      parseGeneratePronunciationResponse({
+        audioUrl: HTTPS_AUDIO,
+        cached: false,
+        effectiveSettings,
+      }),
+    ).toThrow(`invalid_tts_generate_response:${field}`);
+  });
+
   it('rejects non-HTTPS audio URLs', () => {
     expect(() =>
       parseGeneratePronunciationResponse({

--- a/packages/common/src/contracts/tts.ts
+++ b/packages/common/src/contracts/tts.ts
@@ -1,4 +1,5 @@
-export type TtsProvider = 'elevenlabs' | 'openai' | 'gemini';
+const TTS_PROVIDERS = ['elevenlabs', 'openai', 'gemini'] as const;
+export type TtsProvider = (typeof TTS_PROVIDERS)[number];
 
 export type TtsSettings = {
   provider: TtsProvider;
@@ -21,22 +22,7 @@ export type TtsAudioUrlResponse = {
   audioUrl: string;
 };
 
-export type TtsApiErrorCode =
-  | 'tts_not_configured'
-  | 'tts_invalid_provider_configuration'
-  | 'tts_audio_service_unavailable'
-  | 'tts_generation_timeout'
-  | 'tts_generation_failed'
-  | 'tts_audio_storage_failed'
-  | 'tts_audio_access_failed';
-
-export type TtsApiErrorResponse = {
-  error: string;
-  code?: TtsApiErrorCode;
-};
-
-const TTS_PROVIDERS = new Set<TtsProvider>(['elevenlabs', 'openai', 'gemini']);
-const TTS_API_ERROR_CODES = new Set<TtsApiErrorCode>([
+const TTS_API_ERROR_CODES = [
   'tts_not_configured',
   'tts_invalid_provider_configuration',
   'tts_audio_service_unavailable',
@@ -44,7 +30,26 @@ const TTS_API_ERROR_CODES = new Set<TtsApiErrorCode>([
   'tts_generation_failed',
   'tts_audio_storage_failed',
   'tts_audio_access_failed',
-]);
+  'tts_audio_bucket_not_configured',
+  'tts_unexpected_error',
+] as const;
+export type TtsApiErrorCode = (typeof TTS_API_ERROR_CODES)[number];
+
+export type TtsApiErrorResponse = {
+  error: string;
+  code?: TtsApiErrorCode;
+};
+
+const TTS_PROVIDER_VALUES: ReadonlySet<string> = new Set(TTS_PROVIDERS);
+const TTS_API_ERROR_CODE_VALUES: ReadonlySet<string> = new Set(TTS_API_ERROR_CODES);
+
+function isTtsProvider(value: string): value is TtsProvider {
+  return TTS_PROVIDER_VALUES.has(value);
+}
+
+function isTtsApiErrorCode(value: string): value is TtsApiErrorCode {
+  return TTS_API_ERROR_CODE_VALUES.has(value);
+}
 
 function requireRecord(value: unknown, field: string): Record<string, unknown> {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
@@ -89,12 +94,12 @@ function requireHttpsAudioUrl(value: unknown, field: string): string {
 export function parseTtsSettings(value: unknown): TtsSettings {
   const root = requireRecord(value, 'settings:root');
   const provider = requireString(root.provider, 'settings:provider');
-  if (!TTS_PROVIDERS.has(provider as TtsProvider)) {
+  if (!isTtsProvider(provider)) {
     throw new TypeError('invalid_tts_settings:provider');
   }
 
   return {
-    provider: provider as TtsProvider,
+    provider,
     voiceId: requireNullableString(root.voiceId, 'settings:voiceId'),
     model: requireNullableString(root.model, 'settings:model'),
     hasApiKey: requireBoolean(root.hasApiKey, 'settings:hasApiKey'),
@@ -136,8 +141,8 @@ export function parseTtsApiErrorResponse(value: unknown): TtsApiErrorResponse {
   if (code === undefined) {
     return { error };
   }
-  if (typeof code !== 'string' || !TTS_API_ERROR_CODES.has(code as TtsApiErrorCode)) {
+  if (typeof code !== 'string' || !isTtsApiErrorCode(code)) {
     throw new TypeError('invalid_tts_api_error:code');
   }
-  return { error, code: code as TtsApiErrorCode };
+  return { error, code };
 }

--- a/packages/common/src/contracts/tts.ts
+++ b/packages/common/src/contracts/tts.ts
@@ -17,6 +17,10 @@ export type GeneratePronunciationResponse = {
   cached: boolean;
 };
 
+export type TtsAudioUrlResponse = {
+  audioUrl: string;
+};
+
 export type TtsApiErrorCode =
   | 'tts_not_configured'
   | 'tts_invalid_provider_configuration'
@@ -70,6 +74,18 @@ function requireNullableString(value: unknown, field: string): string | null {
   return value;
 }
 
+function requireHttpsAudioUrl(value: unknown, field: string): string {
+  const audioUrl = requireString(value, field);
+  let parsed: URL;
+  try {
+    parsed = new URL(audioUrl);
+  } catch {
+    throw new TypeError(`invalid_tts_${field}`);
+  }
+  if (parsed.protocol !== 'https:') throw new TypeError(`invalid_tts_${field}`);
+  return audioUrl;
+}
+
 export function parseTtsSettings(value: unknown): TtsSettings {
   const root = requireRecord(value, 'settings:root');
   const provider = requireString(root.provider, 'settings:provider');
@@ -102,10 +118,14 @@ export function parseGeneratePronunciationRequest(value: unknown): GeneratePronu
 
 export function parseGeneratePronunciationResponse(value: unknown): GeneratePronunciationResponse {
   const root = requireRecord(value, 'generate_response:root');
-  const audioUrl = requireString(root.audioUrl, 'generate_response:audioUrl');
-  const parsed = new URL(audioUrl);
-  if (parsed.protocol !== 'https:') throw new TypeError('invalid_tts_generate_response:audioUrl');
+  const audioUrl = requireHttpsAudioUrl(root.audioUrl, 'generate_response:audioUrl');
   return { audioUrl, cached: requireBoolean(root.cached, 'generate_response:cached') };
+}
+
+export function parseTtsAudioUrlResponse(value: unknown): TtsAudioUrlResponse {
+  const root = requireRecord(value, 'audio_response:root');
+  const audioUrl = requireHttpsAudioUrl(root.audioUrl, 'audio_response:audioUrl');
+  return { audioUrl };
 }
 
 export function parseTtsApiErrorResponse(value: unknown): TtsApiErrorResponse {

--- a/packages/common/src/contracts/tts.ts
+++ b/packages/common/src/contracts/tts.ts
@@ -34,6 +34,15 @@ export type GeneratePronunciationResponse = {
 
 export type TtsAudioUrlResponse = {
   audioUrl: string;
+  /**
+   * The provider/voice/model the backend used to derive the S3 cache key for
+   * the looked-up audio. The backend re-reads TTS settings during
+   * `GET /tts/audio/:vocabularyId`, so these can differ from the settings a
+   * client read via `GET /tts/settings` if settings changed between the two
+   * requests. Clients use this to avoid caching audio under a stale settings
+   * identity. Optional for backward compatibility with older deployments.
+   */
+  effectiveSettings?: TtsEffectiveSettings;
 };
 
 const TTS_API_ERROR_CODES = [
@@ -135,6 +144,35 @@ export function parseGeneratePronunciationRequest(value: unknown): GeneratePronu
   return { vocabularyId, text };
 }
 
+/**
+ * Parse the optional `effectiveSettings` object shared by the generate and
+ * audio URL responses. `fieldPrefix` scopes the TypeError field path so each
+ * response type reports its own origin (e.g. `generate_response:...` vs
+ * `audio_response:...`).
+ */
+function parseEffectiveSettings(
+  value: unknown,
+  fieldPrefix: string,
+): TtsEffectiveSettings | undefined {
+  if (value === undefined) return undefined;
+  const settingsRecord = requireRecord(value, `${fieldPrefix}:effectiveSettings`);
+  const provider = requireString(
+    settingsRecord.provider,
+    `${fieldPrefix}:effectiveSettings:provider`,
+  );
+  if (!isTtsProvider(provider)) {
+    throw new TypeError(`invalid_tts_${fieldPrefix}:effectiveSettings:provider`);
+  }
+  return {
+    provider,
+    voiceId: requireNullableString(
+      settingsRecord.voiceId,
+      `${fieldPrefix}:effectiveSettings:voiceId`,
+    ),
+    model: requireNullableString(settingsRecord.model, `${fieldPrefix}:effectiveSettings:model`),
+  };
+}
+
 export function parseGeneratePronunciationResponse(value: unknown): GeneratePronunciationResponse {
   const root = requireRecord(value, 'generate_response:root');
   const audioUrl = requireHttpsAudioUrl(root.audioUrl, 'generate_response:audioUrl');
@@ -143,30 +181,8 @@ export function parseGeneratePronunciationResponse(value: unknown): GeneratePron
     cached: requireBoolean(root.cached, 'generate_response:cached'),
   };
 
-  if (root.effectiveSettings !== undefined) {
-    const settingsRecord = requireRecord(
-      root.effectiveSettings,
-      'generate_response:effectiveSettings',
-    );
-    const provider = requireString(
-      settingsRecord.provider,
-      'generate_response:effectiveSettings:provider',
-    );
-    if (!isTtsProvider(provider)) {
-      throw new TypeError('invalid_tts_generate_response:effectiveSettings:provider');
-    }
-    response.effectiveSettings = {
-      provider,
-      voiceId: requireNullableString(
-        settingsRecord.voiceId,
-        'generate_response:effectiveSettings:voiceId',
-      ),
-      model: requireNullableString(
-        settingsRecord.model,
-        'generate_response:effectiveSettings:model',
-      ),
-    };
-  }
+  const effectiveSettings = parseEffectiveSettings(root.effectiveSettings, 'generate_response');
+  if (effectiveSettings) response.effectiveSettings = effectiveSettings;
 
   return response;
 }
@@ -174,7 +190,12 @@ export function parseGeneratePronunciationResponse(value: unknown): GeneratePron
 export function parseTtsAudioUrlResponse(value: unknown): TtsAudioUrlResponse {
   const root = requireRecord(value, 'audio_response:root');
   const audioUrl = requireHttpsAudioUrl(root.audioUrl, 'audio_response:audioUrl');
-  return { audioUrl };
+  const response: TtsAudioUrlResponse = { audioUrl };
+
+  const effectiveSettings = parseEffectiveSettings(root.effectiveSettings, 'audio_response');
+  if (effectiveSettings) response.effectiveSettings = effectiveSettings;
+
+  return response;
 }
 
 export function parseTtsApiErrorResponse(value: unknown): TtsApiErrorResponse {

--- a/packages/common/src/contracts/tts.ts
+++ b/packages/common/src/contracts/tts.ts
@@ -1,0 +1,123 @@
+export type TtsProvider = 'elevenlabs' | 'openai' | 'gemini';
+
+export type TtsSettings = {
+  provider: TtsProvider;
+  voiceId: string | null;
+  model: string | null;
+  hasApiKey: boolean;
+};
+
+export type GeneratePronunciationRequest = {
+  vocabularyId: string;
+  text: string;
+};
+
+export type GeneratePronunciationResponse = {
+  audioUrl: string;
+  cached: boolean;
+};
+
+export type TtsApiErrorCode =
+  | 'tts_not_configured'
+  | 'tts_invalid_provider_configuration'
+  | 'tts_audio_service_unavailable'
+  | 'tts_generation_timeout'
+  | 'tts_generation_failed'
+  | 'tts_audio_storage_failed'
+  | 'tts_audio_access_failed';
+
+export type TtsApiErrorResponse = {
+  error: string;
+  code?: TtsApiErrorCode;
+};
+
+const TTS_PROVIDERS = new Set<TtsProvider>(['elevenlabs', 'openai', 'gemini']);
+const TTS_API_ERROR_CODES = new Set<TtsApiErrorCode>([
+  'tts_not_configured',
+  'tts_invalid_provider_configuration',
+  'tts_audio_service_unavailable',
+  'tts_generation_timeout',
+  'tts_generation_failed',
+  'tts_audio_storage_failed',
+  'tts_audio_access_failed',
+]);
+
+function requireRecord(value: unknown, field: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new TypeError(`invalid_tts_${field}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== 'string') {
+    throw new TypeError(`invalid_tts_${field}`);
+  }
+  return value;
+}
+
+function requireBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== 'boolean') {
+    throw new TypeError(`invalid_tts_${field}`);
+  }
+  return value;
+}
+
+function requireNullableString(value: unknown, field: string): string | null {
+  if (value !== null && typeof value !== 'string') {
+    throw new TypeError(`invalid_tts_${field}`);
+  }
+  return value;
+}
+
+export function parseTtsSettings(value: unknown): TtsSettings {
+  const root = requireRecord(value, 'settings:root');
+  const provider = requireString(root.provider, 'settings:provider');
+  if (!TTS_PROVIDERS.has(provider as TtsProvider)) {
+    throw new TypeError('invalid_tts_settings:provider');
+  }
+
+  return {
+    provider: provider as TtsProvider,
+    voiceId: requireNullableString(root.voiceId, 'settings:voiceId'),
+    model: requireNullableString(root.model, 'settings:model'),
+    hasApiKey: requireBoolean(root.hasApiKey, 'settings:hasApiKey'),
+  };
+}
+
+export function parseGeneratePronunciationRequest(value: unknown): GeneratePronunciationRequest {
+  const root = requireRecord(value, 'generate_request:root');
+  const vocabularyId = requireString(root.vocabularyId, 'generate_request:vocabularyId').trim();
+  const text = requireString(root.text, 'generate_request:text').trim();
+
+  if (!vocabularyId) {
+    throw new TypeError('invalid_tts_generate_request:vocabularyId');
+  }
+  if (!text) {
+    throw new TypeError('invalid_tts_generate_request:text');
+  }
+
+  return { vocabularyId, text };
+}
+
+export function parseGeneratePronunciationResponse(value: unknown): GeneratePronunciationResponse {
+  const root = requireRecord(value, 'generate_response:root');
+  const audioUrl = requireString(root.audioUrl, 'generate_response:audioUrl');
+  const parsed = new URL(audioUrl);
+  if (parsed.protocol !== 'https:') throw new TypeError('invalid_tts_generate_response:audioUrl');
+  return { audioUrl, cached: requireBoolean(root.cached, 'generate_response:cached') };
+}
+
+export function parseTtsApiErrorResponse(value: unknown): TtsApiErrorResponse {
+  const root = requireRecord(value, 'api_error');
+  const error = requireString(root.error, 'api_error:error');
+  const code = root.code;
+
+  if (code === undefined) {
+    return { error };
+  }
+  if (typeof code !== 'string' || !TTS_API_ERROR_CODES.has(code as TtsApiErrorCode)) {
+    throw new TypeError('invalid_tts_api_error:code');
+  }
+  return { error, code: code as TtsApiErrorCode };
+}

--- a/packages/common/src/contracts/tts.ts
+++ b/packages/common/src/contracts/tts.ts
@@ -45,6 +45,31 @@ export type TtsAudioUrlResponse = {
   effectiveSettings?: TtsEffectiveSettings;
 };
 
+/**
+ * Compare the GET /tts/settings snapshot (used to derive the client cache key)
+ * against the effective settings the backend reports it actually used for the
+ * generation or audio lookup. The backend re-reads settings during
+ * `POST /tts/generate` and `GET /tts/audio/:vocabularyId`, so a concurrent
+ * settings change can make these differ. When they differ, the audio was
+ * produced under new settings but the client key was derived from the old
+ * snapshot, so the entry must not be cached under that stale key.
+ *
+ * When the backend omits `effectiveSettings` (older deployment), this returns
+ * false to avoid caching under a settings identity the backend did not
+ * confirm. Playback still succeeds; only the memory cache is skipped.
+ */
+export function effectiveSettingsMatch(
+  snapshot: TtsSettings,
+  effective: TtsEffectiveSettings | undefined,
+): boolean {
+  if (!effective) return false;
+  return (
+    effective.provider === snapshot.provider &&
+    effective.voiceId === snapshot.voiceId &&
+    effective.model === snapshot.model
+  );
+}
+
 const TTS_API_ERROR_CODES = [
   'tts_not_configured',
   'tts_invalid_provider_configuration',
@@ -54,6 +79,7 @@ const TTS_API_ERROR_CODES = [
   'tts_audio_storage_failed',
   'tts_audio_access_failed',
   'tts_audio_bucket_not_configured',
+  'tts_audio_not_found',
   'tts_unexpected_error',
 ] as const;
 export type TtsApiErrorCode = (typeof TTS_API_ERROR_CODES)[number];

--- a/packages/common/src/contracts/tts.ts
+++ b/packages/common/src/contracts/tts.ts
@@ -13,9 +13,23 @@ export type GeneratePronunciationRequest = {
   text: string;
 };
 
+/**
+ * The provider/voice/model the backend actually used to produce (or look up)
+ * the audio for a generate request. The backend re-reads TTS settings during
+ * `POST /tts/generate`, so these can differ from the settings a client read
+ * via `GET /tts/settings` if settings changed between the two requests.
+ * Clients use this to avoid caching audio under a stale settings identity.
+ */
+export type TtsEffectiveSettings = {
+  provider: TtsProvider;
+  voiceId: string | null;
+  model: string | null;
+};
+
 export type GeneratePronunciationResponse = {
   audioUrl: string;
   cached: boolean;
+  effectiveSettings?: TtsEffectiveSettings;
 };
 
 export type TtsAudioUrlResponse = {
@@ -124,7 +138,37 @@ export function parseGeneratePronunciationRequest(value: unknown): GeneratePronu
 export function parseGeneratePronunciationResponse(value: unknown): GeneratePronunciationResponse {
   const root = requireRecord(value, 'generate_response:root');
   const audioUrl = requireHttpsAudioUrl(root.audioUrl, 'generate_response:audioUrl');
-  return { audioUrl, cached: requireBoolean(root.cached, 'generate_response:cached') };
+  const response: GeneratePronunciationResponse = {
+    audioUrl,
+    cached: requireBoolean(root.cached, 'generate_response:cached'),
+  };
+
+  if (root.effectiveSettings !== undefined) {
+    const settingsRecord = requireRecord(
+      root.effectiveSettings,
+      'generate_response:effectiveSettings',
+    );
+    const provider = requireString(
+      settingsRecord.provider,
+      'generate_response:effectiveSettings:provider',
+    );
+    if (!isTtsProvider(provider)) {
+      throw new TypeError('invalid_tts_generate_response:effectiveSettings:provider');
+    }
+    response.effectiveSettings = {
+      provider,
+      voiceId: requireNullableString(
+        settingsRecord.voiceId,
+        'generate_response:effectiveSettings:voiceId',
+      ),
+      model: requireNullableString(
+        settingsRecord.model,
+        'generate_response:effectiveSettings:model',
+      ),
+    };
+  }
+
+  return response;
 }
 
 export function parseTtsAudioUrlResponse(value: unknown): TtsAudioUrlResponse {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -27,3 +27,17 @@ export { DEFAULT_DAILY_LESSON_GOAL, DEFAULT_LESSON_DURATION_MINUTES } from './co
 
 // Export shared domain contracts
 export { parseSrsStats, type SRSStats } from './contracts/srs';
+
+// Export shared TTS contracts
+export {
+  parseGeneratePronunciationRequest,
+  parseGeneratePronunciationResponse,
+  parseTtsApiErrorResponse,
+  parseTtsSettings,
+  type GeneratePronunciationRequest,
+  type GeneratePronunciationResponse,
+  type TtsApiErrorCode,
+  type TtsApiErrorResponse,
+  type TtsProvider,
+  type TtsSettings,
+} from './contracts/tts';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -40,6 +40,7 @@ export {
   type TtsApiErrorCode,
   type TtsApiErrorResponse,
   type TtsAudioUrlResponse,
+  type TtsEffectiveSettings,
   type TtsProvider,
   type TtsSettings,
 } from './contracts/tts';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -33,11 +33,13 @@ export {
   parseGeneratePronunciationRequest,
   parseGeneratePronunciationResponse,
   parseTtsApiErrorResponse,
+  parseTtsAudioUrlResponse,
   parseTtsSettings,
   type GeneratePronunciationRequest,
   type GeneratePronunciationResponse,
   type TtsApiErrorCode,
   type TtsApiErrorResponse,
+  type TtsAudioUrlResponse,
   type TtsProvider,
   type TtsSettings,
 } from './contracts/tts';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -30,6 +30,7 @@ export { parseSrsStats, type SRSStats } from './contracts/srs';
 
 // Export shared TTS contracts
 export {
+  effectiveSettingsMatch,
   parseGeneratePronunciationRequest,
   parseGeneratePronunciationResponse,
   parseTtsApiErrorResponse,


### PR DESCRIPTION
## Summary

- add shared TTS contracts and stable API error codes across common, web, API, and mobile
- add authenticated mobile TTS service, bounded request/replay behavior, cache and invalidation isolation, shared lifecycle state, HTML audio adapter, and pronunciation diagnostic controller/page
- expose an authenticated development-only diagnostic route and scan production bundles for every diagnostic token

## Validation

- `bun run --cwd apps/vela-mobile lint`
- `bun run --cwd apps/vela-mobile typecheck`
- `bun run --cwd apps/vela-mobile test:unit` (55 files, 1,003 tests)
- production Capacitor build plus `verify-production-diagnostics` with documented non-secret CI placeholders (no diagnostic tokens found)
- `bun run test` (7/7 Turbo tasks)
- final source re-review: no Critical, Important, or Minor findings

## Acceptance caveat

Physical-iPhone audibility, silent-mode, interruption, and related native playback validation is intentionally deferred. Simulator evidence is also still pending; no physical-device evidence document or Linear updates were created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a development-only mobile TTS pronunciation diagnostics screen with playback controls, status details, timing metrics, and recovery actions.
  * Added authenticated mobile pronunciation preparation, caching, request deduplication, and audio playback.
  * Added lifecycle-aware interruption and session recovery handling.
* **Bug Fixes**
  * Improved TTS error reporting with stable error codes and safer log redaction.
  * Prevented unsafe caching when audio settings are missing or inconsistent.
  * Added request timeout support and clearer network error handling.
* **Quality Improvements**
  * Expanded validation and automated coverage for TTS, audio playback, authentication, and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->