### PR TITLE
ci: skip runner jobs for draft pull requests

### DIFF
--- a/.github/workflows/build-lint.yml
+++ b/.github/workflows/build-lint.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
     # Retargeting an existing PR changes its base via the `edited` activity.
     # Include it so a PR moved to main reports the required checks.
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened, edited, ready_for_review]
   workflow_dispatch:
 
 env:
@@ -15,6 +15,7 @@ env:
 
 jobs:
   build-and-lint:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,12 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 env:
   BUN_VERSION: "1.3.1"
 
 jobs:
   test:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
     # Retargeting an existing PR changes its base via the `edited` activity.
     # Include it so a PR moved to main reports the required checks.
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened, edited, ready_for_review]
   workflow_dispatch:
 
 env:
@@ -22,6 +22,7 @@ permissions:
 
 jobs:
   web-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -73,6 +74,7 @@ jobs:
         continue-on-error: true
 
   api-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -117,6 +119,7 @@ jobs:
         continue-on-error: true
 
   ext-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -167,6 +170,7 @@ jobs:
         continue-on-error: true
 
   mobile-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -232,6 +236,7 @@ jobs:
         continue-on-error: true
 
   cdk-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

- skip build/lint, all five unit-test runners, and Playwright E2E while a pull request is draft
- preserve the existing `edited` PR activity and add `ready_for_review`
- preserve pushes to `main` and manual build/lint dispatch

## Why

GitHub Actions cannot filter `pull_request` events by draft state. Job-level guards avoid allocating multiple independent runners during draft iteration while keeping normal CI for reviewable PRs.

## Validation

- workflow-only changes across three files
- existing web/API/extension/mobile/CDK test behavior, coverage, and E2E commands are unchanged
