### PR TITLE
docs(mobile): design M1 iOS foundation verification

### DIFF
--- a/docs/superpowers/plans/2026-08-02-mobile-ios-foundation-verification.md
+++ b/docs/superpowers/plans/2026-08-02-mobile-ios-foundation-verification.md
@@ -1,0 +1,1946 @@
+# Mobile iOS Foundation Verification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a repeatable HPA-210 verification harness, collect production and diagnostic evidence on Simulator and a physical iPhone, record the tested iOS foundation architecture, and issue an auditable M1 `GO` or `NO-GO`.
+
+**Architecture:** Keep verification policy in pure TypeScript modules under `apps/vela-mobile/build/`, expose thin Bun entry points under `apps/vela-mobile/scripts/`, and reuse the existing production-diagnostics build/scan path. Machine phases produce append-only manifests keyed by `testedBehaviorCommit`; production product behavior and development-only diagnostic behavior run as separate build classes on the same commit and deployed backend. Physical observations remain explicit manual matrices and cannot be inferred from automated or Simulator results.
+
+**Tech Stack:** Bun 1.3.1+, Turborepo 2, TypeScript 5.6, Vitest 3, Vue 3, Quasar 2, Capacitor 7, Xcode 16+, `xcodebuild`, `xcrun simctl`, `xcrun devicectl`, iOS Simulator, physical iPhone, GitHub Actions, Linear.
+
+## Global Constraints
+
+- Pin every machine manifest and executable matrix row to one exact `testedBehaviorCommit`.
+- Documentation-, manifest-, evidence-reference-, architecture-, and `CLAUDE.md`-only commits do not invalidate rows pinned to `testedBehaviorCommit`.
+- Any change to executable source, native/build configuration, dependency locks, generated WebView assets, or verification tooling creates a new behavior commit and reruns affected gates.
+- Require both native classes on the same behavior commit and deployed backend identity:
+  - production smoke with Release/production assets and diagnostics excluded;
+  - Debug diagnostic observation with development-only routes enabled.
+- Require the five mobile build variables for closure runs: `VITE_MOBILE_API_URL`, `VITE_COGNITO_USER_POOL_ID`, `VITE_COGNITO_MOBILE_USER_POOL_CLIENT_ID`, `VITE_COGNITO_OAUTH_DOMAIN`, and `VITE_AWS_REGION`.
+- Forbid `MOBILE_SKIP_ENV_VALIDATION=true`, `example.invalid`, localhost, placeholder credentials, and mismatched backend/client configuration for closure evidence.
+- Keep `apps/vela-mobile/scripts/verify-production-diagnostics.mjs` as the only forbidden-diagnostic-token implementation.
+- Scan emitted text artifacts with extensions `.js`, `.mjs`, `.cjs`, `.html`, `.css`, `.json`, `.map`, `.txt`, `.svg`, and `.xml`; skip binary files.
+- Keep production diagnostics compiled out; never relax `import.meta.env.DEV` route ownership to make physical validation easier.
+- Require physical-iPhone evidence for fresh Google sign-in, warm/cold callback, relaunch restoration, due-count identity isolation, speaker audibility, silent mode, interruption, Japanese Kana IME, native swipe history, and sensor-region safe areas.
+- Use a development-team-signed personal iPhone controlled by the tester; do not commit `DEVELOPMENT_TEAM`, provisioning profiles, UDIDs, account email addresses, or credential-bearing logs.
+- Use harness exits exactly: `0 passed`, `2 usage_error`, `3 prerequisite_missing`, `4 gate_failed`, `1 harness_error`.
+- Store manifests at `apps/vela-mobile/docs/evidence/hpa-210/<full-testedBehaviorCommit>/<run-id>/manifest.json`.
+- Commit manifests and small bounded text evidence; reference screenshots, videos, raw logs, archives, and other growth-prone artifacts by storage location, byte size, media type, and SHA-256.
+- Preserve the historical flat `apps/vela-mobile/docs/evidence/hpa-209/*.png` layout.
+- After selecting and hashing production `src-capacitor/www`, forbid every Quasar iOS build command until the corresponding production smoke completes; only explicit `bunx cap sync ios` is allowed, with pre/post directory-hash equality.
+- Keep the transient OAuth transaction (`state`, `codeVerifier`, `nonce`, `createdAt`) in Capacitor Preferences/iOS UserDefaults with the existing 10-minute TTL and cleanup lifecycle; do not migrate it during HPA-210.
+- Permit High-severity reclassification only for the silent-mode-only audio-session fork after correct audible core playback, replay, decoding, and lifecycle recovery pass.
+- Keep OAuth/session restoration, data isolation, IME, keyboard obstruction, safe-area failures, navigation traps, unaudible core playback, and `native player adapter required` as hard `NO-GO`.
+- Keep permanent macOS CI, TestFlight, App Store distribution, full native UI automation, Android, SRS review implementation, and unrelated refactors out of scope.
+
+---
+
+## File Map
+
+### Repository freeze coverage
+
+- Modify `package.json` — add the root `compile` entry point.
+- Modify `turbo.json` — define the `compile` task and dependency behavior.
+
+### Production diagnostic scanner
+
+- Modify `apps/vela-mobile/scripts/verify-production-diagnostics.mjs` — scan all emitted text-artifact classes.
+- Modify `apps/vela-mobile/scripts/verify-production-diagnostics.test.mjs` — prove each supported extension and binary exclusion.
+
+### Secret policy and scanner
+
+- Create `apps/vela-mobile/build/mobile-secret-policy.ts` — single policy source for sentinels, regex rules, public identifiers, and redacted finding types.
+- Create `apps/vela-mobile/build/mobile-secret-policy.test.ts`.
+- Create `apps/vela-mobile/scripts/scan-mobile-secrets.mjs` — executable source/artifact/evidence scanner.
+- Create `apps/vela-mobile/scripts/scan-mobile-secrets.test.mjs`.
+- Modify `apps/vela-mobile/src/test/secret-leak-helpers.ts` — import and re-export shared sentinel policy.
+- Modify `apps/vela-mobile/package.json` — add `scan:secrets`, `verify:m1-foundation`, and lint coverage for `scripts/`.
+- Modify `eslint.config.js` only if the existing mobile JavaScript rule does not supply every Node global used by the new scripts.
+
+### Manifest and harness
+
+- Create `apps/vela-mobile/build/m1-foundation-contract.ts` — phases, outcomes, exit codes, manifest schema, run IDs, hashing, and path rules.
+- Create `apps/vela-mobile/build/m1-foundation-contract.test.ts`.
+- Create `apps/vela-mobile/build/m1-foundation-harness.ts` — dependency-injected orchestration for automated, Simulator, and physical-preflight phases.
+- Create `apps/vela-mobile/build/m1-foundation-harness.test.ts`.
+- Create `apps/vela-mobile/scripts/verify-m1-foundation.mjs` — thin CLI wrapper.
+
+### Documentation and evidence
+
+- Create `apps/vela-mobile/docs/ios-foundation-architecture.md`.
+- Create `apps/vela-mobile/docs/m1-ios-foundation-verification.md`.
+- Modify `apps/vela-mobile/README.md` — harness usage, build classes, signing preflight, and evidence layout.
+- Modify `CLAUDE.md` at closeout — replace stale M2 OAuth guidance and link the final HPA-210 records.
+- Modify `docs/superpowers/specs/2026-08-02-mobile-ios-foundation-verification-design.md` as the final pre-merge action — change the review status line.
+
+---
+
+### Task 1: Add Complete Monorepo Freeze Coverage
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `turbo.json`
+
+**Interfaces:**
+
+- Produces root command: `bun run compile`.
+- Produces Turbo task: `compile`, executed by workspaces that define a `compile` script.
+- Consumers: `runAutomatedPhase()` in Task 5 and the final freeze run in Task 9.
+
+- [ ] **Step 1: Verify the missing root command**
+
+Run:
+
+```bash
+bun run compile
+```
+
+Expected: FAIL with Bun reporting that the root `compile` script does not exist.
+
+- [ ] **Step 2: Add the root command**
+
+Add this exact script beside `build` and `typecheck` in `package.json`:
+
+```json
+"compile": "turbo compile"
+```
+
+- [ ] **Step 3: Add the Turbo task**
+
+Add this exact task to `turbo.json`:
+
+```json
+"compile": {
+  "dependsOn": ["^build"],
+  "outputs": []
+}
+```
+
+The dependency ensures `@vela/common` and other upstream build outputs exist before API or extension compilation.
+
+- [ ] **Step 4: Verify workspace participation**
+
+Run:
+
+```bash
+bun run compile -- --dry=json > /tmp/vela-m1-compile-dry-run.json
+```
+
+Inspect the JSON and verify it includes at least:
+
+```text
+vela-api#compile
+wxt-vue-starter#compile
+```
+
+Then run:
+
+```bash
+bun run compile
+```
+
+Expected: PASS with both API `tsc --noEmit` and extension `vue-tsc --noEmit` completing successfully.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json turbo.json
+git commit -m "build: add monorepo compile gate"
+```
+
+---
+
+### Task 2: Widen the Authoritative Production-Diagnostics Scanner
+
+**Files:**
+
+- Modify: `apps/vela-mobile/scripts/verify-production-diagnostics.mjs`
+- Modify: `apps/vela-mobile/scripts/verify-production-diagnostics.test.mjs`
+
+**Interfaces:**
+
+- Produces: `PRODUCTION_TEXT_ARTIFACT_EXTENSIONS`.
+- Preserves: `findDiagnosticTokens(root, tokens)` and `findProductionDiagnosticTokens(root)`.
+- Consumers: `verify:production-diagnostics` and Task 5 automated verification.
+
+- [ ] **Step 1: Replace the JavaScript-only test with extension coverage**
+
+Add this table to `verify-production-diagnostics.test.mjs`:
+
+```js
+const emittedTextExtensions = [
+  '.js',
+  '.mjs',
+  '.cjs',
+  '.html',
+  '.css',
+  '.json',
+  '.map',
+  '.txt',
+  '.svg',
+  '.xml',
+];
+
+it.each(emittedTextExtensions)('finds diagnostic tokens in emitted %s artifacts', async (extension) => {
+  const root = await mkdtemp(join(tmpdir(), 'vela-prod-scan-'));
+  const artifact = join(root, `artifact${extension}`);
+  const token = forbiddenTokens[0];
+  await writeFile(artifact, `prefix ${token} suffix`);
+
+  expect(await findDiagnosticTokens(root, [token])).toEqual([{ path: artifact, token }]);
+});
+
+it('ignores unsupported and binary artifacts', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'vela-prod-scan-'));
+  const token = forbiddenTokens[0];
+  await writeFile(join(root, 'image.png'), Buffer.from(token));
+  await writeFile(join(root, 'archive.zip'), Buffer.from(token));
+
+  expect(await findDiagnosticTokens(root, [token])).toEqual([]);
+});
+```
+
+Remove the old test named `ignores non-JavaScript assets`.
+
+- [ ] **Step 2: Run the focused test and verify red**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- scripts/verify-production-diagnostics.test.mjs
+```
+
+Expected: FAIL for `.html`, `.css`, `.json`, `.map`, `.txt`, `.svg`, and `.xml` because the scanner currently reads only `.js`.
+
+- [ ] **Step 3: Implement the extension allowlist**
+
+Use `extname` and export the exact allowlist:
+
+```js
+import { extname, relative, resolve } from 'node:path';
+
+export const PRODUCTION_TEXT_ARTIFACT_EXTENSIONS = new Set([
+  '.js',
+  '.mjs',
+  '.cjs',
+  '.html',
+  '.css',
+  '.json',
+  '.map',
+  '.txt',
+  '.svg',
+  '.xml',
+]);
+```
+
+Replace the current file branch with:
+
+```js
+} else if (
+  entry.isFile() &&
+  PRODUCTION_TEXT_ARTIFACT_EXTENSIONS.has(extname(entry.name).toLowerCase())
+) {
+  const contents = await readFile(path, 'utf8');
+  for (const token of tokens) {
+    if (contents.includes(token)) matches.push({ path, token });
+  }
+}
+```
+
+Do not move or duplicate `PRODUCTION_FORBIDDEN_TOKENS`.
+
+- [ ] **Step 4: Run the scanner tests**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- scripts/verify-production-diagnostics.test.mjs
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the real production scanner**
+
+Use a configured production environment:
+
+```bash
+bun run --cwd apps/vela-mobile verify:production-diagnostics
+```
+
+Expected: PASS and report no forbidden diagnostic token under `src-capacitor/www`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  apps/vela-mobile/scripts/verify-production-diagnostics.mjs \
+  apps/vela-mobile/scripts/verify-production-diagnostics.test.mjs
+git commit -m "test(mobile): scan all production text assets"
+```
+
+---
+
+### Task 3: Create One Mobile Secret Policy and Executable Scanner
+
+**Files:**
+
+- Create: `apps/vela-mobile/build/mobile-secret-policy.ts`
+- Create: `apps/vela-mobile/build/mobile-secret-policy.test.ts`
+- Create: `apps/vela-mobile/scripts/scan-mobile-secrets.mjs`
+- Create: `apps/vela-mobile/scripts/scan-mobile-secrets.test.mjs`
+- Modify: `apps/vela-mobile/src/test/secret-leak-helpers.ts`
+- Modify: `apps/vela-mobile/package.json`
+- Modify: `eslint.config.js` only when a new script global is not already covered
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+export type MobileSecretRuleId =
+  | 'secret_sentinel'
+  | 'bearer_value'
+  | 'jwt_value'
+  | 'private_key'
+  | 'aws_secret'
+  | 'provider_key'
+  | 'presigned_url';
+
+export type MobileSecretFinding = {
+  ruleId: MobileSecretRuleId;
+  path: string;
+  line: number;
+  valueClass: string;
+  fingerprint: string;
+};
+
+export const SECRET_SENTINELS: readonly string[];
+export const LOG_AND_DOM_SENTINELS: readonly string[];
+export const NON_SCHEMA_STORAGE_SENTINELS: readonly string[];
+export const PUBLIC_CONFIGURATION_KEYS: ReadonlySet<string>;
+export function scanMobileSecretText(input: {
+  path: string;
+  text: string;
+}): MobileSecretFinding[];
+```
+
+- Produces executable: `bun run --cwd apps/vela-mobile scan:secrets -- --root <path>`.
+- Consumers: runtime secret-leak tests, Task 5 automated phase, evidence pre-commit scan.
+
+- [ ] **Step 1: Write policy tests**
+
+Create `mobile-secret-policy.test.ts` with these cases:
+
+```ts
+import {
+  PUBLIC_CONFIGURATION_KEYS,
+  scanMobileSecretText,
+} from './mobile-secret-policy';
+
+it('finds a bearer credential without retaining its raw value', () => {
+  const findings = scanMobileSecretText({
+    path: 'captured.log',
+    text: 'Authorization: Bearer SECRET-id-token',
+  });
+
+  expect(findings).toEqual([
+    expect.objectContaining({
+      ruleId: 'bearer_value',
+      path: 'captured.log',
+      line: 1,
+      valueClass: 'authorization_bearer',
+      fingerprint: expect.stringMatching(/^[a-f0-9]{64}$/u),
+    }),
+  ]);
+  expect(JSON.stringify(findings)).not.toContain('SECRET-id-token');
+});
+
+it('allows public mobile configuration identifiers', () => {
+  expect(PUBLIC_CONFIGURATION_KEYS).toEqual(
+    new Set([
+      'VITE_MOBILE_API_URL',
+      'VITE_COGNITO_USER_POOL_ID',
+      'VITE_COGNITO_MOBILE_USER_POOL_CLIENT_ID',
+      'VITE_COGNITO_OAUTH_DOMAIN',
+      'VITE_AWS_REGION',
+    ]),
+  );
+  expect(
+    scanMobileSecretText({
+      path: 'manifest.json',
+      text: JSON.stringify({
+        VITE_COGNITO_USER_POOL_ID: 'us-east-1_public',
+        VITE_COGNITO_MOBILE_USER_POOL_CLIENT_ID: 'public-client-id',
+      }),
+    }),
+  ).toEqual([]);
+});
+
+it('finds a full presigned URL but allows an origin-only URL', () => {
+  expect(
+    scanMobileSecretText({
+      path: 'audio.log',
+      text: 'https://bucket.example/audio.mp3?X-Amz-Credential=secret&X-Amz-Signature=secret',
+    }),
+  ).toHaveLength(1);
+
+  expect(
+    scanMobileSecretText({
+      path: 'manifest.json',
+      text: 'https://api.example.test/api/',
+    }),
+  ).toEqual([]);
+});
+```
+
+Add cases for JWT-shaped values, private-key headers, AWS secret key assignments, provider API keys, line-number calculation, known sentinels, and bounded false-positive classification.
+
+- [ ] **Step 2: Run policy tests and verify red**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- build/mobile-secret-policy.test.ts
+```
+
+Expected: FAIL because the policy module does not exist.
+
+- [ ] **Step 3: Implement the pure policy**
+
+Implement redacted findings with SHA-256 fingerprints:
+
+```ts
+import { createHash } from 'node:crypto';
+
+function finding(
+  ruleId: MobileSecretRuleId,
+  path: string,
+  line: number,
+  valueClass: string,
+  rawValue: string,
+): MobileSecretFinding {
+  return {
+    ruleId,
+    path,
+    line,
+    valueClass,
+    fingerprint: createHash('sha256').update(rawValue).digest('hex'),
+  };
+}
+```
+
+Move the existing sentinel arrays from `src/test/secret-leak-helpers.ts` into this module without changing their values. Define scanners for:
+
+```ts
+const BEARER_PATTERN = /Authorization:\s*Bearer\s+([^\s"'`]+)/giu;
+const JWT_PATTERN = /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/gu;
+const PRIVATE_KEY_PATTERN = /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/gu;
+const PRESIGNED_URL_PATTERN =
+  /https?:\/\/[^\s"'`?]+\?[^\s"'`]*(?:X-Amz-Credential|X-Amz-Signature|X-Amz-Security-Token)=[^\s"'`]*/giu;
+```
+
+Use key/value matching for AWS and provider secret assignments. Return only redacted findings.
+
+- [ ] **Step 4: Adapt runtime secret-leak helpers**
+
+Replace local sentinel declarations with imports and re-exports:
+
+```ts
+import {
+  LOG_AND_DOM_SENTINELS,
+  NON_SCHEMA_STORAGE_SENTINELS,
+  SECRET_SENTINELS,
+} from '../../build/mobile-secret-policy';
+
+export {
+  LOG_AND_DOM_SENTINELS,
+  NON_SCHEMA_STORAGE_SENTINELS,
+  SECRET_SENTINELS,
+};
+```
+
+Keep `createSecretLeakAssertions()` behavior unchanged.
+
+- [ ] **Step 5: Write executable-scanner tests**
+
+Create temporary source, artifact, native-resource, log, and evidence roots:
+
+```js
+it('scans supported files and returns redacted findings', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'vela-secret-scan-'));
+  await mkdir(join(root, 'nested'));
+  await writeFile(
+    join(root, 'nested', 'captured.log'),
+    'Authorization: Bearer SECRET-access-token',
+  );
+
+  const result = await scanMobileSecretRoots({
+    roots: [root],
+    exclusions: [],
+  });
+
+  expect(result.findings).toEqual([
+    expect.objectContaining({
+      ruleId: 'bearer_value',
+      path: 'nested/captured.log',
+      fingerprint: expect.stringMatching(/^[a-f0-9]{64}$/u),
+    }),
+  ]);
+  expect(JSON.stringify(result)).not.toContain('SECRET-access-token');
+});
+```
+
+Add cases proving `node_modules`, `DerivedData`, archives, images, and files above the configured byte limit are skipped with a bounded skip record.
+
+- [ ] **Step 6: Run scanner tests and verify red**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- scripts/scan-mobile-secrets.test.mjs
+```
+
+Expected: FAIL because `scan-mobile-secrets.mjs` does not exist.
+
+- [ ] **Step 7: Implement the executable scanner**
+
+Export:
+
+```js
+export async function scanMobileSecretRoots({
+  roots,
+  exclusions = ['node_modules', 'DerivedData', 'coverage', '.git'],
+  maxTextBytes = 2 * 1024 * 1024,
+}) {
+  // recursively walk supported text files, call scanMobileSecretText(),
+  // return { findings, skipped } with repository-relative paths
+}
+```
+
+Use the same text-artifact extension set as Task 2 plus `.log`, `.md`, `.plist`, `.pbxproj`, `.xcconfig`, `.entitlements`, `.yaml`, and `.yml`. Never include matched raw values in output.
+
+Define bounded fixture handling: files matching `*.test.*` or `*.spec.*` may contain only the explicit `SECRET-` sentinels and `.example.test` / `example.invalid` fixture values exported by the policy. A real-looking bearer value, JWT, private key, provider key, or AWS secret still fails in a test file. The policy module itself may define its exported sentinel literals without self-reporting them.
+
+Implement CLI flags:
+
+```text
+--root <path>       repeatable
+--json <path>       write redacted report
+--max-bytes <n>     default 2097152
+```
+
+Exit `4` when findings exist, `2` for invalid arguments, and `1` for scanner failures.
+
+- [ ] **Step 8: Add package scripts and lint coverage**
+
+Change the mobile package scripts to:
+
+```json
+"scan:secrets": "bun run scripts/scan-mobile-secrets.mjs",
+"verify:m1-foundation": "bun run scripts/verify-m1-foundation.mjs",
+"lint": "eslint \"./src/**/*.{ts,js,vue}\" \"./build/**/*.{ts,js}\" \"./scripts/**/*.{mjs,js,ts}\""
+```
+
+The root ESLint config already applies Node globals to `apps/vela-mobile/**/*.{js,mjs}`. Modify it only if a new global is genuinely missing.
+
+- [ ] **Step 9: Run focused and package tests**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- \
+  build/mobile-secret-policy.test.ts \
+  scripts/scan-mobile-secrets.test.mjs \
+  src/services/mobile-auth.test.ts \
+  src/boot/mobile-auth.test.ts
+bun run --cwd apps/vela-mobile lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add \
+  apps/vela-mobile/build/mobile-secret-policy.ts \
+  apps/vela-mobile/build/mobile-secret-policy.test.ts \
+  apps/vela-mobile/scripts/scan-mobile-secrets.mjs \
+  apps/vela-mobile/scripts/scan-mobile-secrets.test.mjs \
+  apps/vela-mobile/src/test/secret-leak-helpers.ts \
+  apps/vela-mobile/package.json \
+  eslint.config.js
+git commit -m "feat(mobile): add shared secret scanning policy"
+```
+
+---
+
+### Task 4: Define the Manifest, Run-ID, and Hashing Contract
+
+**Files:**
+
+- Create: `apps/vela-mobile/build/m1-foundation-contract.ts`
+- Create: `apps/vela-mobile/build/m1-foundation-contract.test.ts`
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+export type M1Phase =
+  | 'automated'
+  | 'ios-simulator'
+  | 'ios-physical-preflight'
+  | 'manual';
+export type M1MatrixClass =
+  | 'automated'
+  | 'production-smoke'
+  | 'diagnostic-observation'
+  | 'physical-preflight';
+export type M1Outcome =
+  | 'passed'
+  | 'usage_error'
+  | 'prerequisite_missing'
+  | 'gate_failed'
+  | 'harness_error';
+
+export const M1_EXIT_CODE: Readonly<Record<M1Outcome, 0 | 1 | 2 | 3 | 4>>;
+
+export type M1CommandResult = {
+  label: string;
+  command: string;
+  cwd: string;
+  startedAt: string;
+  endedAt: string;
+  elapsedMs: number;
+  exitCode: number;
+  status: 'passed' | 'failed';
+};
+
+export type M1EvidenceReference = {
+  kind: 'committed' | 'attachment' | 'local-hash';
+  location: string;
+  mediaType: string;
+  byteSize: number;
+  sha256: string;
+};
+
+export type M1Manifest = {
+  schemaVersion: 1;
+  runId: string;
+  testedBehaviorCommit: string;
+  phase: M1Phase;
+  matrixClass: M1MatrixClass;
+  startedAt: string;
+  endedAt: string;
+  outcome: M1Outcome;
+  exitCode: 0 | 1 | 2 | 3 | 4;
+  config: {
+    source: '.env.production' | 'process_env' | 'none';
+    class: 'deployed' | 'placeholder' | 'missing';
+    apiOrigin?: string;
+    region?: string;
+    oauthDomain?: string;
+    publicIdentifiersConsistent: boolean;
+  };
+  host: Record<string, string | number | boolean>;
+  commands: M1CommandResult[];
+  evidence: M1EvidenceReference[];
+  findings: Array<{ severity: string; issue?: string; summary: string }>;
+};
+```
+
+- Produces: `createM1RunId()`, `createM1RunDirectory()`, `hashFile()`, `hashDirectory()`, `validateM1Manifest()`, and `createManualM1Manifest()`.
+- Consumers: Tasks 5–7 and evidence runs.
+
+- [ ] **Step 1: Write contract tests**
+
+```ts
+import {
+  M1_EXIT_CODE,
+  createM1RunDirectory,
+  createM1RunId,
+  hashDirectory,
+} from './m1-foundation-contract';
+
+it('maps every outcome to the stable exit code', () => {
+  expect(M1_EXIT_CODE).toEqual({
+    passed: 0,
+    harness_error: 1,
+    usage_error: 2,
+    prerequisite_missing: 3,
+    gate_failed: 4,
+  });
+});
+
+it('creates UTC run IDs', () => {
+  expect(
+    createM1RunId(new Date('2026-08-03T02:15:00.000Z'), 'production-smoke'),
+  ).toBe('20260803T021500Z-production-smoke');
+});
+
+it('creates the versioned evidence path', () => {
+  expect(
+    createM1RunDirectory({
+      evidenceRoot: '/repo/apps/vela-mobile/docs/evidence/hpa-210',
+      testedBehaviorCommit: 'a'.repeat(40),
+      runId: '20260803T021500Z-production-smoke',
+    }),
+  ).toBe(
+    `/repo/apps/vela-mobile/docs/evidence/hpa-210/${'a'.repeat(40)}/20260803T021500Z-production-smoke`,
+  );
+});
+```
+
+Add hashing tests proving file-order independence, path inclusion, and changed-content detection.
+
+- [ ] **Step 2: Run and verify red**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- build/m1-foundation-contract.test.ts
+```
+
+Expected: FAIL because the contract module does not exist.
+
+- [ ] **Step 3: Implement the contract**
+
+Use sorted relative paths when hashing directories:
+
+```ts
+export async function hashDirectory(root: string): Promise<string> {
+  const files = await listFilesRecursively(root);
+  const hash = createHash('sha256');
+
+  for (const file of files.sort()) {
+    const relativePath = relative(root, file);
+    hash.update(relativePath);
+    hash.update('\0');
+    hash.update(await readFile(file));
+    hash.update('\0');
+  }
+
+  return hash.digest('hex');
+}
+```
+
+Reject non-40-character behavior commits and matrix classes containing path separators.
+
+Implement manual manifest construction:
+
+```ts
+export function createManualM1Manifest(input: {
+  testedBehaviorCommit: string;
+  matrixClass: 'production-smoke' | 'diagnostic-observation';
+  runId: string;
+  startedAt: string;
+  endedAt: string;
+  config: M1Manifest['config'];
+  host: M1Manifest['host'];
+  evidence: M1EvidenceReference[];
+  findings: M1Manifest['findings'];
+  outcome: 'passed' | 'gate_failed' | 'prerequisite_missing';
+}): M1Manifest {
+  return validateM1Manifest({
+    schemaVersion: 1,
+    phase: 'manual',
+    exitCode: M1_EXIT_CODE[input.outcome],
+    commands: [],
+    ...input,
+  });
+}
+```
+
+This helper lets Tasks 10–11 write manual run manifests under the original `testedBehaviorCommit` even after earlier manifest-only commits have advanced Git `HEAD`.
+
+- [ ] **Step 4: Run contract tests**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- build/m1-foundation-contract.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  apps/vela-mobile/build/m1-foundation-contract.ts \
+  apps/vela-mobile/build/m1-foundation-contract.test.ts
+git commit -m "feat(mobile): define M1 verification manifest"
+```
+
+---
+
+### Task 5: Implement the CLI Core and Automated Phase
+
+**Files:**
+
+- Create: `apps/vela-mobile/build/m1-foundation-harness.ts`
+- Create: `apps/vela-mobile/build/m1-foundation-harness.test.ts`
+- Create: `apps/vela-mobile/scripts/verify-m1-foundation.mjs`
+- Modify: `apps/vela-mobile/package.json`
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+export type CommandSpec = {
+  label: string;
+  command: string;
+  args: string[];
+  cwd: string;
+  env?: Record<string, string>;
+};
+
+export type CommandRunner = (spec: CommandSpec) => Promise<{
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}>;
+
+export type HarnessDependencies = {
+  repoRoot: string;
+  now: () => Date;
+  platform: NodeJS.Platform;
+  env: NodeJS.ProcessEnv;
+  runCommand: CommandRunner;
+};
+
+export function parseM1Arguments(argv: string[]):
+  | {
+      mode: 'verify';
+      phase: 'automated' | 'ios-simulator' | 'ios-physical-preflight' | 'all';
+      simulatorUdid?: string;
+      deviceId?: string;
+      requireDeployedConfig: boolean;
+    }
+  | {
+      mode: 'record-manual';
+      matrixClass: 'production-smoke' | 'diagnostic-observation';
+      testedBehaviorCommit: string;
+      inputPath: string;
+    };
+
+export async function runM1FoundationVerification(
+  args: ReturnType<typeof parseM1Arguments>,
+  dependencies: HarnessDependencies,
+): Promise<M1Manifest[]>;
+```
+
+- Consumers: CLI wrapper and Tasks 6–7.
+
+- [ ] **Step 1: Write CLI and command-order tests**
+
+Test invalid phases, required argument pairing, exit mapping, and this exact automated command order:
+
+```ts
+const expectedCommands = [
+  ['bun', ['install', '--frozen-lockfile']],
+  ['bun', ['run', 'lint']],
+  ['bun', ['run', 'typecheck']],
+  ['bun', ['run', 'compile']],
+  ['bun', ['run', 'build']],
+  ['bun', ['run', 'test']],
+  ['bun', ['run', '--cwd', 'apps/vela-mobile', 'verify:production-diagnostics']],
+  ['bun', ['run', '--cwd', 'apps/vela-mobile', 'scan:secrets', '--', '--root', 'apps/vela-mobile']],
+];
+```
+
+Add a test where command four fails and assert:
+
+```ts
+expect(manifest.outcome).toBe('gate_failed');
+expect(manifest.exitCode).toBe(4);
+expect(runner.calls).toHaveLength(4);
+```
+
+Add tests that a missing production configuration returns `prerequisite_missing` before any production build command and that `MOBILE_SKIP_ENV_VALIDATION=true` is rejected for deployed closure runs.
+
+- [ ] **Step 2: Run and verify red**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- build/m1-foundation-harness.test.ts
+```
+
+Expected: FAIL because the harness module does not exist.
+
+- [ ] **Step 3: Implement argument parsing**
+
+Use exact accepted syntax:
+
+```text
+--phase automated
+--phase ios-simulator --simulator-udid <UDID>
+--phase ios-physical-preflight --device-id <CoreDevice identifier>
+--phase all --simulator-udid <UDID> --device-id <CoreDevice identifier>
+--record-manual production-smoke --tested-behavior-commit <SHA> --input <JSON>
+--record-manual diagnostic-observation --tested-behavior-commit <SHA> --input <JSON>
+```
+
+Unknown flags, duplicate scalar flags, or missing values produce `usage_error`.
+
+- [ ] **Step 4: Implement the command runner**
+
+Use `spawn` with argument arrays and no shell:
+
+```ts
+export const spawnCommand: CommandRunner = async (spec) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(spec.command, spec.args, {
+      cwd: spec.cwd,
+      env: { ...process.env, ...spec.env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    // bound stdout/stderr capture to 64 KiB each; resolve on close
+  });
+```
+
+Never copy complete environments into manifests.
+
+- [ ] **Step 5: Reuse the production configuration validator**
+
+Import:
+
+```ts
+import {
+  loadMobileBuildEnv,
+  validateMobileBuildEnv,
+} from './validate-mobile-api-url';
+```
+
+Classify:
+
+```ts
+function classifyMobileConfig(env: ReturnType<typeof loadMobileBuildEnv>) {
+  const values = Object.values(env).filter(
+    (value): value is string => typeof value === 'string',
+  );
+  const placeholder = values.some((value) =>
+    /(?:example\.invalid|localhost|ciPlaceholder|ci-placeholder|placeholder)/iu.test(value),
+  );
+
+  return placeholder ? 'placeholder' : 'deployed';
+}
+```
+
+For the final harness, `automated` may emit placeholder manifests in CI, but a deployed closure run must pass an explicit `--require-deployed-config` flag. Add this flag to parsing and use it for Task 9.
+
+- [ ] **Step 6: Implement automated orchestration**
+
+For each command:
+
+- record ISO timestamps and elapsed milliseconds;
+- store only bounded, secret-scanned output as external evidence when needed;
+- stop at the first failure;
+- always write `manifest.json` in the computed run directory;
+- return exit `4` for failed gates and exit `1` only for unexpected harness failures.
+
+The scanner command must include the generated `src-capacitor/www`, native project resources, and the current HPA-210 run directory after production assets exist.
+
+- [ ] **Step 7: Implement the thin CLI**
+
+`verify-m1-foundation.mjs` should only:
+
+```js
+import { fileURLToPath } from 'node:url';
+import {
+  parseM1Arguments,
+  runM1FoundationVerification,
+  spawnCommand,
+} from '../build/m1-foundation-harness.ts';
+
+const args = parseM1Arguments(process.argv.slice(2));
+const manifests = await runM1FoundationVerification(args, {
+  repoRoot: fileURLToPath(new URL('../../..', import.meta.url)),
+  now: () => new Date(),
+  platform: process.platform,
+  env: process.env,
+  runCommand: spawnCommand,
+});
+process.exit(manifests.at(-1)?.exitCode ?? 1);
+```
+
+Wrap usage errors so they exit `2` and write no misleading pass manifest.
+
+For `mode: 'record-manual'`, read a secret-free JSON input containing timestamps, environment aliases, evidence references, findings, config classification, and the observed outcome. Call `createManualM1Manifest()`, write it under the supplied behavior commit/run ID, and reject any input that contains raw OAuth values, tokens, email addresses, device identifiers, or unhashed binary evidence.
+
+- [ ] **Step 8: Run focused tests**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- \
+  build/m1-foundation-harness.test.ts \
+  build/m1-foundation-contract.test.ts \
+  scripts/scan-mobile-secrets.test.mjs
+bun run --cwd apps/vela-mobile lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Run a placeholder automated smoke**
+
+Use the same five harmless placeholders as PR CI:
+
+```bash
+VITE_MOBILE_API_URL=https://example.invalid/api/ \
+VITE_COGNITO_USER_POOL_ID=us-east-1_ciPlaceholder \
+VITE_COGNITO_MOBILE_USER_POOL_CLIENT_ID=ci-mobile-client-id \
+VITE_COGNITO_OAUTH_DOMAIN=ci-placeholder.auth.us-east-1.amazoncognito.com \
+VITE_AWS_REGION=us-east-1 \
+bun run --cwd apps/vela-mobile verify:m1-foundation -- --phase automated
+```
+
+Expected: machine gates run, manifest class is `placeholder`, and this run is explicitly ineligible for `GO`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add \
+  apps/vela-mobile/build/m1-foundation-harness.ts \
+  apps/vela-mobile/build/m1-foundation-harness.test.ts \
+  apps/vela-mobile/scripts/verify-m1-foundation.mjs \
+  apps/vela-mobile/package.json
+git commit -m "feat(mobile): add M1 automated verification"
+```
+
+---
+
+### Task 6: Add Simulator Build, Install, Launch, and Asset-Immutability Checks
+
+**Files:**
+
+- Modify: `apps/vela-mobile/build/m1-foundation-harness.ts`
+- Modify: `apps/vela-mobile/build/m1-foundation-harness.test.ts`
+
+**Interfaces:**
+
+- Produces: `runIosSimulatorPhase()`.
+- Consumes: `hashDirectory()`, `CommandRunner`, production manifest/config contract.
+- Produces Simulator manifest host fields: `simulatorAlias`, `simulatorRuntime`, `xcodeVersion`, `appBundlePath`, and pre/post `www` hashes.
+
+- [ ] **Step 1: Write Simulator sequencing tests**
+
+Use a fake runner and assert this sequence:
+
+```text
+git rev-parse HEAD
+xcodebuild -version
+xcrun simctl list devices available --json
+bun run --cwd apps/vela-mobile verify:production-diagnostics
+bunx cap sync ios
+xcodebuild -showBuildSettings -json ...
+xcodebuild ... -sdk iphonesimulator ... CODE_SIGNING_ALLOWED=NO build
+xcrun simctl bootstatus <UDID> -b
+xcrun simctl install <UDID> <App.app>
+xcrun simctl launch <UDID> com.vela.app
+xcrun simctl spawn <UDID> ps -A -o comm=
+```
+
+Assert that a changed post-sync `www` hash returns `gate_failed` before `xcodebuild`.
+
+- [ ] **Step 2: Run and verify red**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- build/m1-foundation-harness.test.ts
+```
+
+Expected: FAIL because the Simulator phase is not implemented.
+
+- [ ] **Step 3: Implement Simulator discovery and preflight**
+
+Require macOS and an explicit `--simulator-udid`. Parse `simctl list devices available --json` and return exit `3` when the requested device or runtime is unavailable.
+
+Record versions with:
+
+```bash
+xcodebuild -version
+bun --version
+bun pm ls quasar @capacitor/core @capacitor/ios @capacitor/app @capacitor/keyboard
+```
+
+- [ ] **Step 4: Preserve the verified WebView artifact**
+
+After `verify:production-diagnostics`:
+
+```ts
+const wwwBefore = await hashDirectory(wwwRoot);
+await runOrThrow({
+  label: 'capacitor-sync-ios',
+  command: 'bunx',
+  args: ['cap', 'sync', 'ios'],
+  cwd: capacitorRoot,
+});
+const wwwAfter = await hashDirectory(wwwRoot);
+
+if (wwwBefore !== wwwAfter) {
+  return failManifest('gate_failed', 'cap sync changed verified WebView assets');
+}
+```
+
+Do not invoke `build:ios`, `build:ios:ide`, `build:ios:assets`, or `verify:production-diagnostics` again after recording `wwwBefore`.
+
+- [ ] **Step 5: Build and locate the Simulator app**
+
+Run:
+
+```bash
+xcodebuild \
+  -workspace apps/vela-mobile/src-capacitor/ios/App/App.xcworkspace \
+  -scheme App \
+  -configuration Release \
+  -sdk iphonesimulator \
+  -destination "platform=iOS Simulator,id=<UDID>" \
+  -derivedDataPath "<local-run-dir>/DerivedData" \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+```
+
+Use `xcodebuild -showBuildSettings -json` to derive `TARGET_BUILD_DIR` and `WRAPPER_NAME`; do not guess the `.app` path.
+
+- [ ] **Step 6: Install, launch, and assert process presence**
+
+Run:
+
+```bash
+xcrun simctl bootstatus <UDID> -b
+xcrun simctl install <UDID> <resolved-app-path>
+xcrun simctl launch <UDID> com.vela.app
+xcrun simctl spawn <UDID> ps -A -o comm=
+```
+
+Read `CFBundleExecutable` from the built `Info.plist` with `plutil -extract CFBundleExecutable raw`. Require the executable name in the bounded `ps` output after a five-second sleep.
+
+- [ ] **Step 7: Run tests**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- build/m1-foundation-harness.test.ts
+bun run --cwd apps/vela-mobile lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run on an available Simulator**
+
+```bash
+bun run --cwd apps/vela-mobile verify:m1-foundation -- \
+  --phase ios-simulator \
+  --simulator-udid <available-simulator-udid> \
+  --require-deployed-config
+```
+
+Expected: PASS only when deployed mobile configuration is present and the requested Simulator is available. A missing Simulator or Xcode exits `3`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add \
+  apps/vela-mobile/build/m1-foundation-harness.ts \
+  apps/vela-mobile/build/m1-foundation-harness.test.ts
+git commit -m "feat(mobile): verify iOS Simulator launch"
+```
+
+---
+
+### Task 7: Add Physical-Device and Signing Preflight
+
+**Files:**
+
+- Modify: `apps/vela-mobile/build/m1-foundation-harness.ts`
+- Modify: `apps/vela-mobile/build/m1-foundation-harness.test.ts`
+
+**Interfaces:**
+
+- Produces: `runIosPhysicalPreflightPhase()`.
+- Consumes: explicit `--device-id`, local Xcode signing configuration, deployed config.
+- Produces only non-secret device alias/model and signing readiness.
+
+- [ ] **Step 1: Write physical-preflight tests**
+
+Add fake-runner tests for:
+
+- non-macOS returns `prerequisite_missing`;
+- device absent returns exit `3`;
+- untrusted or unavailable device returns exit `3`;
+- empty `DEVELOPMENT_TEAM` returns exit `3`;
+- automatic signing plus non-empty team returns `passed`;
+- raw CoreDevice identifiers and team IDs never appear in the manifest.
+
+Expected command shape:
+
+```text
+xcrun devicectl list devices --json-output <local-temp-file>
+xcodebuild -showBuildSettings -json
+  -workspace .../App.xcworkspace
+  -scheme App
+  -configuration Debug
+  -destination id=<device-id>
+```
+
+- [ ] **Step 2: Run and verify red**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- build/m1-foundation-harness.test.ts
+```
+
+Expected: FAIL because the physical preflight is not implemented.
+
+- [ ] **Step 3: Implement device discovery**
+
+Write `devicectl` JSON to a local temporary path outside committed evidence, parse only:
+
+```ts
+type PhysicalDeviceSummary = {
+  alias: string;
+  model: string;
+  available: boolean;
+  trusted: boolean;
+  developerMode: boolean;
+};
+```
+
+Delete the raw JSON after parsing. Never copy the device identifier into `manifest.json`.
+
+- [ ] **Step 4: Implement signing readiness**
+
+Parse `xcodebuild -showBuildSettings -json` and require:
+
+```text
+CODE_SIGN_STYLE = Automatic
+DEVELOPMENT_TEAM = non-empty
+PRODUCT_BUNDLE_IDENTIFIER = com.vela.app
+```
+
+The team may be supplied by Xcode user settings, an untracked xcconfig, or an explicit local build argument. Do not update `project.pbxproj` with a team.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- build/m1-foundation-harness.test.ts
+bun run --cwd apps/vela-mobile lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run physical preflight**
+
+```bash
+bun run --cwd apps/vela-mobile verify:m1-foundation -- \
+  --phase ios-physical-preflight \
+  --device-id <connected-device-id> \
+  --require-deployed-config
+```
+
+Expected: `passed` when device, trust, Developer Mode, signing, and provisioning resolve; otherwise exit `3` without a product-failure finding.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add \
+  apps/vela-mobile/build/m1-foundation-harness.ts \
+  apps/vela-mobile/build/m1-foundation-harness.test.ts
+git commit -m "feat(mobile): verify physical iOS readiness"
+```
+
+---
+
+### Task 8: Add Verification and Architecture Record Schemas
+
+**Files:**
+
+- Create: `apps/vela-mobile/docs/ios-foundation-architecture.md`
+- Create: `apps/vela-mobile/docs/m1-ios-foundation-verification.md`
+- Modify: `apps/vela-mobile/README.md`
+
+**Interfaces:**
+
+- Produces the stable architecture destination and the append-only result schema.
+- Consumers: Tasks 9–12 and HPA-202/HPA-205–HPA-210 closeout.
+
+- [ ] **Step 1: Create the architecture record with unset measured conclusions**
+
+Use these exact headings:
+
+```markdown
+# iOS Foundation Architecture
+
+## Tested Revision
+## Authentication and OAuth Callback
+## OAuth Transaction Storage
+## Session Storage and Restoration
+## API Origin and Authenticated Transport
+## User-Scoped Query Isolation
+## Shared App Lifecycle
+## Safe Areas, Keyboard, and Navigation
+## Audio Adapter Decision
+## Development Diagnostics and Production Exclusion
+## Accepted Constraints
+## Change Policy
+```
+
+Under `OAuth Transaction Storage`, record the current boundary:
+
+```markdown
+The transient OAuth transaction contains `state`, `codeVerifier`, `nonce`, and
+`createdAt`. It is serialized as one JSON value through
+`@capacitor/preferences`, backed by iOS UserDefaults, with a 10-minute TTL.
+It contains no access, ID, or refresh token. The coordinator clears it after
+consumption, cancellation, OAuth errors, restoration cleanup, and terminal
+cleanup. UserDefaults is plaintext and may participate in device backup; M1
+accepts this for short-lived, single-use correlation and verifier material,
+not as an authenticated session store.
+```
+
+Set `Audio Adapter Decision` to `Pending physical HPA-210 evidence`; do not preselect an outcome.
+
+- [ ] **Step 2: Create the verification record schema**
+
+Use these sections:
+
+```markdown
+# M1 iOS Foundation Verification
+
+## Final Decision
+## Tested Behavior Commit
+## Selected Run Manifests
+## Production Smoke Matrix
+## Diagnostic Observation Matrix
+## Physical iPhone Matrix
+## Security and Secret Scan
+## Architecture Decision Summary
+## Findings and Follow-up Issues
+## Source-Issue Closure Mapping
+## Milestone 2 Recommendation
+```
+
+Use this row schema for every matrix:
+
+```markdown
+| ID | Commit | Run ID | Matrix class | Build/config | Environment | Precondition | Observation | Status | Evidence | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+```
+
+Leave result rows absent rather than adding predeclared `PASS` or `unrun` rows.
+
+- [ ] **Step 3: Document evidence references**
+
+Add:
+
+```markdown
+Evidence manifests are committed under
+`docs/evidence/hpa-210/<testedBehaviorCommit>/<run-id>/manifest.json`.
+Screenshots, video, raw logs, and archives are attached externally unless a
+small binary is uniquely load-bearing. External evidence is referenced by
+location, byte size, media type, and SHA-256.
+```
+
+State that HPA-209 retains its historical flat evidence layout.
+
+- [ ] **Step 4: Update the mobile README**
+
+Add commands for:
+
+```bash
+bun run verify:m1-foundation -- --phase automated
+bun run verify:m1-foundation -- --phase ios-simulator --simulator-udid <id>
+bun run verify:m1-foundation -- --phase ios-physical-preflight --device-id <id>
+```
+
+Document the two build classes, deployed-config requirement, exit-code meanings, no committed development team, and the ban on Quasar rebuilds after production `www` hashing.
+
+- [ ] **Step 5: Check documentation formatting**
+
+```bash
+bunx prettier --check \
+  apps/vela-mobile/docs/ios-foundation-architecture.md \
+  apps/vela-mobile/docs/m1-ios-foundation-verification.md \
+  apps/vela-mobile/README.md
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  apps/vela-mobile/docs/ios-foundation-architecture.md \
+  apps/vela-mobile/docs/m1-ios-foundation-verification.md \
+  apps/vela-mobile/README.md
+git commit -m "docs(mobile): add M1 verification records"
+```
+
+---
+
+### Task 9: Freeze the Executable Verification Commit and Run Machine Gates
+
+**Files:**
+
+- Create through harness: `apps/vela-mobile/docs/evidence/hpa-210/<testedBehaviorCommit>/<run-id>/manifest.json`
+- Modify only when a machine gate finds a defect: files owned by Tasks 1–8
+
+**Interfaces:**
+
+- Produces: final candidate `testedBehaviorCommit`.
+- Produces successful deployed manifests for `automated`, `ios-simulator`, and `ios-physical-preflight`.
+- Consumers: Tasks 10–12.
+
+- [ ] **Step 1: Run focused verification before the freeze**
+
+```bash
+bun run --cwd apps/vela-mobile test:unit -- \
+  build/mobile-secret-policy.test.ts \
+  build/m1-foundation-contract.test.ts \
+  build/m1-foundation-harness.test.ts \
+  scripts/scan-mobile-secrets.test.mjs \
+  scripts/verify-production-diagnostics.test.mjs
+bun run --cwd apps/vela-mobile lint
+bun run --cwd apps/vela-mobile typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run fresh root gates**
+
+```bash
+bun install --frozen-lockfile
+bun run lint
+bun run typecheck
+bun run compile
+bun run build
+bun run test
+```
+
+Expected: every command exits `0`. Record actual Turbo tasks; do not claim lint/typecheck coverage for skipped workspaces.
+
+- [ ] **Step 3: Commit any gate fixes and select the behavior commit**
+
+When Steps 1–2 require code, config, lock, generated-asset, or harness changes:
+
+```bash
+git add <exact changed files>
+git commit -m "fix(mobile): satisfy M1 verification gates"
+```
+
+Then record:
+
+```bash
+TESTED_BEHAVIOR_COMMIT="$(git rev-parse HEAD)"
+printf '%s\n' "$TESTED_BEHAVIOR_COMMIT"
+```
+
+Do not amend or rebase this commit after native evidence begins.
+
+- [ ] **Step 4: Run the deployed automated phase**
+
+With deployed mobile configuration available:
+
+```bash
+bun run --cwd apps/vela-mobile verify:m1-foundation -- \
+  --phase automated \
+  --require-deployed-config
+```
+
+Expected: `passed`, config class `deployed`, manifest `testedBehaviorCommit` equals `$TESTED_BEHAVIOR_COMMIT`.
+
+- [ ] **Step 5: Run the Simulator phase**
+
+```bash
+bun run --cwd apps/vela-mobile verify:m1-foundation -- \
+  --phase ios-simulator \
+  --simulator-udid <selected-simulator-udid> \
+  --require-deployed-config
+```
+
+Expected: `passed`, pre/post `www` hashes equal, app installs and remains alive.
+
+- [ ] **Step 6: Run the physical preflight**
+
+```bash
+bun run --cwd apps/vela-mobile verify:m1-foundation -- \
+  --phase ios-physical-preflight \
+  --device-id <connected-device-id> \
+  --require-deployed-config
+```
+
+Expected: `passed` with device alias/model and signing readiness, without UDID or team value in the manifest.
+
+- [ ] **Step 7: Scan generated manifests and staged evidence**
+
+```bash
+bun run --cwd apps/vela-mobile scan:secrets -- \
+  --root apps/vela-mobile/docs/evidence/hpa-210 \
+  --json /tmp/hpa-210-evidence-secret-scan.json
+```
+
+Expected: no findings.
+
+- [ ] **Step 8: Commit the machine manifests**
+
+```bash
+git add apps/vela-mobile/docs/evidence/hpa-210
+git commit -m "test(mobile): record M1 machine verification"
+```
+
+This documentation/evidence-only commit does not change `$TESTED_BEHAVIOR_COMMIT`.
+
+---
+
+### Task 10: Run the Physical Production-Smoke Matrix
+
+**Files:**
+
+- Modify after observation: `apps/vela-mobile/docs/m1-ios-foundation-verification.md`
+- Add manifests/text evidence under the selected behavior-commit directory
+- Attach screenshots/logs externally and record hashes
+
+**Interfaces:**
+
+- Consumes: the scanned production `www` artifact and successful physical preflight from Task 9.
+- Produces: physical production rows for installation, OAuth, restoration, due count, sign-out, and product-surface recovery.
+
+- [ ] **Step 1: Build the signed Release target without rebuilding WebView assets**
+
+Use Xcode or this command from the same checkout and existing synced native project:
+
+```bash
+xcodebuild \
+  -workspace apps/vela-mobile/src-capacitor/ios/App/App.xcworkspace \
+  -scheme App \
+  -configuration Release \
+  -destination "id=<connected-device-id>" \
+  -derivedDataPath "<local-only-derived-data>" \
+  -allowProvisioningUpdates \
+  build
+```
+
+Do not run any Quasar build command before this build. Re-hash `src-capacitor/www` immediately before installation and require it to equal the Task 9 production manifest hash.
+
+- [ ] **Step 2: Install and launch on the physical iPhone**
+
+Use Xcode Run or `devicectl` with the resolved `.app`. Record:
+
+- non-secret device alias and model;
+- iOS and Xcode versions;
+- app version/build;
+- `$TESTED_BEHAVIOR_COMMIT`;
+- production manifest run ID;
+- deployed API origin, region, and OAuth domain;
+- non-secret account alias.
+
+- [ ] **Step 3: Execute the authentication lifecycle**
+
+Run and record separate rows for:
+
+```text
+P-AUTH-01 fresh install and first launch
+P-AUTH-02 fresh Google sign-in through the system browser
+P-AUTH-03 direct-provider redirect
+P-AUTH-04 warm callback
+P-AUTH-05 cold-start callback
+P-AUTH-06 user cancellation
+P-AUTH-07 missing code
+P-AUTH-08 provider error
+P-AUTH-09 malformed callback
+P-AUTH-10 state mismatch
+P-AUTH-11 late or duplicate callback
+P-AUTH-12 force-close and relaunch restoration
+P-AUTH-13 proactive refresh
+P-AUTH-14 resume refresh
+P-AUTH-15 revoked/non-refreshable session
+P-AUTH-16 sign-out
+P-AUTH-17 signed-out relaunch
+P-AUTH-18 reinstall residue cleanup
+```
+
+Every failure row includes reproduction, expected/observed behavior, severity, owner, target milestone, and Linear issue.
+
+- [ ] **Step 4: Execute the due-count lifecycle**
+
+Run and record:
+
+```text
+P-DUE-01 restored auth reaches Home
+P-DUE-02 positive due_today
+P-DUE-03 zero due_today
+P-DUE-04 timestamped web/API comparison
+P-DUE-05 loading and manual refresh
+P-DUE-06 foreground refresh
+P-DUE-07 disabled network and retry
+P-DUE-08 request timeout
+P-DUE-09 server failure
+P-DUE-10 malformed response
+P-DUE-11 rejected/expired-token recovery
+P-DUE-12 terminal auth returns to gate
+P-DUE-13 sign-out clears prior-user data
+P-DUE-14 second account sees no prior cache
+P-DUE-15 pending request does not block sign-out
+```
+
+For changing counts, record both observation timestamps instead of asserting later screenshot equality.
+
+- [ ] **Step 5: Run product-surface security checks**
+
+Confirm:
+
+- no protected-content flash before restoration;
+- no token, code, verifier, email, full callback URL, or presigned URL in visible UI or selected logs;
+- development diagnostic labels/routes are absent from the Release build.
+
+- [ ] **Step 6: Preserve evidence and write the manual run manifest**
+
+For every external artifact, compute:
+
+```bash
+shasum -a 256 <artifact>
+wc -c <artifact>
+file --mime-type <artifact>
+```
+
+Record attachment/location, hash, size, and media type in a secret-free JSON input, then write the run manifest:
+
+```bash
+bun run --cwd apps/vela-mobile verify:m1-foundation -- \
+  --record-manual production-smoke \
+  --tested-behavior-commit "$TESTED_BEHAVIOR_COMMIT" \
+  --input /tmp/hpa-210-production-smoke.json
+```
+
+Verify the resulting manifest path is under the original behavior-commit directory and not the current documentation-only `HEAD`. Record the run ID in the verification record.
+
+- [ ] **Step 7: Classify the production result**
+
+Any failed OAuth/session restoration, due-count/data isolation, protected-content flash, or secret finding is a hard `NO-GO`. Create or update the corresponding Linear issue immediately.
+
+---
+
+### Task 11: Run the Physical Diagnostic-Observation Matrix
+
+**Files:**
+
+- Modify after observation: `apps/vela-mobile/docs/m1-ios-foundation-verification.md`
+- Modify after audio decision: `apps/vela-mobile/docs/ios-foundation-architecture.md`
+- Add manifests/text evidence under the selected behavior-commit directory
+- Attach growth-prone artifacts externally
+
+**Interfaces:**
+
+- Consumes: the same `$TESTED_BEHAVIOR_COMMIT` and deployed backend identity as Task 10.
+- Produces: TTS, IME, keyboard, safe-area, orientation, and navigation evidence plus the exact audio architecture conclusion.
+
+- [ ] **Step 1: Start the Debug diagnostic build**
+
+After Task 10 production smoke is complete:
+
+```bash
+cd apps/vela-mobile
+bun run dev:ios
+```
+
+Use the same deployed API origin, user pool, mobile client, OAuth domain, and region. Keep the dev server running and launch the signed Debug target on the physical iPhone.
+
+Record a new diagnostic-observation run ID; do not reuse the production manifest.
+
+- [ ] **Step 2: Execute TTS controller and failure rows**
+
+Run:
+
+```text
+D-TTS-01 restored authentication and configured settings
+D-TTS-02 first server-cache request
+D-TTS-03 genuinely uncached generation
+D-TTS-04 loading/preparation state
+D-TTS-05 first user-gesture playback
+D-TTS-06 prepared direct-tap replay
+D-TTS-07 ten prepared replays
+D-TTS-08 rapid taps during preparation
+D-TTS-09 rapid taps during playback
+D-TTS-10 authentication failure
+D-TTS-11 generation failure
+D-TTS-12 disabled network and retry
+D-TTS-13 expired/invalid presigned URL
+D-TTS-14 decoding/playback failure
+D-TTS-15 background during preparation
+D-TTS-16 background during playback
+D-TTS-17 foreground replayability
+D-TTS-18 sign-out while ready
+D-TTS-19 sign-out while playing
+D-TTS-20 relaunch and replay
+```
+
+- [ ] **Step 3: Execute physical audio rows**
+
+With built-in speaker and nonzero media volume, record human observations:
+
+```text
+D-AUDIO-01 correct audible pronunciation for 水 with silent mode off
+D-AUDIO-02 ten replays without intermittent silence or overlap
+D-AUDIO-03 external/system interruption leaves replayable state
+D-AUDIO-04 silent mode on
+```
+
+On devices with a Ring/Silent switch, use it. On Action Button devices, configure the Action Button for Silent Mode or use the system Silent Mode control and confirm the system indicator. Focus mode is not the silent-mode control.
+
+Select exactly one:
+
+```text
+HTML-only accepted
+native audio-session integration required
+native player adapter required
+```
+
+Only a silent-mode-only failure after all core playback rows pass may become the narrow High pre-M2 audio-session gate. `native player adapter required` is `NO-GO`.
+
+- [ ] **Step 4: Execute Japanese IME rows**
+
+Install the Japanese Kana keyboard and enter `にほんご`, selecting `日本語`. Record:
+
+```text
+D-IME-01 composition does not validate or submit early
+D-IME-02 draft equals 日本語
+D-IME-03 committed value equals 日本語
+D-IME-04 bound model equals 日本語
+D-IME-05 post-render native input equals 日本語
+D-IME-06 submitted value equals 日本語
+```
+
+Any corruption or premature submission is a hard `NO-GO`.
+
+- [ ] **Step 5: Execute keyboard, safe-area, and orientation rows**
+
+Use a notched or Dynamic Island iPhone:
+
+```text
+D-LAYOUT-01 focused input visible in portrait
+D-LAYOUT-02 primary action reachable in portrait
+D-LAYOUT-03 focused input reachable in landscape left
+D-LAYOUT-04 focused input reachable in landscape right
+D-LAYOUT-05 keyboard dismissal restores footer once
+D-LAYOUT-06 no stale keyboard gap
+D-LAYOUT-07 top/bottom safe areas
+D-LAYOUT-08 left/right landscape sensor-region avoidance
+```
+
+Link `ios-interaction-baseline.md` for historical rationale; do not copy its numeric tables.
+
+- [ ] **Step 6: Execute navigation rows**
+
+Run:
+
+```text
+D-NAV-01 visible back returns to exact prior route
+D-NAV-02 native swipe back
+D-NAV-03 native swipe forward
+D-NAV-04 repeated tab switching
+D-NAV-05 validated in-session deep entry
+D-NAV-06 cold deep entry at depth zero
+D-NAV-07 resume without new entry is a no-op
+D-NAV-08 saved scroll restoration on back
+D-NAV-09 saved scroll restoration on forward
+D-NAV-10 no blank frame, app exit, duplicate page, or navigation trap
+```
+
+Any trap, unexpected exit, or broken physical swipe history is a hard `NO-GO`.
+
+- [ ] **Step 7: Scan and preserve diagnostic evidence**
+
+Run the secret scanner against bounded logs and evidence metadata before attachment or commit. Store only manifests and small text evidence in Git; attach images/video externally with hashes.
+
+Write the manual diagnostic manifest:
+
+```bash
+bun run --cwd apps/vela-mobile verify:m1-foundation -- \
+  --record-manual diagnostic-observation \
+  --tested-behavior-commit "$TESTED_BEHAVIOR_COMMIT" \
+  --input /tmp/hpa-210-diagnostic-observation.json
+```
+
+Require the manifest to use the same deployed backend identity and behavior commit as the production-smoke manifest.
+
+- [ ] **Step 8: Update the architecture audio section**
+
+Replace `Pending physical HPA-210 evidence` with the selected exact conclusion and the evidence run ID. Do not change unrelated architecture boundaries.
+
+---
+
+### Task 12: Finalize the Decision, Guidance, and Linear Closeout
+
+**Files:**
+
+- Modify: `apps/vela-mobile/docs/m1-ios-foundation-verification.md`
+- Modify: `apps/vela-mobile/docs/ios-foundation-architecture.md`
+- Modify: `CLAUDE.md`
+- Modify: `apps/vela-mobile/docs/ios-interaction-baseline.md` only when adding a concise closeout link/result
+- Modify: `docs/superpowers/specs/2026-08-02-mobile-ios-foundation-verification-design.md` as the final pre-merge action
+- Add: selected manifests and small bounded evidence under `apps/vela-mobile/docs/evidence/hpa-210/`
+
+**Interfaces:**
+
+- Produces final `GO` or `NO-GO`.
+- Produces HPA-202/HPA-205–HPA-210 and HPA-194 updates.
+- Produces the documentation/evidence commit linked externally to `testedBehaviorCommit`.
+
+- [ ] **Step 1: Verify every required row**
+
+Require:
+
+- successful deployed automated, Simulator, and physical-preflight manifests;
+- complete production-smoke and diagnostic-observation classes on the same `testedBehaviorCommit` and backend;
+- physical OAuth, restoration, due count, audio, IME, keyboard, safe-area, and navigation rows;
+- secret scan with no unresolved finding;
+- exact audio conclusion;
+- Linear issue for every deferred risk.
+
+An unrun or `BLOCKED` required row produces `NO-GO` unless it is the narrow accepted silent-mode audio-session gate.
+
+- [ ] **Step 2: Write the final decision**
+
+Use exactly:
+
+```markdown
+## Final Decision
+
+**Decision:** GO
+```
+
+or:
+
+```markdown
+## Final Decision
+
+**Decision:** NO-GO
+```
+
+For `NO-GO`, list the minimum corrective issues and keep HPA-210 open.
+
+- [ ] **Step 3: Finalize architecture from the behavior commit**
+
+Record:
+
+- `testedBehaviorCommit`;
+- selected run IDs;
+- implemented auth/session/API/query/lifecycle/layout boundaries;
+- OAuth transaction UserDefaults boundary and accepted limitation;
+- exact audio conclusion;
+- links to HPA-209 historical baseline and HPA-210 final verification.
+
+- [ ] **Step 4: Synchronize `CLAUDE.md`**
+
+Replace the stale mobile section that says PKCE, `state`, `nonce`, mobile client wiring, and `identity_provider=Google` remain future M2 work. State that they are implemented, link the architecture record, and retain only current live/native limitations.
+
+Point the HPA-209 physical-validation guidance to HPA-210’s final rows. Do not copy full matrices into `CLAUDE.md`.
+
+- [ ] **Step 5: Update source Linear tickets**
+
+For HPA-202 and HPA-205 through HPA-209, comment with:
+
+- `testedBehaviorCommit`;
+- relevant row IDs and run IDs;
+- result;
+- evidence links;
+- follow-up issue when applicable.
+
+Move a source issue to `Done` only when its acceptance evidence is satisfied.
+
+- [ ] **Step 6: Update HPA-210 and HPA-194**
+
+HPA-210 receives:
+
+- `GO` or `NO-GO`;
+- behavior commit;
+- documentation/evidence commit;
+- architecture and verification links;
+- selected manifests;
+- follow-up issues.
+
+HPA-194 receives:
+
+- concise M1 decision;
+- device/build summary;
+- accepted limitations;
+- recommended first M2 issues.
+
+For `GO`, recommend: Home/Review navigation, ten-card SRS session, rating/pronunciation behavior, then durable outbox and backend idempotency.
+
+- [ ] **Step 7: Run final documentation and secret checks**
+
+```bash
+bunx prettier --check \
+  apps/vela-mobile/docs/ios-foundation-architecture.md \
+  apps/vela-mobile/docs/m1-ios-foundation-verification.md \
+  apps/vela-mobile/README.md \
+  CLAUDE.md \
+  docs/superpowers/specs/2026-08-02-mobile-ios-foundation-verification-design.md
+
+bun run --cwd apps/vela-mobile scan:secrets -- \
+  --root apps/vela-mobile/docs/evidence/hpa-210 \
+  --root apps/vela-mobile/docs/ios-foundation-architecture.md \
+  --root apps/vela-mobile/docs/m1-ios-foundation-verification.md \
+  --root CLAUDE.md
+```
+
+Expected: PASS with no secret findings.
+
+- [ ] **Step 8: Update the design status as the final pre-merge edit**
+
+Change:
+
+```markdown
+**Status:** Approved in project discussion; repository review in PR #56
+```
+
+to:
+
+```markdown
+**Status:** Approved
+```
+
+Do this only after the plan and design have completed repository review.
+
+- [ ] **Step 9: Commit closeout documentation**
+
+```bash
+git add \
+  apps/vela-mobile/docs/ios-foundation-architecture.md \
+  apps/vela-mobile/docs/m1-ios-foundation-verification.md \
+  apps/vela-mobile/docs/evidence/hpa-210 \
+  apps/vela-mobile/docs/ios-interaction-baseline.md \
+  apps/vela-mobile/README.md \
+  CLAUDE.md \
+  docs/superpowers/specs/2026-08-02-mobile-ios-foundation-verification-design.md
+git commit -m "docs(mobile): record M1 iOS foundation decision"
+```
+
+Record this documentation commit in Linear. State explicitly that it does not invalidate executable rows pinned to `testedBehaviorCommit`.
+
+- [ ] **Step 10: Final PR verification**
+
+Run fresh:
+
+```bash
+bun install --frozen-lockfile
+bun run lint
+bun run typecheck
+bun run compile
+bun run build
+bun run test
+```
+
+If these commands modify executable inputs or reveal a required executable fix, create a new behavior commit and rerun the affected HPA-210 evidence rather than claiming the previous rows still apply.
+
+---
+
+## Plan Self-Review Checklist
+
+- [x] Every design requirement maps to a task.
+- [x] Root freeze coverage includes lint, typecheck, compile, build, and tests with actual Turbo participation recorded.
+- [x] The production diagnostic scanner covers all emitted text-artifact classes without forking its token list.
+- [x] One shared secret policy serves runtime tests and artifact/evidence scanning.
+- [x] OAuth transaction Preferences/UserDefaults storage, TTL, cleanup, and threat-model rationale are explicit.
+- [x] Manifest paths, schema, exit codes, redaction, hashes, and `testedBehaviorCommit` semantics are defined.
+- [x] Production and diagnostic build classes run separately on one commit/backend.
+- [x] Simulator results cannot substitute for physical acceptance.
+- [x] Signing readiness is prerequisite handling and never commits a team or device identifier.
+- [x] Verified `www` assets are hashed across `cap sync ios` and protected from Quasar rebuilds before production smoke.
+- [x] Production, TTS, IME, layout, navigation, and failure scenarios have explicit row IDs.
+- [x] The silent-mode-only audio gate is the sole High reclassification path.
+- [x] Growth-prone evidence remains external with hash/size/media references.
+- [x] HPA-209’s historical evidence layout remains unchanged.
+- [x] `CLAUDE.md`, Linear source tickets, HPA-210, and HPA-194 have explicit closeout tasks.
+- [x] The design status update is the final pre-merge action.
+- [x] No unresolved implementation-value placeholder remains.
+
+## Execution Handoff
+
+After PR #56 is reviewed and merged, execute this plan using one of these paths:
+
+1. **Subagent-Driven (recommended):** use `superpowers:subagent-driven-development`, dispatch a fresh implementation subagent per task, and run two-stage review between tasks.
+2. **Inline Execution:** use `superpowers:executing-plans`, execute task batches in one session, and stop at the documented review checkpoints.

--- a/docs/superpowers/specs/2026-08-02-mobile-ios-foundation-verification-design.md
+++ b/docs/superpowers/specs/2026-08-02-mobile-ios-foundation-verification-design.md
@@ -19,7 +19,7 @@ An implementation PR may merge before native acceptance when its ticket explicit
 
 ## 2. Design principles
 
-1. **One tested commit.** Every final row refers to one exact repository commit. A behavior-affecting fix invalidates and reruns the affected rows.
+1. **One tested behavior commit.** Every executable matrix row and machine-generated manifest pins one exact `testedBehaviorCommit`: the commit containing the app, native project, configuration, dependencies, and verification tooling that produced the observed behavior. A later commit containing only documentation, manifests, or evidence references does not invalidate those rows. Any change to executable source, build/native configuration, dependency locks, generated assets, or verification tooling creates a new behavior commit and reruns affected gates. The resulting documentation/evidence commit is linked from HPA-210 and HPA-194 through normal Git history; it is not self-embedded as a second manifest SHA.
 2. **Observation, not inference.** Unit tests, media events, or Simulator behavior cannot be reported as physical speaker audibility, Japanese IME correctness, or native gesture success.
 3. **No pass by partial aggregation.** Strong automated coverage does not compensate for a missing physical exit criterion.
 4. **Two native build classes.** Production product behavior and development-only diagnostic behavior are verified separately on the same commit and deployed backend.
@@ -83,11 +83,13 @@ apps/vela-mobile/docs/evidence/hpa-210/<full-commit-sha>/<run-id>/
 
 `<run-id>` is `<UTC timestamp>-<phase-or-matrix-class>`, such as `20260803T021500Z-production-smoke`. Runs never overwrite one another, and no mutable `latest` symlink is used. The verification record identifies the selected final run IDs while preserving earlier `NO-GO` runs.
 
-Each run directory contains `manifest.json` and may contain sanitized screenshots, bounded logs, command output, and hashes for larger local-only artifacts.
+Each run directory commits `manifest.json` and small bounded text evidence only. Screenshots, videos, raw logs, archives, and other growth-prone artifacts remain local or are attached to the relevant PR/Linear issue; the manifest records their storage reference, byte size, media type, and SHA-256 hash. A binary artifact is committed only when it is both small and load-bearing for future review. This keeps repeated `NO-GO` runs auditable without unbounded repository growth.
+
+The existing flat `docs/evidence/hpa-209/*.png` layout is preserved as historical HPA-209 evidence and is not reorganized into the HPA-210 run structure.
 
 The manifest records:
 
-- schema version, run ID, commit, phase, matrix class, timestamps, outcome, and exit code;
+- schema version, run ID, `testedBehaviorCommit`, phase, matrix class, timestamps, outcome, and exit code;
 - non-secret host, Xcode, iOS, Bun, Quasar, Capacitor, and plugin versions;
 - configuration source/class and public origins;
 - non-secret device or Simulator alias/model;
@@ -134,27 +136,29 @@ Missing tools, configuration, Simulator, device, trust, Developer Mode, signing 
 
 ### 5.1 Final monorepo freeze gates
 
-The final automated phase runs:
+The implementation adds a root `compile` script (`turbo compile`) and a matching Turbo task so workspaces that expose `compile` participate in the freeze gate. The final automated phase runs:
 
 1. `bun install --frozen-lockfile`
 2. `bun run lint`
 3. `bun run typecheck`
-4. `bun run test`
-5. `bun run --cwd apps/vela-mobile verify:production-diagnostics`
-6. HPA-210 secret scanning
-7. manifest generation
+4. `bun run compile`
+5. `bun run build`
+6. `bun run test`
+7. `bun run --cwd apps/vela-mobile verify:production-diagnostics`
+8. HPA-210 secret scanning
+9. manifest generation
 
-The root gates are intentional: HPA-210 must not declare the shared frozen commit ready while another workspace is red. Focused mobile/common/API/CDK commands are encouraged during implementation, but do not replace fresh root gates. Because Turbo skips packages without a requested script, the manifest records actual tasks executed rather than implying every package has its own typecheck target.
+The root gates are intentional: HPA-210 must not declare the shared frozen commit ready while another workspace is red under its applicable repository contract. `typecheck` covers workspaces that define that task, `compile` covers API/extension-style explicit compiler tasks, and `build` covers build-time checkers and package compilation. `lint` still applies only where a workspace defines lint; the manifest records every actual Turbo task and skipped workspace rather than claiming nonexistent lint coverage. Focused mobile/common/API/CDK commands are encouraged during implementation, but do not replace these fresh freeze gates.
 
-`verify:production-diagnostics` is authoritative for production mobile assets and diagnostic exclusion. It invokes `build:ios:assets` and `apps/vela-mobile/scripts/verify-production-diagnostics.mjs`. The HPA-210 harness calls that package script and never forks its forbidden-token list.
+`verify:production-diagnostics` is authoritative for production mobile assets and diagnostic exclusion. It invokes `build:ios:assets` and `apps/vela-mobile/scripts/verify-production-diagnostics.mjs`. The HPA-210 harness calls that package script and never forks its forbidden-token list. HPA-210 widens the existing scanner from JavaScript-only traversal to an explicit text-artifact allowlist covering `.js`, `.mjs`, `.cjs`, `.html`, `.css`, `.json`, `.map`, `.txt`, `.svg`, and `.xml`; binary files remain skipped. Scanner tests place forbidden tokens in each supported artifact class and prove that source maps and top-level HTML are not blind spots.
 
 ### 5.2 Secret scan ownership
 
 Create one pure policy module:
 
-`apps/vela-mobile/src/security/mobile-secret-policy.ts`
+`apps/vela-mobile/build/mobile-secret-policy.ts`
 
-It contains sentinel classes, credential-like patterns, public-identifier allowlists, and bounded false-positive classifications without DOM or Vitest dependencies.
+It contains sentinel classes, credential-like patterns, public-identifier allowlists, and bounded false-positive classifications without DOM or Vitest dependencies. `build/` is used because the module is build/verification infrastructure shared by Bun scripts and tests rather than browser application code.
 
 Create the executable scanner:
 
@@ -164,6 +168,8 @@ It exports its scan function for tests and is invoked by `verify-m1-foundation.m
 
 - `secret-leak-helpers.ts` remains the runtime log/DOM/storage assertion adapter.
 - `scan-mobile-secrets.mjs` owns tracked-source, generated-artifact, native-resource, captured-log, and evidence-file inspection.
+- the mobile lint script is extended to include `scripts/**/*.{mjs,js,ts}` so both GO-gating scripts are linted; the ESLint configuration supplies the required Node globals.
+- tests import the same pure policy and cover positive findings, public-identifier allowlists, bounded false positives, and scanner path/type handling.
 
 The scan checks for embedded credentials, unsafe logging/rendering, bearer values, JWT-shaped values outside mock fixtures, provider/AWS keys, private keys, token material outside the approved storage boundary, full presigned URLs, and known leakage sentinels. Public pool/client IDs, regions, callback schemes, API origins, and non-secret provider/model identifiers remain allowed.
 
@@ -210,7 +216,7 @@ The team may come from an explicit local input, untracked xcconfig, or Xcode use
 
 ### 5.5 Verified WebView asset immutability
 
-After `verify:production-diagnostics` produces and scans `src-capacitor/www`, no Quasar build may run before the corresponding production smoke.
+After `verify:production-diagnostics` produces and scans `src-capacitor/www`, no Quasar build may run before the corresponding production smoke. In particular, `bun run build:ios`, `bun run build:ios:ide`, `bun run build:ios:assets`, and a second `verify:production-diagnostics` invocation are forbidden after the selected artifact hash is recorded because they rebuild or replace `www`.
 
 When an explicit sync is needed, use:
 
@@ -326,7 +332,8 @@ Milestone failures include indefinite loading, protected-content flash, cross-us
 ## 8. Architecture boundaries to record from the tested commit
 
 - Dedicated public mobile Cognito client; authorization code plus PKCE; system browser; app-owned warm/cold/late/malformed/duplicate callback handling.
-- Only the refresh token needed for restoration in device-bound non-synchronizing Keychain; access/ID tokens memory-only; installation marker prevents stale reinstall restoration.
+- Only the refresh token needed for restoration is stored in device-bound, non-synchronizing Keychain; access and ID tokens remain memory-only; the installation marker prevents stale reinstall restoration.
+- The transient OAuth transaction (`state`, `codeVerifier`, `nonce`, `createdAt`) is stored as one JSON value in `@capacitor/preferences` backed by iOS UserDefaults, not Keychain. It contains no access, ID, or refresh token. The store removes the prior value before replacement, enforces the 10-minute TTL, deletes corrupt/expired records, and the coordinator clears it after consumption, cancellation, or terminal cleanup. Plaintext UserDefaults is accepted for this short-lived single-use correlation/verifier material because compromise does not expose a reusable authenticated session; the architecture record names the backup/plaintext limitation and verification confirms bounded cleanup.
 - Auth initialization gates protected rendering; sign-out and terminal recovery clear retained credentials and scoped feature state.
 - Absolute validated native API origin; exact Capacitor CORS, no wildcard; auth coordinator owns bearer injection and bounded single-flight unauthorized recovery.
 - User-scoped query keys; cancel/remove prior-user data without global cache clearing.
@@ -355,7 +362,7 @@ Prose-only deferral is forbidden.
 
 ### 10.1 GO requires
 
-- fresh root monorepo lint, typecheck, tests, production assets, diagnostic exclusion, and secret scan;
+- fresh root monorepo lint, typecheck, compile, build, tests, production assets, diagnostic exclusion, and secret scan;
 - deployed production config through the normal validator;
 - production-smoke and diagnostic-observation classes on the same commit/backend;
 - Simulator build/install/launch;
@@ -387,9 +394,10 @@ After verification:
 4. Update HPA-194 with `GO`/`NO-GO`, commit/device summary, M1 evidence, limitations, and recommended first M2 issues.
 5. Synchronize `CLAUDE.md`.
 6. Preserve `ios-interaction-baseline.md` as historical evidence and add only a closeout link/result if useful.
-7. Preserve earlier evidence run directories.
-8. Finalize the architecture record from the tested commit and selected audio result.
-9. Update this design status to reflect completed repository review before merge.
+7. Preserve earlier evidence run directories and external artifact hashes.
+8. Finalize the architecture record from `testedBehaviorCommit` and the selected audio result.
+9. Commit the verification/architecture/`CLAUDE.md` closeout as documentation-only changes, link the resulting Git commit from HPA-210 and HPA-194, and state explicitly that it does not invalidate executable rows pinned to `testedBehaviorCommit`.
+10. As the final pre-merge checklist action, update this design status to reflect completed repository review.
 
 For `GO`, begin M2 with the smallest end-to-end review path: Home/Review navigation, ten-card SRS, rating/pronunciation, then durable outbox and backend idempotency.
 
@@ -411,13 +419,17 @@ For `GO`, begin M2 with the smallest end-to-end review path: Home/Review navigat
 - two build classes are required on one commit/backend;
 - Simulator evidence cannot replace physical acceptance;
 - signing/device readiness has explicit exit-3 preflight;
-- final root monorepo gates are intentional;
-- secret policy has one source of truth;
-- evidence/manifests are append-only and versioned;
+- final root lint, typecheck, compile, build, and test gates are intentional and their actual workspace coverage is recorded;
+- production diagnostic scanning covers all emitted text-artifact classes rather than JavaScript only;
+- OAuth transaction storage, TTL, plaintext/UserDefaults rationale, and cleanup ownership are explicit;
+- secret policy has one source of truth and GO-gating scripts are linted;
+- manifests are append-only and versioned while growth-prone binary evidence is externalized by hash;
+- manifests pin `testedBehaviorCommit`, and later documentation/evidence-only commits are explicitly non-invalidating;
 - verified `www` assets are hashed across `cap sync ios`;
 - HPA-209 measurements remain canonical history;
 - production config and placeholder classification are explicit;
 - existing production diagnostic scripts are reused;
 - High reclassification is limited to the silent-mode audio fork;
-- architecture and `CLAUDE.md` are finalized from the tested commit;
-- scope remains M1 verification and architecture closeout.
+- architecture and `CLAUDE.md` are finalized from `testedBehaviorCommit`, and their resulting documentation commit is linked externally;
+- scope remains M1 verification and architecture closeout;
+- updating the design status from repository review to approved is the final pre-merge checklist item.

--- a/docs/superpowers/specs/2026-08-02-mobile-ios-foundation-verification-design.md
+++ b/docs/superpowers/specs/2026-08-02-mobile-ios-foundation-verification-design.md
@@ -1,0 +1,489 @@
+# Mobile iOS Foundation Verification and Architecture Record Design
+
+**Linear:** HPA-210  
+**Parent:** HPA-194  
+**Milestone:** Mobile MVP — M1 iOS foundation spike  
+**Status:** Approved design
+
+## 1. Purpose
+
+HPA-210 is the acceptance owner for the complete Mobile MVP Milestone 1 foundation. It does not add another product feature. It verifies that the separately implemented foundation pieces work together on a real iOS runtime, records the architecture decisions established by the spike, and issues an explicit `GO` or `NO-GO` decision before Milestone 2 begins.
+
+The milestone exit story is:
+
+> A user installs Vela on an iPhone, signs in with Google, returns through the iOS callback, relaunches into a restored session, sees the authenticated due-review count, hears one Japanese pronunciation, and can recover from expected authentication, network, playback, keyboard, and navigation failures.
+
+Automated tests establish source-level and artifact-level confidence. Simulator and physical-iPhone runs establish native behavior. Neither substitutes for the other.
+
+## 2. Current State and Tracking Ownership
+
+The implementation work is present across HPA-202 through HPA-209. Several implementation pull requests merged while explicitly deferring live native acceptance. Their Linear issues therefore remain `In Review` until HPA-210 records the missing evidence:
+
+- HPA-202 — physical-device installation and launch.
+- HPA-205 — live Google OAuth and warm/cold callback behavior.
+- HPA-206 — relaunch restoration, refresh, sign-out, and reinstall cleanup.
+- HPA-207 — authenticated due-count and identity/cache isolation.
+- HPA-208 — Simulator and physical-iPhone pronunciation playback.
+- HPA-209 — physical Japanese IME and WKWebView navigation behavior.
+
+HPA-203 and HPA-204 remain complete configuration/infrastructure inputs unless verification exposes a defect in their ownership area.
+
+HPA-210 is the single milestone acceptance owner. The source issues are related evidence sources rather than blockers. This avoids a circular dependency in which HPA-210 must perform evidence required to complete issues that formally block HPA-210.
+
+### Completion semantics
+
+- An implementation pull request may merge before native acceptance when its issue explicitly separates merge and closure gates.
+- An M1 source issue may be `Done` only after its required evidence exists or HPA-210 links a consolidated evidence row that satisfies it.
+- HPA-210 may be `Done` only after the final `GO` or `NO-GO` record is complete, every deferred risk has a Linear issue, and HPA-194 receives the milestone summary.
+
+## 3. Design Principles
+
+1. **One tested commit.** All final matrices refer to one exact repository commit. Any fix invalidating observed behavior requires rerunning affected rows.
+2. **Observation, not inference.** A UI event, media event, automated test, or source review cannot be reported as physical speaker audibility, Japanese IME correctness, or native navigation success.
+3. **No secret-bearing evidence.** Logs, screenshots, environment manifests, and build artifacts are inspected and sanitized before commit or attachment.
+4. **Automate deterministic checks only.** Source, component, bundle, build, install, launch, and process assertions are automated. Human-dependent behavior remains a controlled manual matrix.
+5. **Preserve subsystem ownership.** HPA-210 consumes existing auth, API, query, audio, lifecycle, and navigation interfaces. It does not bypass them with a milestone-only implementation.
+6. **Failures produce tracked work.** A failed or deferred criterion has reproduction evidence, severity, owner, target milestone, and a Linear issue.
+7. **No milestone pass by partial aggregation.** Strong automated coverage does not compensate for a missing physical exit criterion.
+
+## 4. Repository Artifacts
+
+HPA-210 produces these durable artifacts.
+
+### 4.1 Architecture record
+
+Create `apps/vela-mobile/docs/ios-foundation-architecture.md`.
+
+This document records stable decisions that later mobile features must follow:
+
+- authentication and token-storage ownership;
+- OAuth callback strategy and callback lifecycle;
+- absolute API-origin and CORS policy;
+- authenticated transport and query/cache isolation;
+- mobile lifecycle ownership;
+- safe-area, keyboard, and navigation policy;
+- audio adapter boundary and the HPA-208 playback conclusion;
+- development diagnostic isolation from production artifacts;
+- known constraints that intentionally survive M1.
+
+It is not a timestamped test report. Subsequent implementation changes must update it when they change a recorded boundary.
+
+### 4.2 Verification record
+
+Create `apps/vela-mobile/docs/m1-ios-foundation-verification.md`.
+
+Use these top-level sections:
+
+```markdown
+# M1 iOS Foundation Verification
+
+## Final Decision
+## Tested Build and Environment
+## Automated Verification
+## Simulator Matrix
+## Physical iPhone Matrix
+## Security and Secret Scan
+## Architecture Decisions
+## Known Limitations and Follow-up Issues
+## Source-Issue Closure Mapping
+## Milestone 2 Recommendation
+```
+
+The file is initially a complete schema and instruction set, not a pre-filled claim. A result row is added only after that environment and scenario has been run.
+
+### 4.3 Evidence directory
+
+Create `apps/vela-mobile/docs/evidence/hpa-210/` for sanitized, repository-worthy evidence.
+
+Allowed evidence includes:
+
+- screenshots without personal account data or transient OAuth values;
+- bounded console excerpts with sensitive values removed;
+- generated non-secret environment manifests;
+- command output needed to prove build, install, or launch;
+- hashes identifying larger local-only artifacts that should not be committed.
+
+Do not commit DerivedData, full Xcode archives, raw device logs, provider API responses, bearer tokens, refresh tokens, authorization codes, PKCE verifiers, presigned query strings, account email addresses, or device identifiers that are unnecessary for reproduction.
+
+### 4.4 Verification harness
+
+Add `apps/vela-mobile/scripts/verify-m1-foundation.mjs` with a package script named `verify:m1-foundation`.
+
+The harness exposes explicit phases rather than silently skipping unsupported checks:
+
+- `--phase automated` — cross-platform source, tests, production assets, diagnostics exclusion, and secret scanning.
+- `--phase ios-simulator` — macOS-only native build, install, launch, and process assertion.
+- `--phase all` — runs both and fails when native prerequisites are unavailable.
+
+CI may run `--phase automated` on Linux. The milestone closure record must include a successful macOS `--phase ios-simulator` or `--phase all` run against the final tested commit.
+
+The harness returns nonzero on any failed command, missing expected artifact, detected sensitive marker, native launch failure, or incomplete generated manifest. It never converts an unsupported native phase into a passing result.
+
+## 5. Automated Verification Design
+
+### 5.1 Cross-platform phase
+
+The automated phase runs from a clean checkout with a frozen lockfile and executes the established repository gates:
+
+1. dependency installation;
+2. repository lint;
+3. repository type-checking;
+4. repository unit tests and configured coverage thresholds;
+5. mobile production asset build through the normal environment-validation path;
+6. production diagnostic exclusion scan;
+7. secret/token scan over committed mobile files and generated production assets;
+8. generation of a non-secret command/result manifest.
+
+The harness reuses existing scripts rather than reimplementing their assertions. It captures command name, exit status, start/end timestamps, tested commit, and relevant artifact paths. It does not capture command environments wholesale.
+
+### 5.2 Secret and token scan
+
+The scan covers:
+
+- tracked source and configuration under `apps/vela-mobile`;
+- generated `src-capacitor/www` assets;
+- iOS plist, entitlements, project, and resolved package configuration;
+- selected Xcode build settings and application bundle resources;
+- evidence files staged for HPA-210;
+- captured logs selected for attachment.
+
+The scanner looks for both structural and sentinel evidence:
+
+- OAuth authorization codes and PKCE verifier field names in runtime output;
+- `Authorization: Bearer` values;
+- JWT-shaped values;
+- Cognito refresh/access/ID token storage outside the approved secure-storage path;
+- provider API-key names paired with non-placeholder values;
+- AWS secret values or private keys;
+- full presigned TTS URLs containing query credentials;
+- known test sentinels used by existing leakage tests;
+- development diagnostic route labels or markers in production assets.
+
+Configuration identifiers that are intentionally public—Cognito pool IDs, public client IDs, regions, callback schemes, API origins, and non-secret provider/model identifiers—are not treated as secrets. The scan must distinguish these from credentials.
+
+A finding fails the phase until it is removed or explicitly classified as a verified false positive in the verification record with the matching bounded value class. Raw credential-like values are never copied into that explanation.
+
+### 5.3 Native Simulator launch phase
+
+The macOS phase:
+
+1. records `git rev-parse HEAD`, `xcodebuild -version`, `bun --version`, resolved Quasar/Capacitor/plugin versions, selected Simulator model, and Simulator iOS runtime;
+2. builds production WebView assets and synchronizes Capacitor;
+3. builds the `App` scheme from `App.xcworkspace` for an explicit Simulator destination;
+4. boots the selected Simulator when required;
+5. installs the built application bundle;
+6. launches the application by bundle identifier;
+7. asserts that launch succeeds and the process remains alive for the bounded smoke interval;
+8. captures bounded launch output and writes the environment/result manifest;
+9. terminates only the test-launched application process.
+
+The native launch check proves project integrity, installation, and startup. It does not claim authenticated OAuth, TTS audibility, Japanese input, or navigation behavior.
+
+### 5.4 CI boundary
+
+M1 does not add a permanent macOS native-test job solely to close HPA-210. The existing Linux mobile test job continues to run automated source and asset checks. A permanent macOS CI lane, native UI automation, signing automation, and TestFlight automation remain release-readiness work under HPA-194 Milestone 5.
+
+## 6. Verification Matrix Design
+
+Every environment table includes:
+
+- exact commit SHA;
+- date and local time zone;
+- build configuration;
+- packaged assets or development server source;
+- Simulator/device model;
+- iOS version;
+- Xcode version;
+- app version/build number;
+- non-secret account alias;
+- scenario precondition;
+- observed result;
+- `PASS`, `FAIL`, or `BLOCKED` status;
+- evidence path or bounded note;
+- follow-up issue for every `FAIL` or accepted `BLOCKED` row.
+
+`PARTIAL` is allowed during work but cannot satisfy a closure criterion.
+
+### 6.1 Installation and authentication lifecycle
+
+Run on the final Simulator and physical iPhone where applicable:
+
+1. fresh application installation and first launch;
+2. fresh Google sign-in using the system browser;
+3. direct-provider redirect and callback return;
+4. warm callback while the app process is active;
+5. cold-start callback launching the app;
+6. cancellation recovery;
+7. missing-code, provider-error, malformed-callback, and state-mismatch recovery;
+8. late or duplicate callback behavior;
+9. force-close and relaunch restoration without another Google prompt;
+10. proactive refresh and app-resume refresh;
+11. revoked/non-refreshable session recovery;
+12. local sign-out;
+13. relaunch after sign-out remains signed out;
+14. reinstall residue cleanup where Keychain retention would otherwise restore the prior installation.
+
+Successful OAuth evidence records state transitions and outcomes, never codes, verifiers, tokens, or complete callback URLs.
+
+### 6.2 Authenticated API and due-count behavior
+
+Verify:
+
+1. restored authentication reaches Home;
+2. positive `due_today` agrees with the web app or a direct authenticated API observation for the same account and time window;
+3. zero-due state renders correctly;
+4. loading and explicit manual refresh behavior;
+5. foreground/resume refresh;
+6. disabled-network failure and successful retry;
+7. request timeout recovery;
+8. server failure and malformed-response handling;
+9. rejected/expired token recovery;
+10. terminal authentication failure returns to the auth gate;
+11. sign-out removes the previous user’s due-count data;
+12. signing in as another account cannot show the previous account’s cached data;
+13. a pending request cannot block sign-out or lifecycle cleanup.
+
+Where a comparison value may change during testing, record both values and timestamps rather than requiring a stale screenshot to remain numerically equal later.
+
+### 6.3 TTS pronunciation behavior
+
+Use the fixed non-secret diagnostic vocabulary established by HPA-208 and verify:
+
+1. restored authentication and configured TTS settings;
+2. first server-cache request;
+3. genuinely uncached generation;
+4. loading/preparation state;
+5. first user-gesture playback attempt;
+6. prepared direct-tap playback;
+7. correct and audible Japanese pronunciation through the physical iPhone speaker;
+8. ten prepared replays without intermittent silence, overlap, or stuck state;
+9. rapid taps during preparation and playback;
+10. authentication failure;
+11. TTS generation failure;
+12. disabled-network failure and retry;
+13. expired or invalid presigned URL recovery;
+14. playback decoding/error recovery;
+15. background during preparation and playback;
+16. foreground replayability;
+17. sign-out while ready and while playing;
+18. external/system audio interruption;
+19. Ring/Silent off behavior;
+20. Ring/Silent on behavior;
+21. relaunch and replay.
+
+Human observation is required for audibility and pronunciation correctness. Media events alone are insufficient.
+
+The resulting architecture decision is exactly one of:
+
+- `HTML-only accepted`
+- `native audio-session integration required`
+- `native player adapter required`
+
+If silent mode is the only failed requirement and HTML decoding/lifecycle are otherwise reliable, create a narrowly scoped native audio-session issue while retaining `HtmlAudioPlayer`. If HTML playback remains unreliable after correct origin and audio-session handling, create a native `MobileAudioPlayer` implementation issue naming each failed criterion.
+
+### 6.4 Japanese input, keyboard, safe area, and navigation
+
+Verify on a physical iPhone:
+
+1. Japanese Kana keyboard composition;
+2. draft composition, committed model, native input value after render, and submitted value all equal `日本語`;
+3. no validation or submission while composition is active;
+4. focused input remains visible in portrait;
+5. focused input and primary action remain reachable in landscape;
+6. keyboard dismissal restores the viewport and footer without a stale gap;
+7. top and bottom safe areas on a notched or Dynamic Island device;
+8. left and right landscape sensor-region avoidance;
+9. visible back returns to the exact previous app route;
+10. native swipe-back and swipe-forward behavior;
+11. repeated tab switching does not duplicate, blank, close, or trap the app;
+12. validated in-session deep entry;
+13. cold deep entry at depth zero;
+14. app resume without a new entry event is a navigation no-op;
+15. saved scroll restoration on back and forward;
+16. portrait functionality and the documented landscape policy.
+
+The expected baseline remains native `ios.contentInset: "never"` with app CSS owning the headerless top safe area, fixed surfaces owning their appropriate insets, and app-owned chronological mobile navigation depth.
+
+### 6.5 Failure-state recovery
+
+For auth, API, playback, and navigation failures, verify that the app has one of these bounded outcomes:
+
+- retry in place;
+- return to a stable signed-out gate;
+- stop active media and remain replayable;
+- return to a valid route;
+- explain the unsupported or terminal state without protected-content leakage.
+
+The following are milestone failures:
+
+- indefinite loading without a recovery action;
+- protected content briefly shown before auth restoration completes;
+- another user’s cached data shown;
+- duplicated or overlapping playback caused by ordinary taps;
+- a blank frame, app exit, or navigation trap;
+- unrecoverable keyboard obstruction;
+- credentials or transient OAuth material in visible UI, logs, source, or artifacts.
+
+## 7. Architecture Record
+
+The final architecture document records these established boundaries.
+
+### 7.1 Authentication and storage
+
+- The mobile app uses a dedicated public Cognito client with authorization-code grant and PKCE.
+- Google authentication occurs through the system browser.
+- The app owns warm, cold, late, malformed, and duplicate callback handling.
+- Only the refresh token required for restoration is retained in device-bound, non-synchronizing iOS Keychain storage.
+- Access and ID tokens remain memory-only.
+- Installation identity prevents stale Keychain material from restoring a previous installation.
+- Auth initialization gates protected routing and rendering.
+- Sign-out and terminal recovery clear retained credentials and user-scoped feature state.
+
+### 7.2 API origin and transport
+
+- Native builds use an absolute validated API base URL.
+- Approved Capacitor origins are exact; wildcard CORS is forbidden.
+- Existing web and extension origin behavior remains intact.
+- Feature code does not receive raw token-storage ownership.
+- The auth coordinator injects one current bearer token, bounds attempts, performs guarded single-flight unauthorized recovery, and prevents stale-generation mutation.
+- Feature requests do not block sign-out or coordinator disposal.
+
+### 7.3 Query and user-data isolation
+
+- Shared contracts and query keys may be reused without importing complete web pages.
+- User-specific query keys contain the user identity.
+- Identity loss and sign-out cancel then remove only the previous user’s scoped data.
+- No global query-cache clearing is introduced solely for this milestone.
+
+### 7.4 Lifecycle
+
+- One shared Capacitor lifecycle service owns app active/inactive observation.
+- Auth refresh, due-count refresh, and audio interruption consume that shared state rather than registering competing native listeners.
+- Resume is not itself a navigation event.
+
+### 7.5 iOS layout and navigation
+
+- Native content inset is `never`.
+- CSS owns the headerless top safe area; fixed toolbar/footer and page content each own their defined edges exactly once.
+- App-owned chronological route depth drives visible back and native swipe history.
+- A fresh cold entry replaces at depth zero; a validated in-session entry participates in ordinary history.
+
+### 7.6 Audio
+
+- Learning features depend on the browser-free `MobileAudioPlayer` contract.
+- `HtmlAudioPlayer` is the current implementation candidate.
+- The physical verification result determines whether HTML remains sufficient, requires minimal native audio-session configuration, or must be replaced by a native player adapter.
+- Provider credentials remain server-side and no provider API key is bundled in the app.
+
+### 7.7 Diagnostics
+
+- Native-only validation may use authenticated development diagnostic routes and pages.
+- Production builds compile out diagnostic entries, labels, routes, test IDs, and markers.
+- Production artifact scanning is a merge and milestone gate.
+
+## 8. Findings, Severity, and Follow-up Issues
+
+Every unresolved finding contains:
+
+- concise title;
+- affected criterion;
+- severity;
+- exact environment and tested commit;
+- reproduction steps;
+- observed and expected behavior;
+- bounded evidence reference;
+- owner;
+- target milestone;
+- Linear issue.
+
+Severity policy:
+
+- **Critical:** credential exposure, cross-user data leakage, unusable authentication, unrecoverable corruption, or an unresolved architecture ambiguity that prevents safe M2 work. Always blocks `GO`.
+- **High:** failure of an M1 exit behavior on the supported physical iPhone, including relaunch restoration, due-count retrieval, acceptable pronunciation playback, Japanese IME, or non-trapping navigation. Blocks `GO` until fixed or until the accepted architecture decision moves the required fix into a specifically linked pre-M2 gate.
+- **Medium:** bounded limitation that does not invalidate the exit story and has a clear M2 or release-readiness owner. May accompany `GO` with a linked issue.
+- **Low:** polish or observability limitation that is safely deferred. May accompany `GO` with a linked issue.
+
+Prose-only deferral is not allowed.
+
+## 9. GO/NO-GO Decision
+
+The final decision is exactly `GO` or `NO-GO`.
+
+### 9.1 GO requirements
+
+All of the following must be true on the final tested commit:
+
+- automated repository, production asset, diagnostics-exclusion, and secret-scan gates pass;
+- native Simulator build, install, and launch pass;
+- physical iPhone install and launch pass;
+- fresh Google sign-in and warm/cold callback return pass;
+- force-close/relaunch restores a valid session;
+- authenticated due-count is correct and identity-isolated;
+- one acceptable physical Japanese pronunciation path is selected and demonstrated;
+- Japanese IME composition/submission passes;
+- keyboard, safe-area, visible-back, and native navigation have recorded non-trapping results;
+- expected auth, network, and playback failures recover to a stable state;
+- no Critical finding remains;
+- every deferred Medium or Low risk has a Linear issue and target milestone;
+- the architecture record has no unresolved decision required to begin M2.
+
+### 9.2 NO-GO conditions
+
+Report `NO-GO` when any required row is unrun, blocked without an accepted pre-M2 gate, failed, or invalidated by a later code change; when a secret scan fails; or when the audio architecture conclusion is not selected.
+
+`NO-GO` is a useful milestone result. It names the minimum issues that must close before rerunning the decision. HPA-210 remains open until a later run produces a complete decision record.
+
+## 10. Source-Issue and Parent Updates
+
+After final verification:
+
+1. Add a concise evidence comment to HPA-202 and HPA-205 through HPA-209 identifying the tested commit, relevant matrix rows, result, and follow-up issue where applicable.
+2. Return a source issue to `Done` only when its acceptance evidence is satisfied.
+3. Add the complete result to HPA-210 with links to the architecture record, verification record, evidence directory, implementation pull request, and follow-up issues.
+4. Update HPA-194 with:
+   - final `GO` or `NO-GO`;
+   - tested commit and device summary;
+   - concise M1 evidence summary;
+   - accepted architecture limitations;
+   - recommended first M2 issues.
+
+For a `GO`, the recommended M2 start is the smallest end-to-end core review path: mobile Home/Review navigation, a real ten-card SRS session, rating and pronunciation behavior, then durable outbox and backend idempotency. Exact issue order is confirmed from current M2 ticket readiness at closeout time.
+
+## 11. Non-Goals
+
+HPA-210 does not include:
+
+- the SRS review session itself;
+- durable review outbox or backend idempotency implementation;
+- Android verification;
+- TestFlight or App Store distribution;
+- permanent macOS CI or full native UI automation;
+- accessibility certification;
+- final visual polish;
+- AI buddy, microphone, speech-to-text, or background audio;
+- unrelated refactoring of the existing mobile foundation.
+
+## 12. Alternatives Considered
+
+### Evidence-only closeout
+
+Rejected because it would leave deterministic verification fragmented across prior implementation plans and make future native closeout difficult to reproduce.
+
+### Full native UI automation in M1
+
+Rejected because OAuth provider interaction, human audio confirmation, Japanese IME observation, and speaker behavior still require controlled manual checks. Building a full native test stack would materially expand the spike and belongs in release readiness.
+
+### Consolidated verification harness and manual native matrix
+
+Selected because it automates repeatable source/build/launch evidence while preserving explicit human observation for behavior automation cannot honestly establish.
+
+## 13. Design Completion Check
+
+- No unresolved implementation decision is required to write the implementation plan.
+- No required evidence row is pre-declared as passing.
+- Automated and manual evidence have distinct ownership.
+- Secret-handling rules cover source, artifacts, logs, and screenshots.
+- Source-ticket state semantics and HPA-210 ownership are explicit.
+- GO/NO-GO conditions are deterministic.
+- Deferred risks require Linear issues.
+- Scope remains limited to M1 verification and architecture closeout.

--- a/docs/superpowers/specs/2026-08-02-mobile-ios-foundation-verification-design.md
+++ b/docs/superpowers/specs/2026-08-02-mobile-ios-foundation-verification-design.md
@@ -3,7 +3,7 @@
 **Linear:** HPA-210  
 **Parent:** HPA-194  
 **Milestone:** Mobile MVP — M1 iOS foundation spike  
-**Status:** Approved design
+**Status:** Approved in project discussion; draft PR pending repository review
 
 ## 1. Purpose
 
@@ -45,6 +45,7 @@ HPA-210 is the single milestone acceptance owner. The source issues are related 
 5. **Preserve subsystem ownership.** HPA-210 consumes existing auth, API, query, audio, lifecycle, and navigation interfaces. It does not bypass them with a milestone-only implementation.
 6. **Failures produce tracked work.** A failed or deferred criterion has reproduction evidence, severity, owner, target milestone, and a Linear issue.
 7. **No milestone pass by partial aggregation.** Strong automated coverage does not compensate for a missing physical exit criterion.
+8. **One canonical source per fact class.** Historical measurement records, the stable architecture record, and the final milestone verification record link to one another instead of copying the same policy or evidence into competing documents.
 
 ## 4. Repository Artifacts
 
@@ -68,6 +69,8 @@ This document records stable decisions that later mobile features must follow:
 
 It is not a timestamped test report. Subsequent implementation changes must update it when they change a recorded boundary.
 
+The existing `apps/vela-mobile/docs/ios-interaction-baseline.md` is not superseded or folded into this file. It remains the canonical detailed HPA-209 measurement and historical evidence record for the safe-area candidates, Simulator environments, navigation observations, and pending physical checks. The architecture record references that baseline as the measured rationale and extracts only the stable selected policy and reusable rules. It does not duplicate the baseline's numeric tables, screenshots, hashes, or environment rows.
+
 ### 4.2 Verification record
 
 Create `apps/vela-mobile/docs/m1-ios-foundation-verification.md`.
@@ -90,6 +93,10 @@ Use these top-level sections:
 ```
 
 The file is initially a complete schema and instruction set, not a pre-filled claim. A result row is added only after that environment and scenario has been run.
+
+The `Architecture Decisions` section is a concise tested-revision summary and pointer to `ios-foundation-architecture.md`, not a second copy of the decisions. It records the architecture document path and commit, the final HPA-208 audio conclusion, and any decision changed by the verification run.
+
+Existing HPA-209 Simulator rows and screenshots remain in `ios-interaction-baseline.md` and `docs/evidence/hpa-209/`; they are cross-referenced as historical evidence rather than migrated or copied. Because HPA-210 requires one final tested commit, those historical rows cannot by themselves satisfy a `GO`. The final HPA-210 record contains fresh closure rows for the load-bearing behavior on the final tested commit, while linking the earlier detailed measurements for rationale and comparison.
 
 ### 4.3 Evidence directory
 
@@ -117,24 +124,43 @@ The harness exposes explicit phases rather than silently skipping unsupported ch
 
 CI may run `--phase automated` on Linux. The milestone closure record must include a successful macOS `--phase ios-simulator` or `--phase all` run against the final tested commit.
 
-The harness returns nonzero on any failed command, missing expected artifact, detected sensitive marker, native launch failure, or incomplete generated manifest. It never converts an unsupported native phase into a passing result.
+The harness uses stable process exits and matching manifest outcomes:
+
+- exit `0`, outcome `passed` — every requested gate passed;
+- exit `2`, outcome `usage_error` — invalid CLI arguments or unsupported phase selection;
+- exit `3`, outcome `prerequisite_missing` — required host capability, tool, Simulator, signing/configuration input, or production mobile environment is unavailable;
+- exit `4`, outcome `gate_failed` — a test, build, scan, install, launch, or expected-artifact assertion failed;
+- exit `1`, outcome `harness_error` — an unexpected harness implementation or manifest-write failure.
+
+A missing prerequisite is never reported as a passing or failed product check. The manifest records the failed preflight without dumping command environments or sensitive values.
+
+### 4.5 Guidance synchronization
+
+HPA-210 also updates `CLAUDE.md` as a closeout artifact:
+
+- replace the stale statement that mobile PKCE, `state`, `nonce`, client-ID wiring, and `identity_provider=Google` are future M2 work with the implemented HPA-205 architecture and the remaining live acceptance gates;
+- keep the HPA-209 physical-device note while evidence is pending, but point it to HPA-210 as the consolidated closure owner;
+- after physical verification, replace the pending note with a concise result and links to the final architecture and verification records rather than silently deleting the historical context.
+
+`CLAUDE.md` remains developer guidance. It links to the canonical architecture and evidence documents instead of reproducing their full matrices.
 
 ## 5. Automated Verification Design
 
 ### 5.1 Cross-platform phase
 
-The automated phase runs from a clean checkout with a frozen lockfile and executes the established repository gates:
+The automated phase runs from a clean checkout with a frozen lockfile and invokes the established repository/package entry points:
 
-1. dependency installation;
-2. repository lint;
-3. repository type-checking;
-4. repository unit tests and configured coverage thresholds;
-5. mobile production asset build through the normal environment-validation path;
-6. production diagnostic exclusion scan;
-7. secret/token scan over committed mobile files and generated production assets;
-8. generation of a non-secret command/result manifest.
+1. `bun install --frozen-lockfile`;
+2. `bun run lint`;
+3. `bun run typecheck`;
+4. `bun run test`;
+5. `bun run --cwd apps/vela-mobile verify:production-diagnostics`;
+6. the HPA-210 secret/token scan over committed mobile files, generated production assets, selected native resources, and staged evidence;
+7. generation of a non-secret command/result manifest.
 
-The harness reuses existing scripts rather than reimplementing their assertions. It captures command name, exit status, start/end timestamps, tested commit, and relevant artifact paths. It does not capture command environments wholesale.
+`verify:production-diagnostics` is the authoritative production mobile asset and diagnostic-exclusion gate. It invokes the existing `build:ios:assets` package script and then `apps/vela-mobile/scripts/verify-production-diagnostics.mjs`. The HPA-210 harness calls this package script and does not copy, reinterpret, or maintain a second forbidden-token list.
+
+The harness captures command name, exit status, start/end timestamps, tested commit, and relevant artifact paths. It does not capture command environments wholesale.
 
 ### 5.2 Secret and token scan
 
@@ -165,23 +191,59 @@ Configuration identifiers that are intentionally public—Cognito pool IDs, publ
 
 A finding fails the phase until it is removed or explicitly classified as a verified false positive in the verification record with the matching bounded value class. Raw credential-like values are never copied into that explanation.
 
-### 5.3 Native Simulator launch phase
+### 5.3 Production mobile configuration prerequisite
+
+Every phase that produces production WebView assets preflights the complete build-time mobile configuration before invoking Quasar. The required variables are:
+
+- `VITE_MOBILE_API_URL`;
+- `VITE_COGNITO_USER_POOL_ID`;
+- `VITE_COGNITO_MOBILE_USER_POOL_CLIENT_ID`;
+- `VITE_COGNITO_OAUTH_DOMAIN`;
+- `VITE_AWS_REGION`.
+
+The values may come from `apps/vela-mobile/.env.production`, normally generated by `packages/cdk/scripts/inject-env.ts` after deployment outputs exist, or from explicit process environment values. The harness must use the same precedence and validation contract as `apps/vela-mobile/build/validate-mobile-api-url.ts`.
+
+The harness reports a missing or malformed contract as `prerequisite_missing` before the production build begins. It does not rely on the later Vite exception as the user-facing diagnosis.
+
+For the final HPA-210 Simulator and physical-device closure run:
+
+- the normal `validate-mobile-api-url` path must execute;
+- `MOBILE_SKIP_ENV_VALIDATION=true` is forbidden;
+- values must identify the deployed environment under test;
+- CI/example placeholders such as `example.invalid` cannot satisfy a `GO`.
+
+Compile-only CI may provide documented non-secret placeholders while still exercising the normal validation path. Such a run is marked `placeholder` and may support automated build confidence, but it is not closure evidence for authenticated or native behavior.
+
+The non-secret manifest records:
+
+- `mobileConfigSource`: `.env.production` or `process_env`;
+- `mobileConfigClass`: `deployed` or `placeholder`;
+- API origin;
+- AWS region;
+- OAuth domain;
+- whether public pool/client identifiers were present and internally consistent.
+
+It does not dump the complete environment or any credentials.
+
+### 5.4 Native Simulator launch phase
 
 The macOS phase:
 
-1. records `git rev-parse HEAD`, `xcodebuild -version`, `bun --version`, resolved Quasar/Capacitor/plugin versions, selected Simulator model, and Simulator iOS runtime;
-2. builds production WebView assets and synchronizes Capacitor;
-3. builds the `App` scheme from `App.xcworkspace` for an explicit Simulator destination;
-4. boots the selected Simulator when required;
-5. installs the built application bundle;
-6. launches the application by bundle identifier;
-7. asserts that launch succeeds and the process remains alive for the bounded smoke interval;
-8. captures bounded launch output and writes the environment/result manifest;
-9. terminates only the test-launched application process.
+1. preflights the complete production mobile configuration from §5.3;
+2. records `git rev-parse HEAD`, `xcodebuild -version`, `bun --version`, resolved Quasar/Capacitor/plugin versions, selected Simulator model, and Simulator iOS runtime;
+3. ensures the authoritative `verify:production-diagnostics` gate has passed for the same commit and production configuration;
+4. synchronizes Capacitor without replacing the verified WebView assets;
+5. builds the `App` scheme from `App.xcworkspace` for an explicit Simulator destination;
+6. boots the selected Simulator when required;
+7. installs the built application bundle;
+8. launches the application by bundle identifier;
+9. asserts that launch succeeds and the process remains alive for the bounded smoke interval;
+10. captures bounded launch output and writes the environment/result manifest;
+11. terminates only the test-launched application process.
 
 The native launch check proves project integrity, installation, and startup. It does not claim authenticated OAuth, TTS audibility, Japanese input, or navigation behavior.
 
-### 5.4 CI boundary
+### 5.5 CI boundary
 
 M1 does not add a permanent macOS native-test job solely to close HPA-210. The existing Linux mobile test job continues to run automated source and asset checks. A permanent macOS CI lane, native UI automation, signing automation, and TestFlight automation remain release-readiness work under HPA-194 Milestone 5.
 
@@ -198,6 +260,7 @@ Every environment table includes:
 - Xcode version;
 - app version/build number;
 - non-secret account alias;
+- production mobile configuration source and class;
 - scenario precondition;
 - observed result;
 - `PASS`, `FAIL`, or `BLOCKED` status;
@@ -304,7 +367,7 @@ Verify on a physical iPhone:
 15. saved scroll restoration on back and forward;
 16. portrait functionality and the documented landscape policy.
 
-The expected baseline remains native `ios.contentInset: "never"` with app CSS owning the headerless top safe area, fixed surfaces owning their appropriate insets, and app-owned chronological mobile navigation depth.
+The expected baseline remains native `ios.contentInset: "never"` with app CSS owning the headerless top safe area, fixed surfaces owning their appropriate insets, and app-owned chronological mobile navigation depth. `ios-interaction-baseline.md` remains the canonical detailed measurement record; the final HPA-210 rows verify the load-bearing behavior on the final tested commit and link back to that baseline.
 
 ### 6.5 Failure-state recovery
 
@@ -369,6 +432,7 @@ The final architecture document records these established boundaries.
 - CSS owns the headerless top safe area; fixed toolbar/footer and page content each own their defined edges exactly once.
 - App-owned chronological route depth drives visible back and native swipe history.
 - A fresh cold entry replaces at depth zero; a validated in-session entry participates in ordinary history.
+- `apps/vela-mobile/docs/ios-interaction-baseline.md` remains the detailed evidence source for why this policy was selected; `ios-foundation-architecture.md` is the canonical stable policy reference for future feature work.
 
 ### 7.6 Audio
 
@@ -381,6 +445,7 @@ The final architecture document records these established boundaries.
 
 - Native-only validation may use authenticated development diagnostic routes and pages.
 - Production builds compile out diagnostic entries, labels, routes, test IDs, and markers.
+- `apps/vela-mobile/scripts/verify-production-diagnostics.mjs`, invoked through `verify:production-diagnostics`, remains the single authoritative forbidden-token implementation.
 - Production artifact scanning is a merge and milestone gate.
 
 ## 8. Findings, Severity, and Follow-up Issues
@@ -416,6 +481,7 @@ The final decision is exactly `GO` or `NO-GO`.
 All of the following must be true on the final tested commit:
 
 - automated repository, production asset, diagnostics-exclusion, and secret-scan gates pass;
+- the production mobile configuration is classified as `deployed`, passes the normal build validator, and matches the environment exercised by the native matrices;
 - native Simulator build, install, and launch pass;
 - physical iPhone install and launch pass;
 - fresh Google sign-in and warm/cold callback return pass;
@@ -427,11 +493,12 @@ All of the following must be true on the final tested commit:
 - expected auth, network, and playback failures recover to a stable state;
 - no Critical finding remains;
 - every deferred Medium or Low risk has a Linear issue and target milestone;
-- the architecture record has no unresolved decision required to begin M2.
+- the architecture record has no unresolved decision required to begin M2;
+- `CLAUDE.md` no longer describes implemented M1 OAuth work as future M2 work and links the final closeout records.
 
 ### 9.2 NO-GO conditions
 
-Report `NO-GO` when any required row is unrun, blocked without an accepted pre-M2 gate, failed, or invalidated by a later code change; when a secret scan fails; or when the audio architecture conclusion is not selected.
+Report `NO-GO` when any required row is unrun, blocked without an accepted pre-M2 gate, failed, or invalidated by a later code change; when a secret scan fails; when the production mobile configuration is missing, placeholder-only, or mismatched with the tested deployment; or when the audio architecture conclusion is not selected.
 
 `NO-GO` is a useful milestone result. It names the minimum issues that must close before rerunning the decision. HPA-210 remains open until a later run produces a complete `GO`.
 
@@ -448,6 +515,8 @@ After final verification:
    - concise M1 evidence summary;
    - accepted architecture limitations;
    - recommended first M2 issues.
+5. Synchronize `CLAUDE.md` as defined in §4.5 and link it to the final records.
+6. Keep `ios-interaction-baseline.md` as the historical HPA-209 evidence record; add only a concise closeout link/result if needed rather than copying the HPA-210 matrix into it.
 
 For a `GO`, the recommended M2 start is the smallest end-to-end core review path: mobile Home/Review navigation, a real ten-card SRS session, rating and pronunciation behavior, then durable outbox and backend idempotency. Exact issue order is confirmed from current M2 ticket readiness at closeout time.
 
@@ -484,8 +553,13 @@ Selected because it automates repeatable source/build/launch evidence while pres
 - No unresolved implementation decision is required to write the implementation plan.
 - No required evidence row is pre-declared as passing.
 - Automated and manual evidence have distinct ownership.
+- Existing HPA-209 detailed measurements remain canonical historical evidence; the architecture and final verification records do not duplicate them.
+- Production mobile environment prerequisites, live-versus-placeholder classification, and normal validator execution are explicit.
+- Existing package scripts and the authoritative production diagnostic scanner are named and reused.
+- Harness prerequisite failures and product-gate failures have distinct exit/manifest semantics.
 - Secret-handling rules cover source, artifacts, logs, and screenshots without rejecting legitimate source field names.
 - Source-ticket state semantics and HPA-210 ownership are explicit.
 - GO/NO-GO conditions are deterministic.
 - Deferred risks require Linear issues.
+- `CLAUDE.md` synchronization is an explicit closeout requirement.
 - Scope remains limited to M1 verification and architecture closeout.

--- a/docs/superpowers/specs/2026-08-02-mobile-ios-foundation-verification-design.md
+++ b/docs/superpowers/specs/2026-08-02-mobile-ios-foundation-verification-design.md
@@ -3,79 +3,57 @@
 **Linear:** HPA-210  
 **Parent:** HPA-194  
 **Milestone:** Mobile MVP — M1 iOS foundation spike  
-**Status:** Approved in project discussion; draft PR pending repository review
+**Status:** Approved in project discussion; repository review in PR #56
 
-## 1. Purpose
+## 1. Purpose and acceptance ownership
 
-HPA-210 is the acceptance owner for the complete Mobile MVP Milestone 1 foundation. It does not add another product feature. It verifies that the separately implemented foundation pieces work together on a real iOS runtime, records the architecture decisions established by the spike, and issues an explicit `GO` or `NO-GO` decision before Milestone 2 begins.
+HPA-210 is the single acceptance owner for the complete Mobile MVP Milestone 1 foundation. It does not add another product feature. It verifies that the separately implemented foundation pieces work together on real iOS runtimes, records the architecture established by the spike, and issues an explicit `GO` or `NO-GO` before Milestone 2 begins.
 
 The milestone exit story is:
 
-> A user installs Vela on an iPhone, signs in with Google, returns through the iOS callback, relaunches into a restored session, sees the authenticated due-review count, hears one Japanese pronunciation, and can recover from expected authentication, network, playback, keyboard, and navigation failures.
+> A user installs Vela on an iPhone, signs in with Google, returns through the iOS callback, relaunches into a restored session, sees the authenticated due-review count, hears one Japanese pronunciation, and recovers from expected authentication, network, playback, keyboard, and navigation failures.
 
-Automated tests establish source-level and artifact-level confidence. Simulator and physical-iPhone runs establish native behavior. Neither substitutes for the other.
+HPA-202 and HPA-205 through HPA-209 remain `In Review` until HPA-210 links evidence satisfying their native closure gates. They are related evidence sources, not formal blockers. HPA-203 and HPA-204 remain complete infrastructure inputs unless verification exposes a defect in their ownership area.
 
-## 2. Current State and Tracking Ownership
+An implementation PR may merge before native acceptance when its ticket explicitly separates merge and closure gates. HPA-210 may move to `Done` only after a complete `GO`, every deferred risk has a Linear issue, and HPA-194 receives the milestone summary. A complete `NO-GO` is preserved as useful evidence, but HPA-210 remains open for corrective work and rerun.
 
-The implementation work is present across HPA-202 through HPA-209. Several implementation pull requests merged while explicitly deferring live native acceptance. Their Linear issues therefore remain `In Review` until HPA-210 records the missing evidence:
+## 2. Design principles
 
-- HPA-202 — physical-device installation and launch.
-- HPA-205 — live Google OAuth and warm/cold callback behavior.
-- HPA-206 — relaunch restoration, refresh, sign-out, and reinstall cleanup.
-- HPA-207 — authenticated due-count and identity/cache isolation.
-- HPA-208 — Simulator and physical-iPhone pronunciation playback.
-- HPA-209 — physical Japanese IME and WKWebView navigation behavior.
+1. **One tested commit.** Every final row refers to one exact repository commit. A behavior-affecting fix invalidates and reruns the affected rows.
+2. **Observation, not inference.** Unit tests, media events, or Simulator behavior cannot be reported as physical speaker audibility, Japanese IME correctness, or native gesture success.
+3. **No pass by partial aggregation.** Strong automated coverage does not compensate for a missing physical exit criterion.
+4. **Two native build classes.** Production product behavior and development-only diagnostic behavior are verified separately on the same commit and deployed backend.
+5. **No secret-bearing evidence.** Source, artifacts, logs, screenshots, and manifests are scanned and sanitized.
+6. **One canonical source per fact class.** Stable architecture, final milestone results, and historical HPA-209 measurements link to one another instead of duplicating tables.
+7. **Failures produce tracked work.** Every failed or deferred criterion has severity, owner, target milestone, evidence, and a Linear issue.
 
-HPA-203 and HPA-204 remain complete configuration/infrastructure inputs unless verification exposes a defect in their ownership area.
+## 3. Repository artifacts and fact ownership
 
-HPA-210 is the single milestone acceptance owner. The source issues are related evidence sources rather than blockers. This avoids a circular dependency in which HPA-210 must perform evidence required to complete issues that formally block HPA-210.
-
-### Completion semantics
-
-- An implementation pull request may merge before native acceptance when its issue explicitly separates merge and closure gates.
-- An M1 source issue may be `Done` only after its required evidence exists or HPA-210 links a consolidated evidence row that satisfies it.
-- HPA-210 records both `GO` and `NO-GO` runs. It may transition to `Done` only after a complete `GO`, every deferred risk has a Linear issue, and HPA-194 receives the milestone summary. A complete `NO-GO` is preserved as evidence, but HPA-210 remains open for the corrective work and rerun.
-
-## 3. Design Principles
-
-1. **One tested commit.** All final matrices refer to one exact repository commit. Any fix invalidating observed behavior requires rerunning affected rows.
-2. **Observation, not inference.** A UI event, media event, automated test, or source review cannot be reported as physical speaker audibility, Japanese IME correctness, or native navigation success.
-3. **No secret-bearing evidence.** Logs, screenshots, environment manifests, and build artifacts are inspected and sanitized before commit or attachment.
-4. **Automate deterministic checks only.** Source, component, bundle, build, install, launch, and process assertions are automated. Human-dependent behavior remains a controlled manual matrix.
-5. **Preserve subsystem ownership.** HPA-210 consumes existing auth, API, query, audio, lifecycle, and navigation interfaces. It does not bypass them with a milestone-only implementation.
-6. **Failures produce tracked work.** A failed or deferred criterion has reproduction evidence, severity, owner, target milestone, and a Linear issue.
-7. **No milestone pass by partial aggregation.** Strong automated coverage does not compensate for a missing physical exit criterion.
-8. **One canonical source per fact class.** Historical measurement records, the stable architecture record, and the final milestone verification record link to one another instead of copying the same policy or evidence into competing documents.
-
-## 4. Repository Artifacts
-
-HPA-210 produces these durable artifacts.
-
-### 4.1 Architecture record
+### 3.1 Stable architecture record
 
 Create `apps/vela-mobile/docs/ios-foundation-architecture.md`.
 
-This document records stable decisions that later mobile features must follow:
+It records stable boundaries for:
 
-- authentication and token-storage ownership;
-- OAuth callback strategy and callback lifecycle;
-- absolute API-origin and CORS policy;
-- authenticated transport and query/cache isolation;
-- mobile lifecycle ownership;
+- mobile Cognito OAuth, PKCE, callback, and token-storage ownership;
+- absolute API origin, CORS, authenticated transport, and user-data isolation;
+- shared lifecycle ownership;
 - safe-area, keyboard, and navigation policy;
-- audio adapter boundary and the HPA-208 playback conclusion;
-- development diagnostic isolation from production artifacts;
+- `MobileAudioPlayer` and the final HPA-208 audio conclusion;
+- development diagnostic exclusion from production;
 - known constraints that intentionally survive M1.
 
-It is not a timestamped test report. Subsequent implementation changes must update it when they change a recorded boundary.
+The file may be scaffolded early, but its final factual claims are written or reconciled from the exact tested commit. The audio conclusion remains unset until physical verification selects one of:
 
-The existing `apps/vela-mobile/docs/ios-interaction-baseline.md` is not superseded or folded into this file. It remains the canonical detailed HPA-209 measurement and historical evidence record for the safe-area candidates, Simulator environments, navigation observations, and pending physical checks. The architecture record references that baseline as the measured rationale and extracts only the stable selected policy and reusable rules. It does not duplicate the baseline's numeric tables, screenshots, hashes, or environment rows.
+- `HTML-only accepted`
+- `native audio-session integration required`
+- `native player adapter required`
 
-### 4.2 Verification record
+`apps/vela-mobile/docs/ios-interaction-baseline.md` remains the canonical detailed HPA-209 measurement and historical evidence record. The architecture record links to it for rationale and extracts only the stable selected policy and reusable rules; it does not copy its numeric tables, screenshots, hashes, or old environment rows.
 
-Create `apps/vela-mobile/docs/m1-ios-foundation-verification.md`.
+### 3.2 Final verification record
 
-Use these top-level sections:
+Create `apps/vela-mobile/docs/m1-ios-foundation-verification.md` with:
 
 ```markdown
 # M1 iOS Foundation Verification
@@ -83,7 +61,8 @@ Use these top-level sections:
 ## Final Decision
 ## Tested Build and Environment
 ## Automated Verification
-## Simulator Matrix
+## Production Smoke Matrix
+## Diagnostic Observation Matrix
 ## Physical iPhone Matrix
 ## Security and Secret Scan
 ## Architecture Decisions
@@ -92,474 +71,353 @@ Use these top-level sections:
 ## Milestone 2 Recommendation
 ```
 
-The file is initially a complete schema and instruction set, not a pre-filled claim. A result row is added only after that environment and scenario has been run.
+Rows are added only after they are run. `Architecture Decisions` is a concise tested-revision summary and pointer to `ios-foundation-architecture.md`, not a second copy. Existing HPA-209 Simulator rows remain historical evidence; HPA-210 records fresh load-bearing rows on the final tested commit.
 
-The `Architecture Decisions` section is a concise tested-revision summary and pointer to `ios-foundation-architecture.md`, not a second copy of the decisions. It records the architecture document path and commit, the final HPA-208 audio conclusion, and any decision changed by the verification run.
+### 3.3 Versioned evidence and manifests
 
-Existing HPA-209 Simulator rows and screenshots remain in `ios-interaction-baseline.md` and `docs/evidence/hpa-209/`; they are cross-referenced as historical evidence rather than migrated or copied. Because HPA-210 requires one final tested commit, those historical rows cannot by themselves satisfy a `GO`. The final HPA-210 record contains fresh closure rows for the load-bearing behavior on the final tested commit, while linking the earlier detailed measurements for rationale and comparison.
+Store append-only evidence under:
 
-### 4.3 Evidence directory
+```text
+apps/vela-mobile/docs/evidence/hpa-210/<full-commit-sha>/<run-id>/
+```
 
-Create `apps/vela-mobile/docs/evidence/hpa-210/` for sanitized, repository-worthy evidence.
+`<run-id>` is `<UTC timestamp>-<phase-or-matrix-class>`, such as `20260803T021500Z-production-smoke`. Runs never overwrite one another, and no mutable `latest` symlink is used. The verification record identifies the selected final run IDs while preserving earlier `NO-GO` runs.
 
-Allowed evidence includes:
+Each run directory contains `manifest.json` and may contain sanitized screenshots, bounded logs, command output, and hashes for larger local-only artifacts.
 
-- screenshots without personal account data or transient OAuth values;
-- bounded console excerpts with sensitive values removed;
-- generated non-secret environment manifests;
-- command output needed to prove build, install, or launch;
-- hashes identifying larger local-only artifacts that should not be committed.
+The manifest records:
 
-Do not commit DerivedData, full Xcode archives, raw device logs, provider API responses, bearer tokens, refresh tokens, authorization codes, PKCE verifiers, presigned query strings, account email addresses, or device identifiers that are unnecessary for reproduction.
+- schema version, run ID, commit, phase, matrix class, timestamps, outcome, and exit code;
+- non-secret host, Xcode, iOS, Bun, Quasar, Capacitor, and plugin versions;
+- configuration source/class and public origins;
+- non-secret device or Simulator alias/model;
+- bounded command statuses and elapsed times;
+- evidence paths and SHA-256 hashes;
+- finding and Linear-issue references.
 
-### 4.4 Verification harness
+It never records a device UDID, account email, complete environment, full OAuth callback URL, token, code, verifier, provider response, or presigned query string. Do not commit DerivedData, archives, raw device logs, or credential-bearing responses.
 
-Add `apps/vela-mobile/scripts/verify-m1-foundation.mjs` with a package script named `verify:m1-foundation`.
+### 3.4 Developer guidance synchronization
 
-The harness exposes explicit phases rather than silently skipping unsupported checks:
+HPA-210 updates `CLAUDE.md`:
 
-- `--phase automated` — cross-platform source, tests, production assets, diagnostics exclusion, and secret scanning.
-- `--phase ios-simulator` — macOS-only native build, install, launch, and process assertion.
-- `--phase all` — runs both and fails when native prerequisites are unavailable.
+- replace the stale statement that PKCE, `state`, `nonce`, mobile client wiring, and `identity_provider=Google` are future M2 work;
+- point pending HPA-209 physical validation to HPA-210;
+- after closeout, link the final architecture and verification records instead of copying their matrices.
 
-CI may run `--phase automated` on Linux. The milestone closure record must include a successful macOS `--phase ios-simulator` or `--phase all` run against the final tested commit.
+Before PR #56 leaves draft review, update this design header to reflect repository approval. It must not claim repository review is pending after merge.
 
-The harness uses stable process exits and matching manifest outcomes:
+## 4. Verification harness
 
-- exit `0`, outcome `passed` — every requested gate passed;
-- exit `2`, outcome `usage_error` — invalid CLI arguments or unsupported phase selection;
-- exit `3`, outcome `prerequisite_missing` — required host capability, tool, Simulator, signing/configuration input, or production mobile environment is unavailable;
-- exit `4`, outcome `gate_failed` — a test, build, scan, install, launch, or expected-artifact assertion failed;
-- exit `1`, outcome `harness_error` — an unexpected harness implementation or manifest-write failure.
+Add `apps/vela-mobile/scripts/verify-m1-foundation.mjs` and package script `verify:m1-foundation`.
 
-A missing prerequisite is never reported as a passing or failed product check. The manifest records the failed preflight without dumping command environments or sensitive values.
+### 4.1 Phases
 
-### 4.5 Guidance synchronization
+- `--phase automated` — clean-install, root repository gates, production assets, diagnostic exclusion, secret scan, and manifest.
+- `--phase ios-simulator` — macOS Simulator build, install, launch, and process-alive smoke.
+- `--phase ios-physical-preflight` — connected-device, trust, Developer Mode, signing, and build-setting readiness; it does not replace human observation.
+- `--phase all` — all machine-checkable phases; it requires the configured physical device.
 
-HPA-210 also updates `CLAUDE.md` as a closeout artifact:
+Linux CI may run `automated`. Final closure requires successful `automated`, `ios-simulator`, and `ios-physical-preflight` manifests on the same commit, plus both manual native matrix classes.
 
-- replace the stale statement that mobile PKCE, `state`, `nonce`, client-ID wiring, and `identity_provider=Google` are future M2 work with the implemented HPA-205 architecture and the remaining live acceptance gates;
-- keep the HPA-209 physical-device note while evidence is pending, but point it to HPA-210 as the consolidated closure owner;
-- after physical verification, replace the pending note with a concise result and links to the final architecture and verification records rather than silently deleting the historical context.
+### 4.2 Exit and outcome contract
 
-`CLAUDE.md` remains developer guidance. It links to the canonical architecture and evidence documents instead of reproducing their full matrices.
+- exit `0`, `passed`
+- exit `2`, `usage_error`
+- exit `3`, `prerequisite_missing`
+- exit `4`, `gate_failed`
+- exit `1`, `harness_error`
 
-## 5. Automated Verification Design
+Missing tools, configuration, Simulator, device, trust, Developer Mode, signing team, or provisioning are prerequisites, not product failures. The harness records the failed preflight without dumping sensitive inputs.
 
-### 5.1 Cross-platform phase
+## 5. Automated verification
 
-The automated phase runs from a clean checkout with a frozen lockfile and invokes the established repository/package entry points:
+### 5.1 Final monorepo freeze gates
 
-1. `bun install --frozen-lockfile`;
-2. `bun run lint`;
-3. `bun run typecheck`;
-4. `bun run test`;
-5. `bun run --cwd apps/vela-mobile verify:production-diagnostics`;
-6. the HPA-210 secret/token scan over committed mobile files, generated production assets, selected native resources, and staged evidence;
-7. generation of a non-secret command/result manifest.
+The final automated phase runs:
 
-`verify:production-diagnostics` is the authoritative production mobile asset and diagnostic-exclusion gate. It invokes the existing `build:ios:assets` package script and then `apps/vela-mobile/scripts/verify-production-diagnostics.mjs`. The HPA-210 harness calls this package script and does not copy, reinterpret, or maintain a second forbidden-token list.
+1. `bun install --frozen-lockfile`
+2. `bun run lint`
+3. `bun run typecheck`
+4. `bun run test`
+5. `bun run --cwd apps/vela-mobile verify:production-diagnostics`
+6. HPA-210 secret scanning
+7. manifest generation
 
-The harness captures command name, exit status, start/end timestamps, tested commit, and relevant artifact paths. It does not capture command environments wholesale.
+The root gates are intentional: HPA-210 must not declare the shared frozen commit ready while another workspace is red. Focused mobile/common/API/CDK commands are encouraged during implementation, but do not replace fresh root gates. Because Turbo skips packages without a requested script, the manifest records actual tasks executed rather than implying every package has its own typecheck target.
 
-### 5.2 Secret and token scan
+`verify:production-diagnostics` is authoritative for production mobile assets and diagnostic exclusion. It invokes `build:ios:assets` and `apps/vela-mobile/scripts/verify-production-diagnostics.mjs`. The HPA-210 harness calls that package script and never forks its forbidden-token list.
 
-The scan covers:
+### 5.2 Secret scan ownership
 
-- tracked source and configuration under `apps/vela-mobile`;
-- generated `src-capacitor/www` assets;
-- iOS plist, entitlements, project, and resolved package configuration;
-- selected Xcode build settings and application bundle resources;
-- evidence files staged for HPA-210;
-- captured logs selected for attachment.
+Create one pure policy module:
 
-Source and configuration scanning looks for embedded credential values, forbidden persistence targets, unsafe logging/rendering paths, and known leakage sentinels. Legitimate source identifiers such as `codeVerifier`, `authorizationCode`, or token type names do not fail merely because the code defines or handles those fields.
+`apps/vela-mobile/src/security/mobile-secret-policy.ts`
 
-Runtime output, generated artifacts, and evidence are checked for:
+It contains sentinel classes, credential-like patterns, public-identifier allowlists, and bounded false-positive classifications without DOM or Vitest dependencies.
 
-- OAuth authorization-code or PKCE-verifier values;
-- `Authorization: Bearer` values;
-- JWT-shaped values outside documented mock/sentinel fixtures;
-- Cognito refresh/access/ID token material outside the approved secure-storage boundary;
-- provider API-key names paired with non-placeholder values;
-- AWS secret values or private keys;
-- full presigned TTS URLs containing query credentials;
-- known test sentinels used by existing leakage tests;
-- development diagnostic route labels or markers in production assets.
+Create the executable scanner:
 
-Configuration identifiers that are intentionally public—Cognito pool IDs, public client IDs, regions, callback schemes, API origins, and non-secret provider/model identifiers—are not treated as secrets. The scan must distinguish these from credentials.
+`apps/vela-mobile/scripts/scan-mobile-secrets.mjs`
 
-A finding fails the phase until it is removed or explicitly classified as a verified false positive in the verification record with the matching bounded value class. Raw credential-like values are never copied into that explanation.
+It exports its scan function for tests and is invoked by `verify-m1-foundation.mjs`. Both the scanner and existing `src/test/secret-leak-helpers.ts` consume the shared policy.
+
+- `secret-leak-helpers.ts` remains the runtime log/DOM/storage assertion adapter.
+- `scan-mobile-secrets.mjs` owns tracked-source, generated-artifact, native-resource, captured-log, and evidence-file inspection.
+
+The scan checks for embedded credentials, unsafe logging/rendering, bearer values, JWT-shaped values outside mock fixtures, provider/AWS keys, private keys, token material outside the approved storage boundary, full presigned URLs, and known leakage sentinels. Public pool/client IDs, regions, callback schemes, API origins, and non-secret provider/model identifiers remain allowed.
+
+A finding fails until removed or classified by bounded value class; raw credential-like values are never copied into the record.
 
 ### 5.3 Production mobile configuration prerequisite
 
-Every phase that produces production WebView assets preflights the complete build-time mobile configuration before invoking Quasar. The required variables are:
+Any production asset phase preflights all five build variables using the same precedence and validation contract as `build/validate-mobile-api-url.ts`:
 
-- `VITE_MOBILE_API_URL`;
-- `VITE_COGNITO_USER_POOL_ID`;
-- `VITE_COGNITO_MOBILE_USER_POOL_CLIENT_ID`;
-- `VITE_COGNITO_OAUTH_DOMAIN`;
-- `VITE_AWS_REGION`.
+- `VITE_MOBILE_API_URL`
+- `VITE_COGNITO_USER_POOL_ID`
+- `VITE_COGNITO_MOBILE_USER_POOL_CLIENT_ID`
+- `VITE_COGNITO_OAUTH_DOMAIN`
+- `VITE_AWS_REGION`
 
-The values may come from `apps/vela-mobile/.env.production`, normally generated by `packages/cdk/scripts/inject-env.ts` after deployment outputs exist, or from explicit process environment values. The harness must use the same precedence and validation contract as `apps/vela-mobile/build/validate-mobile-api-url.ts`.
+They may come from generated `.env.production` or explicit process environment values. Missing or malformed values are `prerequisite_missing` before Quasar runs.
 
-The harness reports a missing or malformed contract as `prerequisite_missing` before the production build begins. It does not rely on the later Vite exception as the user-facing diagnosis.
+For closure:
 
-For the final HPA-210 Simulator and physical-device closure run:
-
-- the normal `validate-mobile-api-url` path must execute;
+- normal validation must execute;
 - `MOBILE_SKIP_ENV_VALIDATION=true` is forbidden;
-- values must identify the deployed environment under test;
-- CI/example placeholders such as `example.invalid` cannot satisfy a `GO`.
+- the values must identify the deployed environment under test;
+- `example.invalid`, localhost, placeholders, or a different backend/client cannot satisfy `GO`.
 
-Compile-only CI may provide documented non-secret placeholders while still exercising the normal validation path. Such a run is marked `placeholder` and may support automated build confidence, but it is not closure evidence for authenticated or native behavior.
+Compile-only CI may use documented placeholders while exercising the normal validator; that run is classified `placeholder`, not closure evidence.
 
-The non-secret manifest records:
+The manifest records config source (`.env.production` or `process_env`), class (`deployed` or `placeholder`), API origin, region, OAuth domain, and public identifier consistency—never the complete environment.
 
-- `mobileConfigSource`: `.env.production` or `process_env`;
-- `mobileConfigClass`: `deployed` or `placeholder`;
-- API origin;
-- AWS region;
-- OAuth domain;
-- whether public pool/client identifiers were present and internally consistent.
+### 5.4 Simulator and physical preflights
 
-It does not dump the complete environment or any credentials.
+The Simulator phase records tool/runtime versions, uses the `iphonesimulator` SDK, and does not require a development team. The implementation plan uses `CODE_SIGNING_ALLOWED=NO` where supported.
 
-### 5.4 Native Simulator launch phase
+The physical path uses a development-team-signed personal iPhone controlled by the tester. The committed project keeps automatic signing and no `DEVELOPMENT_TEAM`.
 
-The macOS phase:
+Physical preflight:
 
-1. preflights the complete production mobile configuration from §5.3;
-2. records `git rev-parse HEAD`, `xcodebuild -version`, `bun --version`, resolved Quasar/Capacitor/plugin versions, selected Simulator model, and Simulator iOS runtime;
-3. ensures the authoritative `verify:production-diagnostics` gate has passed for the same commit and production configuration;
-4. synchronizes Capacitor without replacing the verified WebView assets;
-5. builds the `App` scheme from `App.xcworkspace` for an explicit Simulator destination;
-6. boots the selected Simulator when required;
-7. installs the built application bundle;
-8. launches the application by bundle identifier;
-9. asserts that launch succeeds and the process remains alive for the bounded smoke interval;
-10. captures bounded launch output and writes the environment/result manifest;
-11. terminates only the test-launched application process.
+1. resolves a connected device through `xcrun devicectl list devices`;
+2. confirms availability, trust, and Developer Mode;
+3. runs `xcodebuild -showBuildSettings` for `App.xcworkspace`, scheme `App`, Debug configuration, and the physical destination;
+4. requires a resolved non-empty `DEVELOPMENT_TEAM` and usable signing/provisioning;
+5. records only a non-secret device alias/model and whether signing resolved.
 
-The native launch check proves project integrity, installation, and startup. It does not claim authenticated OAuth, TTS audibility, Japanese input, or navigation behavior.
+The team may come from an explicit local input, untracked xcconfig, or Xcode user configuration. The harness never writes it into the committed project. Missing device/signing readiness is exit `3`. Physical build/install/launch may be captured through Xcode or `xcodebuild` plus `devicectl`; Linux CI never claims it.
 
-### 5.5 CI boundary
+### 5.5 Verified WebView asset immutability
 
-M1 does not add a permanent macOS native-test job solely to close HPA-210. The existing Linux mobile test job continues to run automated source and asset checks. A permanent macOS CI lane, native UI automation, signing automation, and TestFlight automation remain release-readiness work under HPA-194 Milestone 5.
+After `verify:production-diagnostics` produces and scans `src-capacitor/www`, no Quasar build may run before the corresponding production smoke.
 
-## 6. Verification Matrix Design
+When an explicit sync is needed, use:
 
-Every environment table includes:
+```bash
+cd apps/vela-mobile/src-capacitor
+bunx cap sync ios
+```
 
-- exact commit SHA;
-- date and local time zone;
-- build configuration;
-- packaged assets or development server source;
-- Simulator/device model;
-- iOS version;
-- Xcode version;
-- app version/build number;
-- non-secret account alias;
-- production mobile configuration source and class;
-- scenario precondition;
-- observed result;
-- `PASS`, `FAIL`, or `BLOCKED` status;
-- evidence path or bounded note;
-- follow-up issue for every `FAIL` or accepted `BLOCKED` row.
+Hash `src-capacitor/www` before and after sync and fail if it changes. `cap sync` may copy from the configured `webDir` and run CocoaPods; it must not rebuild or replace the verified artifact.
 
-`PARTIAL` is allowed during work but cannot satisfy a closure criterion.
+Permanent macOS CI, native UI automation, signing automation, and TestFlight remain HPA-194 Milestone 5 work.
 
-### 6.1 Installation and authentication lifecycle
+## 6. Native matrix classes
 
-Run on the final Simulator and physical iPhone where applicable:
+HPA-210 requires both build classes on the same commit and against the same deployed API, user pool, mobile client, OAuth domain, and region.
 
-1. fresh application installation and first launch;
-2. fresh Google sign-in using the system browser;
-3. direct-provider redirect and callback return;
-4. warm callback while the app process is active;
-5. cold-start callback launching the app;
-6. cancellation recovery;
-7. missing-code, provider-error, malformed-callback, and state-mismatch recovery;
-8. late or duplicate callback behavior;
-9. force-close and relaunch restoration without another Google prompt;
-10. proactive refresh and app-resume refresh;
-11. revoked/non-refreshable session recovery;
-12. local sign-out;
-13. relaunch after sign-out remains signed out;
-14. reinstall residue cleanup where Keychain retention would otherwise restore the prior installation.
+| Matrix class | Build | Config | What it proves |
+| --- | --- | --- | --- |
+| Production smoke | Release/production Capacitor assets that passed `verify:production-diagnostics` | `deployed` | artifact/secret gates; install/launch; product OAuth, restoration, Home/due-count, sign-out, and product-surface recovery |
+| Diagnostic observation | Debug development via `bun run dev:ios`, `quasar dev -m capacitor -T ios`, or equivalent packaged Debug-development build | same deployed API/Cognito identity | authenticated TTS diagnostic, Japanese IME, keyboard, safe-area, orientation, and navigation probes |
+| Final GO | union of both | same commit and backend identity | complete milestone decision |
 
-Successful OAuth evidence records state transitions and outcomes, never codes, verifiers, tokens, or complete callback URLs.
+Debug diagnostics may call the deployed API and Cognito endpoints. Their config source is recorded. They must not use placeholders, localhost, an unrelated client/backend, or validation bypass for closure. Diagnostics remain absent from the production artifact; the production scan is never relaxed.
 
-### 6.2 Authenticated API and due-count behavior
+### 6.1 Environment ownership
+
+| Scenario | Simulator role | Physical requirement |
+| --- | --- | --- |
+| Build/install/launch/process alive | required automated smoke | required production-smoke install and launch |
+| Fresh Google sign-in; direct-provider, warm, and cold callback | supplemental where interaction works | required for `GO` |
+| Relaunch, refresh, due-count, sign-out, auth/network recovery | supplemental | required for `GO` |
+| TTS state/error/replay controller | supplemental diagnostic evidence | correct speaker pronunciation, replay reliability, silent mode, and interruption are physical-only |
+| Japanese Kana IME, edge swipe, sensor-region safe areas | historical/focused Simulator evidence supports diagnosis | physical observation required |
+| Diagnostic exclusion and artifact secret scan | automated artifact gate, no UI claim | the same scanned artifact is used for physical production smoke |
+
+A Simulator-only OAuth, restoration, due-count, TTS, IME, or navigation result never satisfies the physical milestone criterion.
+
+### 6.2 Common fields
+
+Every row records commit, timestamp/time zone, matrix class, build configuration, asset source, model, OS, Xcode, app version/build, non-secret account/device alias, config source/class, precondition, observation, status (`PASS`, `FAIL`, `BLOCKED`, or working-only `PARTIAL`), evidence path, and follow-up issue.
+
+`PARTIAL` cannot satisfy closure.
+
+## 7. Required scenarios
+
+### 7.1 Production installation, auth, and session lifecycle — physical required
+
+- fresh install and first launch;
+- fresh Google sign-in in the system browser;
+- direct-provider redirect;
+- warm and cold-start callbacks;
+- cancellation, missing code, provider error, malformed callback, state mismatch, late/duplicate callback;
+- force-close and relaunch restoration;
+- proactive and resume refresh;
+- revoked/non-refreshable session recovery;
+- sign-out and signed-out relaunch;
+- reinstall residue cleanup.
+
+Evidence records transitions and outcomes, never codes, verifiers, tokens, or full callback URLs.
+
+### 7.2 Authenticated due-count — physical required
+
+- restored auth reaches Home;
+- positive and zero `due_today`;
+- timestamped comparison with web/API;
+- loading and manual refresh;
+- foreground refresh;
+- disabled network, timeout, server failure, malformed response, and retry;
+- rejected/expired-token recovery;
+- terminal auth returns to the auth gate;
+- sign-out clears prior-user data;
+- a second account cannot see prior cached data;
+- pending requests do not block sign-out or lifecycle cleanup.
+
+### 7.3 TTS diagnostic and physical audio
+
+Use the fixed HPA-208 diagnostic vocabulary and verify preparation, server cache, uncached generation, loading, first-tap, prepared replay, ten replays, rapid taps, auth/generation/network/expiry/decoding failures, background/foreground, sign-out, interruption, and relaunch.
+
+Physical-only observations include correct built-in-speaker pronunciation, replay reliability, silent mode, and system interruption.
+
+For silent-mode rows:
+
+- keep media volume nonzero;
+- record device model and control used;
+- use the Ring/Silent switch when present;
+- on Action Button devices, use an Action Button configured for Silent Mode or the system Silent Mode control and confirm the system indicator;
+- Focus mode alone is not the silent-mode control.
+
+Media events never substitute for human audibility.
+
+### 7.4 Japanese input, keyboard, safe area, and navigation — physical required
+
+Use a development-team-signed personal iPhone controlled by the tester, with a notch or Dynamic Island for safe-area rows. Record aliases, not email or UDID.
 
 Verify:
 
-1. restored authentication reaches Home;
-2. positive `due_today` agrees with the web app or a direct authenticated API observation for the same account and time window;
-3. zero-due state renders correctly;
-4. loading and explicit manual refresh behavior;
-5. foreground/resume refresh;
-6. disabled-network failure and successful retry;
-7. request timeout recovery;
-8. server failure and malformed-response handling;
-9. rejected/expired token recovery;
-10. terminal authentication failure returns to the auth gate;
-11. sign-out removes the previous user’s due-count data;
-12. signing in as another account cannot show the previous account’s cached data;
-13. a pending request cannot block sign-out or lifecycle cleanup.
+- Japanese Kana composition;
+- draft, committed model, post-render native value, and submitted value all equal `日本語`;
+- no validation/submission while composing;
+- focused input and primary action remain reachable in portrait and landscape;
+- keyboard dismissal restores viewport/footer without stale gap;
+- top/bottom and landscape sensor-region safe areas;
+- visible back, native swipe back/forward, repeated tabs, deep entry, cold entry, resume no-op, scroll restoration, and no blank frame, exit, or trap.
 
-Where a comparison value may change during testing, record both values and timestamps rather than requiring a stale screenshot to remain numerically equal later.
+The expected policy remains `ios.contentInset: "never"` with CSS headerless-top ownership and app-owned chronological route depth. `ios-interaction-baseline.md` remains the detailed historical rationale; HPA-210 records final-commit closure rows.
 
-### 6.3 TTS pronunciation behavior
+### 7.5 Failure-state recovery
 
-Use the fixed non-secret diagnostic vocabulary established by HPA-208 and verify:
+Expected bounded outcomes are retry in place, stable signed-out gate, stopped/replayable audio, valid route recovery, or an actionable terminal state without protected-content leakage.
 
-1. restored authentication and configured TTS settings;
-2. first server-cache request;
-3. genuinely uncached generation;
-4. loading/preparation state;
-5. first user-gesture playback attempt;
-6. prepared direct-tap playback;
-7. correct and audible Japanese pronunciation through the physical iPhone speaker;
-8. ten prepared replays without intermittent silence, overlap, or stuck state;
-9. rapid taps during preparation and playback;
-10. authentication failure;
-11. TTS generation failure;
-12. disabled-network failure and retry;
-13. expired or invalid presigned URL recovery;
-14. playback decoding/error recovery;
-15. background during preparation and playback;
-16. foreground replayability;
-17. sign-out while ready and while playing;
-18. external/system audio interruption;
-19. Ring/Silent off behavior;
-20. Ring/Silent on behavior;
-21. relaunch and replay.
+Milestone failures include indefinite loading, protected-content flash, cross-user cached data, ordinary-tap audio overlap, blank frame/app exit/navigation trap, unrecoverable keyboard obstruction, or credentials/transient OAuth material in UI, logs, source, or artifacts.
 
-Human observation is required for audibility and pronunciation correctness. Media events alone are insufficient.
+## 8. Architecture boundaries to record from the tested commit
 
-The resulting architecture decision is exactly one of:
+- Dedicated public mobile Cognito client; authorization code plus PKCE; system browser; app-owned warm/cold/late/malformed/duplicate callback handling.
+- Only the refresh token needed for restoration in device-bound non-synchronizing Keychain; access/ID tokens memory-only; installation marker prevents stale reinstall restoration.
+- Auth initialization gates protected rendering; sign-out and terminal recovery clear retained credentials and scoped feature state.
+- Absolute validated native API origin; exact Capacitor CORS, no wildcard; auth coordinator owns bearer injection and bounded single-flight unauthorized recovery.
+- User-scoped query keys; cancel/remove prior-user data without global cache clearing.
+- One shared Capacitor lifecycle service; resume alone is not navigation.
+- Native inset `never`; CSS/fixed surfaces own each safe-area edge once; app-owned route depth.
+- Learning features depend on `MobileAudioPlayer`; `HtmlAudioPlayer` is the current candidate; physical evidence selects the final audio architecture.
+- Development diagnostics are compiled out of production, and `verify-production-diagnostics.mjs` remains the authoritative forbidden-token implementation.
 
-- `HTML-only accepted`
-- `native audio-session integration required`
-- `native player adapter required`
+## 9. Findings and severity
 
-If silent mode is the only failed requirement and HTML decoding/lifecycle are otherwise reliable, create a narrowly scoped native audio-session issue while retaining `HtmlAudioPlayer`. If HTML playback remains unreliable after correct origin and audio-session handling, create a native `MobileAudioPlayer` implementation issue naming each failed criterion.
+Every unresolved finding records criterion, severity, environment/commit, reproduction, expected/observed behavior, bounded evidence, owner, target milestone, and Linear issue.
 
-### 6.4 Japanese input, keyboard, safe area, and navigation
+- **Critical:** credential exposure, cross-user leakage, unusable auth, unrecoverable corruption, or unresolved architecture ambiguity. Always blocks `GO`.
+- **High:** failure of a physical M1 exit behavior. Blocks `GO` by default.
 
-Verify on a physical iPhone:
+The only High reclassification is the explicit audio fork: if correct audible pronunciation, replay, decoding, and lifecycle recovery pass and silent-mode policy is the sole failure, `native audio-session integration required` may become a pre-M2 gate. Its Linear issue must be High and block the first M2 review issue depending on audio.
 
-1. Japanese Kana keyboard composition;
-2. draft composition, committed model, native input value after render, and submitted value all equal `日本語`;
-3. no validation or submission while composition is active;
-4. focused input remains visible in portrait;
-5. focused input and primary action remain reachable in landscape;
-6. keyboard dismissal restores the viewport and footer without a stale gap;
-7. top and bottom safe areas on a notched or Dynamic Island device;
-8. left and right landscape sensor-region avoidance;
-9. visible back returns to the exact previous app route;
-10. native swipe-back and swipe-forward behavior;
-11. repeated tab switching does not duplicate, blank, close, or trap the app;
-12. validated in-session deep entry;
-13. cold deep entry at depth zero;
-14. app resume without a new entry event is a navigation no-op;
-15. saved scroll restoration on back and forward;
-16. portrait functionality and the documented landscape policy.
+`native player adapter required`, unaudible core playback, OAuth/session restoration, due-count/data isolation, IME, keyboard obstruction, safe-area failure, and navigation traps remain hard `NO-GO`.
 
-The expected baseline remains native `ios.contentInset: "never"` with app CSS owning the headerless top safe area, fixed surfaces owning their appropriate insets, and app-owned chronological mobile navigation depth. `ios-interaction-baseline.md` remains the canonical detailed measurement record; the final HPA-210 rows verify the load-bearing behavior on the final tested commit and link back to that baseline.
+- **Medium:** bounded limitation that does not invalidate the exit story and has an M2 or release-readiness issue.
+- **Low:** safely deferred polish or observability issue.
 
-### 6.5 Failure-state recovery
+Prose-only deferral is forbidden.
 
-For auth, API, playback, and navigation failures, verify that the app has one of these bounded outcomes:
+## 10. GO / NO-GO
 
-- retry in place;
-- return to a stable signed-out gate;
-- stop active media and remain replayable;
-- return to a valid route;
-- explain the unsupported or terminal state without protected-content leakage.
+### 10.1 GO requires
 
-The following are milestone failures:
+- fresh root monorepo lint, typecheck, tests, production assets, diagnostic exclusion, and secret scan;
+- deployed production config through the normal validator;
+- production-smoke and diagnostic-observation classes on the same commit/backend;
+- Simulator build/install/launch;
+- physical signing preflight and production install/launch;
+- physical fresh Google sign-in, warm/cold callbacks, and relaunch restoration;
+- correct identity-isolated due-count;
+- an acceptable physical Japanese pronunciation path;
+- Japanese IME and non-trapping keyboard/safe-area/navigation results;
+- stable recovery for expected auth/network/playback failures;
+- no Critical finding;
+- every deferred Medium/Low risk tracked;
+- any permitted silent-mode High issue blocks the first dependent M2 issue;
+- tested-commit architecture record complete;
+- `CLAUDE.md` synchronized.
 
-- indefinite loading without a recovery action;
-- protected content briefly shown before auth restoration completes;
-- another user’s cached data shown;
-- duplicated or overlapping playback caused by ordinary taps;
-- a blank frame, app exit, or navigation trap;
-- unrecoverable keyboard obstruction;
-- credentials or transient OAuth material in visible UI, logs, source, or artifacts.
+### 10.2 NO-GO
 
-## 7. Architecture Record
+Report `NO-GO` when a required row is unrun, blocked without the narrow silent-mode audio gate, failed, invalidated by later code, uses placeholder/mismatched config, fails a secret scan, or lacks an audio conclusion.
 
-The final architecture document records these established boundaries.
+A `NO-GO` names the minimum corrective issues and preserves its evidence. HPA-210 remains open until a later complete `GO`.
 
-### 7.1 Authentication and storage
+## 11. Closeout updates
 
-- The mobile app uses a dedicated public Cognito client with authorization-code grant and PKCE.
-- Google authentication occurs through the system browser.
-- The app owns warm, cold, late, malformed, and duplicate callback handling.
-- Only the refresh token required for restoration is retained in device-bound, non-synchronizing iOS Keychain storage.
-- Access and ID tokens remain memory-only.
-- Installation identity prevents stale Keychain material from restoring a previous installation.
-- Auth initialization gates protected routing and rendering.
-- Sign-out and terminal recovery clear retained credentials and user-scoped feature state.
+After verification:
 
-### 7.2 API origin and transport
+1. Comment on HPA-202 and HPA-205 through HPA-209 with tested commit, relevant rows, result, and follow-up.
+2. Return a source issue to `Done` only when its evidence is satisfied.
+3. Update HPA-210 with architecture, verification, selected run IDs, evidence, implementation PR, and follow-ups.
+4. Update HPA-194 with `GO`/`NO-GO`, commit/device summary, M1 evidence, limitations, and recommended first M2 issues.
+5. Synchronize `CLAUDE.md`.
+6. Preserve `ios-interaction-baseline.md` as historical evidence and add only a closeout link/result if useful.
+7. Preserve earlier evidence run directories.
+8. Finalize the architecture record from the tested commit and selected audio result.
+9. Update this design status to reflect completed repository review before merge.
 
-- Native builds use an absolute validated API base URL.
-- Approved Capacitor origins are exact; wildcard CORS is forbidden.
-- Existing web and extension origin behavior remains intact.
-- Feature code does not receive raw token-storage ownership.
-- The auth coordinator injects one current bearer token, bounds attempts, performs guarded single-flight unauthorized recovery, and prevents stale-generation mutation.
-- Feature requests do not block sign-out or coordinator disposal.
+For `GO`, begin M2 with the smallest end-to-end review path: Home/Review navigation, ten-card SRS, rating/pronunciation, then durable outbox and backend idempotency.
 
-### 7.3 Query and user-data isolation
+## 12. Non-goals
 
-- Shared contracts and query keys may be reused without importing complete web pages.
-- User-specific query keys contain the user identity.
-- Identity loss and sign-out cancel then remove only the previous user’s scoped data.
-- No global query-cache clearing is introduced solely for this milestone.
-
-### 7.4 Lifecycle
-
-- One shared Capacitor lifecycle service owns app active/inactive observation.
-- Auth refresh, due-count refresh, and audio interruption consume that shared state rather than registering competing native listeners.
-- Resume is not itself a navigation event.
-
-### 7.5 iOS layout and navigation
-
-- Native content inset is `never`.
-- CSS owns the headerless top safe area; fixed toolbar/footer and page content each own their defined edges exactly once.
-- App-owned chronological route depth drives visible back and native swipe history.
-- A fresh cold entry replaces at depth zero; a validated in-session entry participates in ordinary history.
-- `apps/vela-mobile/docs/ios-interaction-baseline.md` remains the detailed evidence source for why this policy was selected; `ios-foundation-architecture.md` is the canonical stable policy reference for future feature work.
-
-### 7.6 Audio
-
-- Learning features depend on the browser-free `MobileAudioPlayer` contract.
-- `HtmlAudioPlayer` is the current implementation candidate.
-- The physical verification result determines whether HTML remains sufficient, requires minimal native audio-session configuration, or must be replaced by a native player adapter.
-- Provider credentials remain server-side and no provider API key is bundled in the app.
-
-### 7.7 Diagnostics
-
-- Native-only validation may use authenticated development diagnostic routes and pages.
-- Production builds compile out diagnostic entries, labels, routes, test IDs, and markers.
-- `apps/vela-mobile/scripts/verify-production-diagnostics.mjs`, invoked through `verify:production-diagnostics`, remains the single authoritative forbidden-token implementation.
-- Production artifact scanning is a merge and milestone gate.
-
-## 8. Findings, Severity, and Follow-up Issues
-
-Every unresolved finding contains:
-
-- concise title;
-- affected criterion;
-- severity;
-- exact environment and tested commit;
-- reproduction steps;
-- observed and expected behavior;
-- bounded evidence reference;
-- owner;
-- target milestone;
-- Linear issue.
-
-Severity policy:
-
-- **Critical:** credential exposure, cross-user data leakage, unusable authentication, unrecoverable corruption, or an unresolved architecture ambiguity that prevents safe M2 work. Always blocks `GO`.
-- **High:** failure of an M1 exit behavior on the supported physical iPhone, including relaunch restoration, due-count retrieval, acceptable pronunciation playback, Japanese IME, or non-trapping navigation. Blocks `GO` until fixed or until the accepted architecture decision moves the required fix into a specifically linked pre-M2 gate.
-- **Medium:** bounded limitation that does not invalidate the exit story and has a clear M2 or release-readiness owner. May accompany `GO` with a linked issue.
-- **Low:** polish or observability limitation that is safely deferred. May accompany `GO` with a linked issue.
-
-Prose-only deferral is not allowed.
-
-## 9. GO/NO-GO Decision
-
-The final decision is exactly `GO` or `NO-GO`.
-
-### 9.1 GO requirements
-
-All of the following must be true on the final tested commit:
-
-- automated repository, production asset, diagnostics-exclusion, and secret-scan gates pass;
-- the production mobile configuration is classified as `deployed`, passes the normal build validator, and matches the environment exercised by the native matrices;
-- native Simulator build, install, and launch pass;
-- physical iPhone install and launch pass;
-- fresh Google sign-in and warm/cold callback return pass;
-- force-close/relaunch restores a valid session;
-- authenticated due-count is correct and identity-isolated;
-- one acceptable physical Japanese pronunciation path is selected and demonstrated;
-- Japanese IME composition/submission passes;
-- keyboard, safe-area, visible-back, and native navigation have recorded non-trapping results;
-- expected auth, network, and playback failures recover to a stable state;
-- no Critical finding remains;
-- every deferred Medium or Low risk has a Linear issue and target milestone;
-- the architecture record has no unresolved decision required to begin M2;
-- `CLAUDE.md` no longer describes implemented M1 OAuth work as future M2 work and links the final closeout records.
-
-### 9.2 NO-GO conditions
-
-Report `NO-GO` when any required row is unrun, blocked without an accepted pre-M2 gate, failed, or invalidated by a later code change; when a secret scan fails; when the production mobile configuration is missing, placeholder-only, or mismatched with the tested deployment; or when the audio architecture conclusion is not selected.
-
-`NO-GO` is a useful milestone result. It names the minimum issues that must close before rerunning the decision. HPA-210 remains open until a later run produces a complete `GO`.
-
-## 10. Source-Issue and Parent Updates
-
-After final verification:
-
-1. Add a concise evidence comment to HPA-202 and HPA-205 through HPA-209 identifying the tested commit, relevant matrix rows, result, and follow-up issue where applicable.
-2. Return a source issue to `Done` only when its acceptance evidence is satisfied.
-3. Add the complete result to HPA-210 with links to the architecture record, verification record, evidence directory, implementation pull request, and follow-up issues.
-4. Update HPA-194 with:
-   - final `GO` or `NO-GO`;
-   - tested commit and device summary;
-   - concise M1 evidence summary;
-   - accepted architecture limitations;
-   - recommended first M2 issues.
-5. Synchronize `CLAUDE.md` as defined in §4.5 and link it to the final records.
-6. Keep `ios-interaction-baseline.md` as the historical HPA-209 evidence record; add only a concise closeout link/result if needed rather than copying the HPA-210 matrix into it.
-
-For a `GO`, the recommended M2 start is the smallest end-to-end core review path: mobile Home/Review navigation, a real ten-card SRS session, rating and pronunciation behavior, then durable outbox and backend idempotency. Exact issue order is confirmed from current M2 ticket readiness at closeout time.
-
-## 11. Non-Goals
-
-HPA-210 does not include:
-
-- the SRS review session itself;
-- durable review outbox or backend idempotency implementation;
-- Android verification;
-- TestFlight or App Store distribution;
+- SRS review implementation;
+- durable outbox or idempotency implementation;
+- Android;
+- TestFlight/App Store;
 - permanent macOS CI or full native UI automation;
 - accessibility certification;
 - final visual polish;
-- AI buddy, microphone, speech-to-text, or background audio;
-- unrelated refactoring of the existing mobile foundation.
+- AI buddy, microphone, STT, or background audio;
+- unrelated foundation refactoring.
 
-## 12. Alternatives Considered
+## 13. Design completion check
 
-### Evidence-only closeout
-
-Rejected because it would leave deterministic verification fragmented across prior implementation plans and make future native closeout difficult to reproduce.
-
-### Full native UI automation in M1
-
-Rejected because OAuth provider interaction, human audio confirmation, Japanese IME observation, and speaker behavior still require controlled manual checks. Building a full native test stack would materially expand the spike and belongs in release readiness.
-
-### Consolidated verification harness and manual native matrix
-
-Selected because it automates repeatable source/build/launch evidence while preserving explicit human observation for behavior automation cannot honestly establish.
-
-## 13. Design Completion Check
-
-- No unresolved implementation decision is required to write the implementation plan.
-- No required evidence row is pre-declared as passing.
-- Automated and manual evidence have distinct ownership.
-- Existing HPA-209 detailed measurements remain canonical historical evidence; the architecture and final verification records do not duplicate them.
-- Production mobile environment prerequisites, live-versus-placeholder classification, and normal validator execution are explicit.
-- Existing package scripts and the authoritative production diagnostic scanner are named and reused.
-- Harness prerequisite failures and product-gate failures have distinct exit/manifest semantics.
-- Secret-handling rules cover source, artifacts, logs, and screenshots without rejecting legitimate source field names.
-- Source-ticket state semantics and HPA-210 ownership are explicit.
-- GO/NO-GO conditions are deterministic.
-- Deferred risks require Linear issues.
-- `CLAUDE.md` synchronization is an explicit closeout requirement.
-- Scope remains limited to M1 verification and architecture closeout.
+- no required row is pre-declared passing;
+- two build classes are required on one commit/backend;
+- Simulator evidence cannot replace physical acceptance;
+- signing/device readiness has explicit exit-3 preflight;
+- final root monorepo gates are intentional;
+- secret policy has one source of truth;
+- evidence/manifests are append-only and versioned;
+- verified `www` assets are hashed across `cap sync ios`;
+- HPA-209 measurements remain canonical history;
+- production config and placeholder classification are explicit;
+- existing production diagnostic scripts are reused;
+- High reclassification is limited to the silent-mode audio fork;
+- architecture and `CLAUDE.md` are finalized from the tested commit;
+- scope remains M1 verification and architecture closeout.

--- a/docs/superpowers/specs/2026-08-02-mobile-ios-foundation-verification-design.md
+++ b/docs/superpowers/specs/2026-08-02-mobile-ios-foundation-verification-design.md
@@ -34,7 +34,7 @@ HPA-210 is the single milestone acceptance owner. The source issues are related 
 
 - An implementation pull request may merge before native acceptance when its issue explicitly separates merge and closure gates.
 - An M1 source issue may be `Done` only after its required evidence exists or HPA-210 links a consolidated evidence row that satisfies it.
-- HPA-210 may be `Done` only after the final `GO` or `NO-GO` record is complete, every deferred risk has a Linear issue, and HPA-194 receives the milestone summary.
+- HPA-210 records both `GO` and `NO-GO` runs. It may transition to `Done` only after a complete `GO`, every deferred risk has a Linear issue, and HPA-194 receives the milestone summary. A complete `NO-GO` is preserved as evidence, but HPA-210 remains open for the corrective work and rerun.
 
 ## 3. Design Principles
 
@@ -147,12 +147,14 @@ The scan covers:
 - evidence files staged for HPA-210;
 - captured logs selected for attachment.
 
-The scanner looks for both structural and sentinel evidence:
+Source and configuration scanning looks for embedded credential values, forbidden persistence targets, unsafe logging/rendering paths, and known leakage sentinels. Legitimate source identifiers such as `codeVerifier`, `authorizationCode`, or token type names do not fail merely because the code defines or handles those fields.
 
-- OAuth authorization codes and PKCE verifier field names in runtime output;
+Runtime output, generated artifacts, and evidence are checked for:
+
+- OAuth authorization-code or PKCE-verifier values;
 - `Authorization: Bearer` values;
-- JWT-shaped values;
-- Cognito refresh/access/ID token storage outside the approved secure-storage path;
+- JWT-shaped values outside documented mock/sentinel fixtures;
+- Cognito refresh/access/ID token material outside the approved secure-storage boundary;
 - provider API-key names paired with non-placeholder values;
 - AWS secret values or private keys;
 - full presigned TTS URLs containing query credentials;
@@ -431,7 +433,7 @@ All of the following must be true on the final tested commit:
 
 Report `NO-GO` when any required row is unrun, blocked without an accepted pre-M2 gate, failed, or invalidated by a later code change; when a secret scan fails; or when the audio architecture conclusion is not selected.
 
-`NO-GO` is a useful milestone result. It names the minimum issues that must close before rerunning the decision. HPA-210 remains open until a later run produces a complete decision record.
+`NO-GO` is a useful milestone result. It names the minimum issues that must close before rerunning the decision. HPA-210 remains open until a later run produces a complete `GO`.
 
 ## 10. Source-Issue and Parent Updates
 
@@ -482,7 +484,7 @@ Selected because it automates repeatable source/build/launch evidence while pres
 - No unresolved implementation decision is required to write the implementation plan.
 - No required evidence row is pre-declared as passing.
 - Automated and manual evidence have distinct ownership.
-- Secret-handling rules cover source, artifacts, logs, and screenshots.
+- Secret-handling rules cover source, artifacts, logs, and screenshots without rejecting legitimate source field names.
 - Source-ticket state semantics and HPA-210 ownership are explicit.
 - GO/NO-GO conditions are deterministic.
 - Deferred risks require Linear issues.


### PR DESCRIPTION
## Summary

- define HPA-210 as the single Mobile MVP M1 acceptance owner
- separate deterministic automated verification from Simulator and physical-iPhone observation
- define the verification harness, architecture record, evidence layout, security scan, native matrix, and GO/NO-GO contract
- require failed or deferred risks to have severity, ownership, a target milestone, and a Linear issue
- preserve `NO-GO` evidence while keeping HPA-210 open for corrective work and rerun

## Tracking correction

The implementation for HPA-202 and HPA-205 through HPA-209 is merged, but their own PRs deferred required native acceptance. Those issues are now `In Review`; HPA-210 is High priority and `In Progress`, and consumes them as related evidence sources rather than formal blockers.

HPA-203 and HPA-204 remain complete infrastructure/configuration inputs unless live verification exposes a defect.

## Selected approach

Use a thin, repeatable verification harness for source, unit, production-artifact, secret-scan, native build/install/launch checks, plus controlled manual matrices for OAuth, physical speaker audibility, Japanese IME, keyboard, safe areas, and native navigation.

Full native UI automation and permanent macOS CI remain release-readiness work.

## Design document

- `docs/superpowers/specs/2026-08-02-mobile-ios-foundation-verification-design.md`

## Review completed

- checked for incomplete placeholders and pre-declared evidence
- reconciled source-ticket and HPA-210 completion semantics
- made `GO`/`NO-GO` closure behavior deterministic
- separated secret values from legitimate sensitive-field identifiers in source
- confirmed scope remains M1 verification and architecture closeout only

## Tracking

- Linear: HPA-210
- Parent: HPA-194