### PR TITLE
ci: lower Codecov coverage target

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,14 +2,14 @@ coverage:
   status:
     project:
       default:
-        target: 95%
+        target: 90%
         threshold: 0%
         base: auto
         informational: false
         if_not_found: failure
     patch:
       default:
-        target: 95%
+        target: 90%
         threshold: 0%
         base: auto
         informational: false


### PR DESCRIPTION
## Summary

- lower Codecov project and patch targets from 95% to 90%
- preserve zero tolerance, blocking statuses, missing-report failure, flags, ignore rules, and comment behavior

## Validation

- `codecov.yml` only
