### PR TITLE
ci: require 95% Codecov coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,16 +2,16 @@ coverage:
   status:
     project:
       default:
-        target: auto
-        threshold: 1%
+        target: 95%
+        threshold: 0%
         base: auto
-        informational: true
+        informational: false
     patch:
       default:
-        target: auto
-        threshold: 1%
+        target: 95%
+        threshold: 0%
         base: auto
-        informational: true
+        informational: false
 
 ignore:
   - '**/*.test.ts'

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,12 +6,14 @@ coverage:
         threshold: 0%
         base: auto
         informational: false
+        if_not_found: failure
     patch:
       default:
         target: 95%
         threshold: 0%
         base: auto
         informational: false
+        if_not_found: failure
 
 ignore:
   - '**/*.test.ts'


### PR DESCRIPTION
## Summary

- require Codecov project and patch coverage to be at least 95%
- set threshold to 0% and make both statuses blocking
- preserve existing ignore rules, flags, and comment behavior

## Validation

- only `codecov.yml` changes
- no test/build/upload workflow commands changed
